### PR TITLE
fix(docker): Fix unhealthy status due to missing curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ EXPOSE 8501
 
 # Install debian packages
 RUN apt-get update && apt-get install -y \
-    ffmpeg
+    curl \
+	ffmpeg
 
 # Install dependencies
 COPY requirements.txt /kiwi/requirements.txt


### PR DESCRIPTION
Patch fixes incorrect unhealthy status of Docker container due to missing curl, which is used to determine the health status.

![whisper](https://github.com/user-attachments/assets/d6d082e4-dbbf-4f32-ad9a-51a46142dbe0)
