### PR TITLE
fix: language button and default language detection

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -22,7 +22,7 @@ export function Header() {
           title={i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
           aria-label={i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
         >
-          {i18n.language.toUpperCase()}
+          {(i18n.language === 'de' ? 'en' : 'de').toUpperCase()}
         </button>
         {config?.logout_url && (
           <button

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -3,9 +3,13 @@ import { initReactI18next } from 'react-i18next'
 import de from './de.json'
 import en from './en.json'
 
+const supportedLanguages = ['de', 'en']
+const browserLang = navigator.language.split('-')[0]
+const defaultLang = supportedLanguages.includes(browserLang) ? browserLang : 'de'
+
 i18n.use(initReactI18next).init({
   resources: { de: { translation: de }, en: { translation: en } },
-  lng: 'de',
+  lng: defaultLang,
   fallbackLng: 'de',
   interpolation: { escapeValue: false },
 })


### PR DESCRIPTION
## Summary
- **Language button now shows the target language** instead of the current one (e.g. shows "EN" when viewing in German, since clicking switches to English). Closes #52
- **Default UI language uses browser language** when supported (en/de), falling back to German. Closes #53

## Changes
- `frontend/src/components/Header.tsx`: Button label shows the opposite language
- `frontend/src/i18n/index.ts`: Detect `navigator.language` and use it if it's `en` or `de`