### PR TITLE
feat: per-item expiration with archive action

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,8 @@ LLM_BASE_URL=                     # for local servers (e.g., http://localhost:11
 TEMP_PATH=tmp/transcription-files
 FFMPEG_PATH=ffmpeg
 LOGOUT_URL=/oauth2/sign_out
-CLEANUP_TTL_HOURS=720             # auto-delete files older than this (default 30 days)
+DEFAULT_EXPIRY_HOURS=72           # auto-delete files after this many hours (default 3 days)
+ARCHIVE_EXPIRY_HOURS=4320         # archived files kept for this many hours (default 180 days)
 DATABASE_PATH=                    # SQLite DB path, defaults to {TEMP_PATH}/transcription.db
 
 # Metrics

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - Copy, download, and delete generated analysis results.
 - LLM provider and model attribution display on generated content.
 - Transcription history as default landing page with persistent storage.
+- Per-item expiration with configurable retention — files expire after a default period (3 days), with an "archive" action to extend retention (180 days).
 - Real-time progress updates via WebSocket.
 - Responsive layout — mobile-friendly UI with no horizontal overflow on small screens.
 - System audio capture for recording online meetings (experimental; best on Chrome/Edge on Windows).
@@ -73,7 +74,8 @@ LLM_BASE_URL=                     # for custom endpoints (e.g., vLLM, Ollama: ht
 TEMP_PATH=tmp/transcription-files
 FFMPEG_PATH=ffmpeg
 LOGOUT_URL=/oauth2/sign_out
-CLEANUP_TTL_HOURS=168             # auto-delete files older than this (default 7 days)
+DEFAULT_EXPIRY_HOURS=72           # auto-delete files after this many hours (default 3 days)
+ARCHIVE_EXPIRY_HOURS=4320         # archived files kept for this many hours (default 180 days)
 DATABASE_PATH=                    # SQLite DB path, defaults to {TEMP_PATH}/transcription.db
 
 # Metrics

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,7 +21,8 @@ class Settings:
     TEMP_PATH: str = os.getenv("TEMP_PATH", "tmp/transcription-files")
     FFMPEG_PATH: str = os.getenv("FFMPEG_PATH", "ffmpeg")
     LOGOUT_URL: str = os.getenv("LOGOUT_URL", "")
-    CLEANUP_TTL_HOURS: int = int(os.getenv("CLEANUP_TTL_HOURS", "720"))
+    DEFAULT_EXPIRY_HOURS: int = int(os.getenv("DEFAULT_EXPIRY_HOURS", "72"))
+    ARCHIVE_EXPIRY_HOURS: int = int(os.getenv("ARCHIVE_EXPIRY_HOURS", "4320"))
     DATABASE_PATH: str = os.getenv("DATABASE_PATH", "")
 
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "true").lower() in ("true", "1", "yes")

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,5 +1,6 @@
 import aiosqlite
 from contextlib import asynccontextmanager
