### PR TITLE
Optimize memory usage by clearing uploaded files from session state

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import streamlit.runtime.scriptrunner as scriptrunner
 import requests
 import time
 import os
@@ -376,7 +377,7 @@ if "initialized" not in st.session_state:
     st.session_state.input_path = None
     st.session_state.unique_file_path = None
     st.session_state.original_file_name = None
-    st.session_state.media_file_data = None
+    st.session_state.file_uploaded = False
     st.session_state.txt_edit = ""
     st.session_state.json_edit = ""
     st.session_state.srt_edit = ""
@@ -399,7 +400,7 @@ def reset_transcription_complete():
     st.session_state.input_path = None
     st.session_state.unique_file_path = None
     st.session_state.original_file_name = None
-    st.session_state.media_file_data = None
+    st.session_state.file_uploaded = False
     st.session_state.txt_edit = ""
     st.session_state.json_edit = ""
     st.session_state.srt_edit = ""
@@ -467,16 +468,29 @@ def callback_extract_file():
     message_placeholder = st.empty()
     message_placeholder.info(__("processing_uploaded_file"))
     input_path, unique_file_path, original_file_name = process_uploaded_file(st.session_state.uploaded_file)
-    st.session_state.media_file_data = st.session_state.uploaded_file
     st.session_state.original_file_name = original_file_name
     st.session_state.input_path = input_path
     st.session_state.unique_file_path = unique_file_path
+    st.session_state.file_uploaded = True
     message_placeholder.empty()
+    
+    # Memory optimization: Clear uploaded file from Streamlit's internal storage
+    # This prevents duplicate memory usage from the file_uploader widget
+    try:
+        ctx = scriptrunner.get_script_run_ctx()
+        if ctx and hasattr(ctx, 'uploaded_file_mgr'):
+            ctx.uploaded_file_mgr.remove_session_files(ctx.session_id)
+    except Exception:
+        pass  # Silently ignore if clearing fails
+    
+    # Clear the file uploader session state entry
+    if 'uploaded_file' in st.session_state:
+        del st.session_state['uploaded_file']
 
 
 with st.sidebar:
 
-    if st.session_state.media_file_data:
+    if st.session_state.file_uploaded:
         st.write(f"{__("uploaded_file")}: {st.session_state.original_file_name}.")
         st.button(__("delete_file"), on_click=reset_transcription_complete)
     else:
@@ -553,12 +567,12 @@ with st.sidebar:
 
     if st.session_state.result:
         transcribe_button_clicked = False
-        st.button(__("delete_transcription"), 
-                  disabled=(st.session_state.processing or not st.session_state.media_file_data),
+        st.button(__("delete_transcription"),
+                  disabled=(st.session_state.processing or not st.session_state.file_uploaded),
                   on_click=reset_transcription_except_uploaded_file)
     else:
         transcribe_button_clicked = st.button(__("transcribe"),
-                                            disabled=(st.session_state.processing or not st.session_state.media_file_data),
+                                            disabled=(st.session_state.processing or not st.session_state.file_uploaded),
                                             on_click=callback_validate_speakers_and_disable_controls)
 
     # Add Logout button if LOGOUT_URL is set
@@ -583,7 +597,7 @@ with st.sidebar:
 
 if st.session_state.speaker_error:
     st.error(__("validate_number_speakers"))
-elif st.session_state.media_file_data and transcribe_button_clicked:
+elif st.session_state.file_uploaded and transcribe_button_clicked:
 
     # Store the transcription language code and model used for this transcription
     st.session_state.transcription_language_code = st.session_state.selected_transcription_language_code
@@ -661,18 +675,21 @@ if st.session_state.status == "SUCCESS" and st.session_state.result:
 
     # Expander around the media player
     with st.expander(__("media_player"), expanded=True):
-        # Display the media player at the top
-        if st.session_state.media_file_data:
+        # Display the media player at the top - read from disk to save RAM
+        if st.session_state.file_uploaded and st.session_state.input_path and os.path.exists(st.session_state.input_path):
             ext = os.path.splitext(st.session_state.original_file_name)[1].lower()
+            # Read file from disk instead of keeping it in session state memory
+            with open(st.session_state.input_path, 'rb') as media_file:
+                media_data = media_file.read()
             if ext in ['.mp3', '.wav']:
-                st.audio(st.session_state.media_file_data)
+                st.audio(media_data)
             elif ext in ['.mp4']:
                 subtitle_content = result.get('vtt_content', '') or result.get('srt_content', '') or None
                 if subtitle_content:
-                    st.video(st.session_state.media_file_data,
+                    st.video(media_data,
                              subtitles={st.session_state.transcription_language_code: subtitle_content})
                 else:
-                    st.video(st.session_state.media_file_data)
+                    st.video(media_data)
 
     # Define format options with fixed identifiers
     format_options = ['srt', 'json', 'txt', 'vtt']


### PR DESCRIPTION
- Add streamlit.runtime.scriptrunner import for session file management
- Replace media_file_data with file_uploaded boolean flag
- Clear UploadedFileManager session files after saving to disk
- Delete uploaded_file from session state after processing
- Update media player to read from disk instead of session state

This addresses the Streamlit file_uploader memory issue (GitHub #9218) where uploaded files persist in RAM indefinitely. Now files are:
1. Saved to disk with unique UUID filenames
2. Cleared from Streamlit's internal UploadedFileManager
3. Read on-demand from disk for the media player

Memory impact: Previously files were stored 2-3x in RAM (widget state, UploadedFileManager, media_file_data). Now only file paths are stored.