+from app.config import settings
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS users (
@@ -17,7 +18,9 @@ CREATE TABLE IF NOT EXISTS files (
     mp3_path TEXT,
     media_type TEXT,
     file_size INTEGER,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP,
+    is_archived INTEGER DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS transcriptions (
@@ -69,6 +72,8 @@ MIGRATIONS = [
     ("refinement_metadata_json", "transcriptions", "refinement_metadata_json TEXT"),
     ("translated_utterances_json", "transcriptions", "translated_utterances_json TEXT"),
     ("translation_language", "transcriptions", "translation_language TEXT"),
+    ("expires_at", "files", "expires_at TIMESTAMP"),
+    ("is_archived", "files", "is_archived INTEGER DEFAULT 0"),
 ]
 
 
@@ -83,6 +88,11 @@ async def init_db(db_path: str) -> None:
             columns = {row[1] for row in await cursor.fetchall()}
             if col_name not in columns:
                 await db.execute(f"ALTER TABLE {table} ADD COLUMN {col_def}")
+        # Backfill expires_at for existing files
+        await db.execute(
+            "UPDATE files SET expires_at = datetime(created_at, '+' || ? || ' hours') WHERE expires_at IS NULL",
+            (str(settings.DEFAULT_EXPIRY_HOURS),),
+        )
         await db.commit()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,33 +12,59 @@ from app.metrics import inc, cleanup_runs_total, cleanup_items_deleted_total
 
 
 async def cleanup_old_files():
-    """Periodically delete files and DB records older than CLEANUP_TTL_HOURS."""
+    """Periodically delete files and DB records that have passed their expires_at."""
     while True:
         await asyncio.sleep(3600)  # Check every hour
         try:
-            cutoff = datetime.now(timezone.utc) - timedelta(hours=settings.CLEANUP_TTL_HOURS)
+            now = datetime.now(timezone.utc).isoformat()
             async with get_db() as db:
-                # Get old files to delete from disk
+                # Subquery for expired file IDs, skipping files with in-flight transcriptions
+                expired_files_q = """
+                    SELECT id FROM files
+                    WHERE expires_at < ?
+                    AND id NOT IN (
+                        SELECT file_id FROM transcriptions
+                        WHERE status IN ('pending', 'processing')
+                    )
+                """
+
+                # Get expired files to delete from disk
                 cursor = await db.execute(
-                    "SELECT file_path, mp3_path FROM files WHERE created_at < ?",
-                    (cutoff.isoformat(),),
+                    f"SELECT file_path, mp3_path FROM files WHERE id IN ({expired_files_q})",
+                    (now,),
                 )
                 rows = await cursor.fetchall()
                 files_deleted = 0
                 for row in rows:
                     for path in [row["file_path"], row["mp3_path"]]:
                         if path and os.path.exists(path):
-                            os.unlink(path)
-                            files_deleted += 1
+                            try:
+                                os.unlink(path)
+                                files_deleted += 1
+                            except OSError:
+                                pass
 
-                # Delete old DB records (cascade via foreign keys)
-                cursor = await db.execute("DELETE FROM analyses WHERE transcription_id IN (SELECT id FROM transcriptions WHERE created_at < ?)", (cutoff.isoformat(),))
+                # Delete related DB records
+                expired_transcriptions_q = f"SELECT id FROM transcriptions WHERE file_id IN ({expired_files_q})"
+                cursor = await db.execute(
+                    f"DELETE FROM analyses WHERE transcription_id IN ({expired_transcriptions_q})",
+                    (now,),
+                )
                 analyses_deleted = cursor.rowcount
-                cursor = await db.execute("DELETE FROM speaker_mappings WHERE transcription_id IN (SELECT id FROM transcriptions WHERE created_at < ?)", (cutoff.isoformat(),))
+                cursor = await db.execute(
+                    f"DELETE FROM speaker_mappings WHERE transcription_id IN ({expired_transcriptions_q})",
+                    (now,),
+                )
                 mappings_deleted = cursor.rowcount
-                cursor = await db.execute("DELETE FROM transcriptions WHERE created_at < ?", (cutoff.isoformat(),))
+                cursor = await db.execute(
+                    f"DELETE FROM transcriptions WHERE file_id IN ({expired_files_q})",
+                    (now,),
+                )
                 transcriptions_deleted = cursor.rowcount
-                cursor = await db.execute("DELETE FROM files WHERE created_at < ?", (cutoff.isoformat(),))
+                cursor = await db.execute(
+                    f"DELETE FROM files WHERE id IN ({expired_files_q})",
+                    (now,),
+                )
                 db_files_deleted = cursor.rowcount
                 await db.commit()
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -59,6 +59,8 @@ class TranscriptionListItem(BaseModel):
     model: str | None = None
     created_at: str
     file_size: int = 0
+    expires_at: str
+    archived: bool = False
 
 
 class SpeakerMappingRequest(BaseModel):

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from app.config import settings
 from app.dependencies import get_current_user
@@ -291,11 +291,32 @@ async def delete_transcription(transcription_id: str, user: UserInfo = Depends(g
     return {"status": "deleted"}
 
 
+@router.post("/api/transcription/{transcription_id}/archive")
+async def archive_transcription(transcription_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT file_id FROM transcriptions WHERE id = ? AND user_id = ?",
+            (transcription_id, user.id),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Transcription not found")
+
+        expires_at = (datetime.now(timezone.utc) + timedelta(hours=settings.ARCHIVE_EXPIRY_HOURS)).isoformat()
+        await db.execute(
+            "UPDATE files SET expires_at = ?, is_archived = 1 WHERE id = ?",
+            (expires_at, row["file_id"]),
+        )
+        await db.commit()
+
+    return {"status": "archived", "expires_at": expires_at}
+
+
 @router.get("/api/transcriptions")
 async def list_transcriptions(user: UserInfo = Depends(get_current_user)):
     async with get_db() as db:
         cursor = await db.execute(
-            """SELECT t.id, t.file_id, f.original_filename, t.status, t.language, t.model, t.created_at, f.file_size
+            """SELECT t.id, t.file_id, f.original_filename, t.status, t.language, t.model, t.created_at, f.file_size, f.expires_at, f.is_archived
                FROM transcriptions t
                JOIN files f ON t.file_id = f.id
                WHERE t.user_id = ?
@@ -309,6 +330,7 @@ async def list_transcriptions(user: UserInfo = Depends(get_current_user)):
             id=r["id"], file_id=r["file_id"], original_filename=r["original_filename"],
             status=r["status"], language=r["language"], model=r["model"],
             created_at=r["created_at"], file_size=r["file_size"],
+            expires_at=r["expires_at"], archived=bool(r["is_archived"]),
         ).model_dump()
         for r in rows
     ]

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, UploadFile, HTTPException
 from fastapi.responses import FileResponse
 from app.config import settings
@@ -56,6 +57,7 @@ async def upload_file(
     mp3_path = await convert_to_mp3(file_path)
 
     media_type = ext.lstrip(".")
+    expires_at = (datetime.now(timezone.utc) + timedelta(hours=settings.DEFAULT_EXPIRY_HOURS)).isoformat()
 
     async with get_db() as db:
         # Ensure user exists
@@ -64,8 +66,8 @@ async def upload_file(
             (user.id, user.email),
         )
         await db.execute(
-            "INSERT INTO files (id, user_id, original_filename, file_path, mp3_path, media_type, file_size) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (file_id, user.id, file.filename, file_path, mp3_path, media_type, file_size),
+            "INSERT INTO files (id, user_id, original_filename, file_path, mp3_path, media_type, file_size, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (file_id, user.id, file.filename, file_path, mp3_path, media_type, file_size, expires_at),
         )
         await db.commit()
 

--- a/backend/tests/test_transcription_api.py
+++ b/backend/tests/test_transcription_api.py
@@ -40,6 +40,58 @@ async def test_transcribe_creates_job(mock_asr):
 async def test_get_transcriptions_list(mock_asr):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Upload a file first so we have something in the list
+        upload_resp = await client.post(
+            "/api/upload",
+            files={"file": ("test.mp3", b"fake", "audio/mpeg")},
+        )
+        file_id = upload_resp.json()["id"]
+
+        with patch("app.routers.transcription.get_asr_backend", return_value=mock_asr):
+            await client.post("/api/transcribe", json={
+                "file_id": file_id, "language": "en", "model": "base",
+            })
+
         resp = await client.get("/api/transcriptions")
     assert resp.status_code == 200
-    assert isinstance(resp.json(), list)
+    items = resp.json()
+    assert isinstance(items, list)
+    assert len(items) > 0
+    item = items[0]
+    assert "expires_at" in item
+    assert "archived" in item
+    assert item["archived"] is False
+
+@pytest.mark.asyncio
+async def test_archive_transcription(mock_asr):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        upload_resp = await client.post(
+            "/api/upload",
+            files={"file": ("test.mp3", b"fake", "audio/mpeg")},
+        )
+        file_id = upload_resp.json()["id"]
+
+        with patch("app.routers.transcription.get_asr_backend", return_value=mock_asr):
+            transcribe_resp = await client.post("/api/transcribe", json={
+                "file_id": file_id, "language": "en", "model": "base",
+            })
+        transcription_id = transcribe_resp.json()["id"]
+
+        resp = await client.post(f"/api/transcription/{transcription_id}/archive")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "archived"
+        assert "expires_at" in resp.json()
+
+        # Verify list reflects archived state
+        list_resp = await client.get("/api/transcriptions")
+        items = list_resp.json()
+        archived_item = next(i for i in items if i["id"] == transcription_id)
+        assert archived_item["archived"] is True
+
+@pytest.mark.asyncio
+async def test_archive_nonexistent_transcription():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/transcription/nonexistent-id/archive")
+    assert resp.status_code == 404

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -74,6 +74,9 @@ export const api = {
   deleteTranscription: (id: string) =>
     request<{ status: string }>(`/api/transcription/${id}`, { method: 'DELETE' }),
 
+  archiveTranscription: (id: string) =>
+    request<{ status: string; expires_at: string }>(`/api/transcription/${id}/archive`, { method: 'POST' }),
+
   listTranscriptions: () => request<TranscriptionListItem[]>('/api/transcriptions'),
 
   renameFile: (fileId: string, filename: string) =>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -49,6 +49,8 @@ export interface TranscriptionListItem {
   model: string | null
   created_at: string
   file_size: number
+  expires_at: string
+  archived: boolean
 }
 
 export interface ChapterHint {

--- a/frontend/src/components/TranscriptionList/TranscriptionList.tsx
+++ b/frontend/src/components/TranscriptionList/TranscriptionList.tsx
@@ -86,12 +86,42 @@ export function TranscriptionList() {
 
   const handleDelete = async (e: React.MouseEvent, id: string) => {
     e.stopPropagation()
+    if (!confirm(t('transcription.confirmDelete'))) return
     try {
       await api.deleteTranscription(id)
       setHistory(history.filter((item) => item.id !== id))
     } catch (err) {
       console.error('Delete failed:', err)
     }
+  }
+
+  const handleArchive = async (e: React.MouseEvent, item: TranscriptionListItem) => {
+    e.stopPropagation()
+    // Optimistic update
+    const currentHistory = useStore.getState().transcriptionHistory
+    setHistory(currentHistory.map((h) =>
+      h.id === item.id ? { ...h, archived: true, expires_at: new Date(Date.now() + 180 * 24 * 60 * 60 * 1000).toISOString() } : h
+    ))
+    try {
+      const result = await api.archiveTranscription(item.id)
+      // Update with server-provided expires_at
+      const updatedHistory = useStore.getState().transcriptionHistory
+      setHistory(updatedHistory.map((h) =>
+        h.id === item.id ? { ...h, archived: true, expires_at: result.expires_at } : h
+      ))
+    } catch (err) {
+      console.error('Archive failed:', err)
+      // Revert on failure
+      const revertHistory = useStore.getState().transcriptionHistory
+      setHistory(revertHistory.map((h) =>
+        h.id === item.id ? { ...h, archived: item.archived, expires_at: item.expires_at } : h
+      ))
+    }
+  }
+
+  const isExpiringSoon = (expiresAt: string) => {
+    const remaining = new Date(expiresAt).getTime() - Date.now()
+    return remaining < 24 * 60 * 60 * 1000 // < 24 hours
   }
 
   const handleRenameStart = useCallback((e: React.MouseEvent, item: TranscriptionListItem) => {
@@ -222,6 +252,26 @@ export function TranscriptionList() {
             </span>
             <span className="text-gray-500 text-xs">
               {new Date(item.created_at).toLocaleDateString()}
+            </span>
+            {item.archived ? (
+              <span className="text-xs text-blue-400" title={t('transcription.archived')}>
+                <svg className="w-3.5 h-3.5 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8" />
+                </svg>
+              </span>
+            ) : (
+              <button
+                onClick={(e) => handleArchive(e, item)}
+                className="text-gray-500 hover:text-blue-400 text-xs px-1"
+                title={t('transcription.archive')}
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8" />
+                </svg>
+              </button>
+            )}
+            <span className={`text-xs ${isExpiringSoon(item.expires_at) ? 'text-red-400' : 'text-gray-500'}`}>
+              {t('transcription.expiresOn', { date: new Date(item.expires_at).toLocaleDateString() })}
             </span>
             <button
               onClick={(e) => handleDelete(e, item.id)}

--- a/frontend/src/components/TranscriptionList/TranscriptionList.tsx
+++ b/frontend/src/components/TranscriptionList/TranscriptionList.tsx
@@ -12,8 +12,6 @@ export function TranscriptionList() {
   const setTranscriptionStatus = useStore((s) => s.setTranscriptionStatus)
   const setResult = useStore((s) => s.setTranscriptionResult)
   const setSpeakerMappings = useStore((s) => s.setSpeakerMappings)
-  const setSummary = useStore((s) => s.setSummary)
-  const setProtocol = useStore((s) => s.setProtocol)
   const setFile = useStore((s) => s.setFile)
   const setRefinedUtterances = useStore((s) => s.setRefinedUtterances)
   const setRefinementMetadata = useStore((s) => s.setRefinementMetadata)
@@ -53,8 +51,6 @@ export function TranscriptionList() {
         const result = await api.getTranscription(item.id)
         setResult(result)
         setSpeakerMappings(result.speaker_mappings || {})
-        setSummary(result.summary || null)
-        setProtocol(result.protocol || null)
         try {
           const refinement = await api.getRefinement(item.id)
           setRefinedUtterances(refinement.utterances)

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -27,7 +27,11 @@
     "failed": "Transkription fehlgeschlagen",
     "delete": "Transkription löschen",
     "history": "Meine Transkriptionen",
-    "doubleClickToRename": "Doppelklick zum Umbenennen"
+    "doubleClickToRename": "Doppelklick zum Umbenennen",
+    "archive": "Archivieren",
+    "archived": "Archiviert",
+    "expiresOn": "Läuft ab: {{date}}",
+    "confirmDelete": "Sind Sie sicher, dass Sie diese Transkription löschen möchten? Dies kann nicht rückgängig gemacht werden."
   },
   "editor": {
     "subtitles": "Untertitel",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -27,7 +27,11 @@
     "failed": "Transcription failed",
     "delete": "Delete transcription",
     "history": "My Transcriptions",
-    "doubleClickToRename": "Double-click to rename"
+    "doubleClickToRename": "Double-click to rename",
+    "archive": "Archive",
+    "archived": "Archived",
+    "expiresOn": "Expires: {{date}}",
+    "confirmDelete": "Are you sure you want to delete this transcription? This cannot be undone."
   },
   "editor": {
     "subtitles": "Subtitles",


### PR DESCRIPTION
## Summary
- Replace global `CLEANUP_TTL_HOURS` with per-item `expires_at` timestamps on files
- New files expire after `DEFAULT_EXPIRY_HOURS` (default 3 days)
- Users can archive transcriptions to extend retention to `ARCHIVE_EXPIRY_HOURS` (default 180 days)
- Archive list shows expiry dates with red highlight when < 24 hours remaining
- Archive button on each non-archived item, archived items show an archive icon
- Cleanup task uses `expires_at` and skips files with in-flight transcriptions

Closes #46