### PR TITLE
feat: auto-generate transcription titles with LLM

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -74,6 +74,7 @@ MIGRATIONS = [
     ("translation_language", "transcriptions", "translation_language TEXT"),
     ("expires_at", "files", "expires_at TIMESTAMP"),
     ("is_archived", "files", "is_archived INTEGER DEFAULT 0"),
+    ("title", "transcriptions", "title TEXT"),
 ]
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -61,6 +61,7 @@ class TranscriptionListItem(BaseModel):
     file_size: int = 0
     expires_at: str
     archived: bool = False
+    title: str | None = None
 
 
 class SpeakerMappingRequest(BaseModel):
@@ -69,6 +70,10 @@ class SpeakerMappingRequest(BaseModel):
 
 class RenameRequest(BaseModel):
     filename: str
+
+
+class TitleRequest(BaseModel):
+    title: str
 
 
 class ChapterHint(BaseModel):

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -109,6 +109,23 @@ async def _run_transcription(transcription_id: str, file_path: str, req: Transcr
             )
             await db.commit()
 
+        # Generate title if LLM is available
+        try:
+            from app.services.llm import get_llm_provider
+            provider = get_llm_provider()
+            if provider and result.utterances:
+                transcript_text = " ".join(u.text for u in result.utterances)
+                title = await provider.generate_title(transcript_text)
+                if title:
+                    async with get_db() as db:
+                        await db.execute(
+                            "UPDATE transcriptions SET title = ? WHERE id = ?",
+                            (title, transcription_id),
+                        )
+                        await db.commit()
+        except Exception as e:
+            logging.warning("Title generation failed for %s: %s", transcription_id, e)
+
     except Exception as e:
         logging.error("Transcription %s failed: %s: %s", transcription_id, type(e).__name__, e)
         logging.error("Traceback: %s", traceback.format_exc())

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -11,6 +11,7 @@ from app.dependencies import get_current_user
 from app.models import (
     UserInfo, TranscriptionSettings as TranscriptionSettingsModel,
     TranscriptionStatus, TranscriptionListItem, Utterance, SpeakerMappingRequest,
+    TitleRequest,
 )
 from app.database import get_db
 from app.services.asr import get_asr_backend
@@ -347,7 +348,7 @@ async def archive_transcription(transcription_id: str, user: UserInfo = Depends(
 async def list_transcriptions(user: UserInfo = Depends(get_current_user)):
     async with get_db() as db:
         cursor = await db.execute(
-            """SELECT t.id, t.file_id, f.original_filename, t.status, t.language, t.model, t.created_at, f.file_size, f.expires_at, f.is_archived
+            """SELECT t.id, t.file_id, f.original_filename, t.status, t.language, t.model, t.created_at, f.file_size, f.expires_at, f.is_archived, t.title
                FROM transcriptions t
                JOIN files f ON t.file_id = f.id
                WHERE t.user_id = ?
@@ -362,9 +363,27 @@ async def list_transcriptions(user: UserInfo = Depends(get_current_user)):
             status=r["status"], language=r["language"], model=r["model"],
             created_at=r["created_at"], file_size=r["file_size"],
             expires_at=r["expires_at"], archived=bool(r["is_archived"]),
+            title=r["title"],
         ).model_dump()
         for r in rows
     ]
+
+
+@router.patch("/api/transcription/{transcription_id}/title")
+async def update_title(transcription_id: str, body: TitleRequest, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
+            (transcription_id, user.id),
+        )
+        if not await cursor.fetchone():
+            raise HTTPException(status_code=404, detail="Not found")
+        await db.execute(
+            "UPDATE transcriptions SET title = ? WHERE id = ?",
+            (body.title, transcription_id),
+        )
+        await db.commit()
+    return {"status": "ok"}
 
 
 @router.websocket("/api/ws/status/{transcription_id}")

--- a/backend/app/services/llm/base.py
+++ b/backend/app/services/llm/base.py
@@ -14,3 +14,7 @@ class LLMProvider(ABC):
     @abstractmethod
     async def generate_refinement(self, transcript: str, context: str | None = None) -> LLMRefinementResponse:
         ...
+
+    @abstractmethod
+    async def generate_title(self, transcript: str) -> str:
+        """Generate a short title from transcript text."""

--- a/backend/app/services/llm/ollama.py
+++ b/backend/app/services/llm/ollama.py
@@ -136,3 +136,15 @@ class OllamaProvider(LLMProvider):
             utterances=[Utterance(**u) for u in all_refined],
             changes_summary=combined_summary,
         )
+
+    async def generate_title(self, transcript: str) -> str:
+        result = await self._chat(
+            "Generate a short descriptive title (max 8 words) for the following transcript. Return ONLY the title text, nothing else. No quotes, no punctuation at the end.",
+            transcript[:2000],
+        )
+        try:
+            data = json.loads(result)
+            return str(data.get("title", data.get("text", result))).strip().strip('"\'')
+        except (json.JSONDecodeError, AttributeError):
+            return result.strip().strip('"\'')
+

--- a/backend/app/services/llm/openai.py
+++ b/backend/app/services/llm/openai.py
@@ -174,3 +174,15 @@ class OpenAIProvider(LLMProvider):
             utterances=[Utterance(**u) for u in all_refined],
             changes_summary=combined_summary,
         )
+
+    async def generate_title(self, transcript: str) -> str:
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": "Generate a short descriptive title (max 8 words) for the following transcript. Return ONLY the title text, nothing else. No quotes, no punctuation at the end."},
+                {"role": "user", "content": transcript[:2000]},
+            ],
+            temperature=0.3,
+        )
+        return (response.choices[0].message.content or "").strip().strip('"\'')
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -198,6 +198,7 @@ function App() {
         <>
           <BackButton />
           <RecorderPanel />
+          {file && !showEditor && <SettingsPanel />}
           <ProgressBar />
         </>
       )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,6 +124,7 @@ function App() {
   const currentView = useStore((s) => s.currentView)
   const setCurrentView = useStore((s) => s.setCurrentView)
   const transcriptionStatus = useStore((s) => s.transcriptionStatus)
+  const transcriptionTitle = useStore((s) => s.transcriptionTitle)
   const transcriptionResult = useStore((s) => s.transcriptionResult)
   const activeTab = useStore((s) => s.activeTab)
   const [speakerModalOpen, setSpeakerModalOpen] = useState(false)
@@ -156,7 +157,7 @@ function App() {
   // Update browser tab title based on current view
   useEffect(() => {
     if (currentView === 'detail' && file) {
-      document.title = `${file.original_filename} — ${t('title')}`
+      document.title = `${transcriptionTitle || file.original_filename} — ${t('title')}`
     } else {
       document.title = t('title')
     }
@@ -208,7 +209,10 @@ function App() {
           <BackButton />
           {file && (
             <h1 className="px-6 text-lg font-semibold text-white truncate">
-              {file.original_filename}
+              {transcriptionTitle || file.original_filename}
+              {transcriptionTitle && (
+                <span className="text-sm font-normal text-gray-500 ml-2">[{file.original_filename}]</span>
+              )}
             </h1>
           )}
           <DetailActions />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -85,6 +85,12 @@ export const api = {
       body: JSON.stringify({ filename }),
     }),
 
+  renameTitle: (id: string, title: string) =>
+    request<{ status: string }>(`/api/transcription/${id}/title`, {
+      method: 'PATCH',
+      body: JSON.stringify({ title }),
+    }),
+
   generateRefinement: (id: string, context?: string) =>
     request<RefinementResult>(`/api/refine/${id}`, {
       method: 'POST',

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -51,6 +51,7 @@ export interface TranscriptionListItem {
   file_size: number
   expires_at: string
   archived: boolean
+  title: string | null
 }
 
 export interface ChapterHint {

--- a/frontend/src/components/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/FileUpload/FileUpload.tsx
@@ -9,6 +9,7 @@ export function FileUpload() {
   const file = useStore((s) => s.file)
   const setFile = useStore((s) => s.setFile)
   const transcriptionId = useStore((s) => s.transcriptionId)
+  const transcriptionTitle = useStore((s) => s.transcriptionTitle)
   const reset = useStore((s) => s.reset)
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -60,7 +61,9 @@ export function FileUpload() {
   if (file) {
     return (
       <div className="flex items-center gap-4 px-6 py-2 bg-gray-800 border-b border-gray-700 text-sm text-gray-300 min-w-0">
-        <span className="truncate min-w-0">{file.original_filename}</span>
+        <span className="truncate min-w-0">
+          {transcriptionTitle ? <>{transcriptionTitle} <span className="text-gray-500">[{file.original_filename}]</span></> : file.original_filename}
+        </span>
         <span className="text-gray-500 shrink-0">({formatFileSize(file.file_size)})</span>
         <button onClick={handleDelete} className="text-red-400 hover:text-red-300 shrink-0">
           {t('upload.deleteFile')}

--- a/frontend/src/components/Recorder/RecorderPanel.tsx
+++ b/frontend/src/components/Recorder/RecorderPanel.tsx
@@ -83,6 +83,27 @@ export function RecorderPanel() {
     }
   }, [blob, useCamera, setFile, t])
 
+  const handleStart = useCallback(async () => {
+    // Play a short beep tone to signal recording start
+    try {
+      const ctx = new AudioContext()
+      await ctx.resume()
+      const oscillator = ctx.createOscillator()
+      const gain = ctx.createGain()
+      oscillator.connect(gain)
+      gain.connect(ctx.destination)
+      oscillator.frequency.value = 880
+      gain.gain.value = 0.3
+      oscillator.start()
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.3)
+      oscillator.stop(ctx.currentTime + 0.3)
+      setTimeout(() => ctx.close(), 500)
+    } catch {
+      // Audio cue is best-effort
+    }
+    await start()
+  }, [start])
+
   const isActive = state === 'recording' || state === 'paused'
 
   if (file) {
@@ -134,11 +155,18 @@ export function RecorderPanel() {
         </div>
       )}
 
+      {/* Consent reminder */}
+      {state === 'idle' && (
+        <p className="text-xs text-gray-400 text-center">
+          {t('recorder.consentReminder')}
+        </p>
+      )}
+
       {/* Controls */}
       <RecorderControls
         state={state}
         duration={duration}
-        onStart={start}
+        onStart={handleStart}
         onPause={pause}
         onResume={resume}
         onStop={stop}

--- a/frontend/src/components/Recorder/RecorderPanel.tsx
+++ b/frontend/src/components/Recorder/RecorderPanel.tsx
@@ -13,6 +13,7 @@ export function RecorderPanel() {
   const file = useStore((s) => s.file)
   const setFile = useStore((s) => s.setFile)
   const transcriptionId = useStore((s) => s.transcriptionId)
+  const transcriptionTitle = useStore((s) => s.transcriptionTitle)
   const reset = useStore((s) => s.reset)
 
   const handleDelete = useCallback(async () => {
@@ -109,7 +110,9 @@ export function RecorderPanel() {
   if (file) {
     return (
       <div className="flex items-center gap-4 px-6 py-2 bg-gray-800 border-b border-gray-700 text-sm text-gray-300">
-        <span>{file.original_filename}</span>
+        <span>
+          {transcriptionTitle ? <>{transcriptionTitle} <span className="text-gray-500">[{file.original_filename}]</span></> : file.original_filename}
+        </span>
         <span className="text-gray-500">({formatFileSize(file.file_size)})</span>
         <button onClick={handleDelete} className="text-red-400 hover:text-red-300">
           {t('upload.deleteFile')}

--- a/frontend/src/components/Recorder/useMediaRecorder.ts
+++ b/frontend/src/components/Recorder/useMediaRecorder.ts
@@ -115,6 +115,7 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
 
   const start = useCallback(async () => {
     if (recorderRef.current && recorderRef.current.state !== 'inactive') return
+    discardingRef.current = false
     setError(null)
     setBlob(null)
     chunksRef.current = []

--- a/frontend/src/components/TranscriptionList/TranscriptionList.tsx
+++ b/frontend/src/components/TranscriptionList/TranscriptionList.tsx
@@ -4,6 +4,20 @@ import { useStore } from '../../store'
 import { api } from '../../api/client'
 import type { TranscriptionListItem } from '../../api/types'
 
+function PencilButton({ onClick, title }: { onClick: (e: React.MouseEvent) => void; title: string }) {
+  return (
+    <button
+      onClick={onClick}
+      className="text-gray-500 hover:text-gray-300 p-0.5 flex-shrink-0"
+      title={title}
+    >
+      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+      </svg>
+    </button>
+  )
+}
+
 export function TranscriptionList() {
   const { t } = useTranslation()
   const history = useStore((s) => s.transcriptionHistory)
@@ -23,6 +37,7 @@ export function TranscriptionList() {
 
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
+  const [editingField, setEditingField] = useState<'title' | 'filename' | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const savingRef = useRef(false)
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -80,70 +95,98 @@ export function TranscriptionList() {
     }, 250)
   }, [])
 
-  const handleRenameStart = useCallback((e: React.MouseEvent, item: TranscriptionListItem) => {
+  const handleEditStart = useCallback((e: React.MouseEvent, item: TranscriptionListItem, field: 'title' | 'filename') => {
     e.stopPropagation()
     if (clickTimerRef.current) {
       clearTimeout(clickTimerRef.current)
       clickTimerRef.current = null
     }
-    const baseName = item.original_filename.replace(/\.[^.]+$/, '')
+    if (field === 'filename') {
+      const baseName = item.original_filename.replace(/\.[^.]+$/, '')
+      setEditValue(baseName)
+    } else {
+      setEditValue(item.title || '')
+    }
     setEditingId(item.id)
-    setEditValue(baseName)
+    setEditingField(field)
   }, [])
 
-  const handleRenameSave = useCallback(async (item: TranscriptionListItem) => {
+  const handleEditSave = useCallback(async (item: TranscriptionListItem) => {
     if (savingRef.current) return
     if (editingId !== item.id) return
 
     const trimmed = editValue.trim()
+    const field = editingField
     setEditingId(null)
+    setEditingField(null)
 
     if (!trimmed) return
 
-    const ext = item.original_filename.includes('.')
-      ? '.' + item.original_filename.split('.').pop()
-      : ''
-    const oldFilename = item.original_filename
-    const newFilename = trimmed + ext
+    if (field === 'filename') {
+      const ext = item.original_filename.includes('.')
+        ? '.' + item.original_filename.split('.').pop()
+        : ''
+      const oldFilename = item.original_filename
+      const newFilename = trimmed + ext
 
-    if (newFilename === oldFilename) return
+      if (newFilename === oldFilename) return
 
-    // Optimistic update using current store state to avoid stale closure
-    const currentHistory = useStore.getState().transcriptionHistory
-    setHistory(currentHistory.map((h) =>
-      h.id === item.id ? { ...h, original_filename: newFilename } : h
-    ))
-    const currentFile = useStore.getState().file
-    if (currentFile && currentFile.id === item.file_id) {
-      setFile({ ...currentFile, original_filename: newFilename })
-    }
-
-    savingRef.current = true
-    try {
-      await api.renameFile(item.file_id, trimmed)
-    } catch {
-      // Revert on failure using current store state to avoid stale closure
       const currentHistory = useStore.getState().transcriptionHistory
       setHistory(currentHistory.map((h) =>
-        h.id === item.id ? { ...h, original_filename: oldFilename } : h
+        h.id === item.id ? { ...h, original_filename: newFilename } : h
       ))
       const currentFile = useStore.getState().file
       if (currentFile && currentFile.id === item.file_id) {
-        setFile({ ...currentFile, original_filename: oldFilename })
+        setFile({ ...currentFile, original_filename: newFilename })
       }
-    } finally {
-      savingRef.current = false
+
+      savingRef.current = true
+      try {
+        await api.renameFile(item.file_id, trimmed)
+      } catch {
+        const currentHistory = useStore.getState().transcriptionHistory
+        setHistory(currentHistory.map((h) =>
+          h.id === item.id ? { ...h, original_filename: oldFilename } : h
+        ))
+        const currentFile = useStore.getState().file
+        if (currentFile && currentFile.id === item.file_id) {
+          setFile({ ...currentFile, original_filename: oldFilename })
+        }
+      } finally {
+        savingRef.current = false
+      }
+    } else if (field === 'title') {
+      const oldTitle = item.title
+      if (trimmed === oldTitle) return
+
+      const currentHistory = useStore.getState().transcriptionHistory
+      setHistory(currentHistory.map((h) =>
+        h.id === item.id ? { ...h, title: trimmed } : h
+      ))
+
+      savingRef.current = true
+      try {
+        await api.renameTitle(item.id, trimmed)
+      } catch {
+        const currentHistory = useStore.getState().transcriptionHistory
+        setHistory(currentHistory.map((h) =>
+          h.id === item.id ? { ...h, title: oldTitle } : h
+        ))
+      } finally {
+        savingRef.current = false
+      }
     }
-  }, [editValue, editingId, setHistory, setFile])
+  }, [editValue, editingId, editingField, setHistory, setFile])
 
   const handleRenameKeyDown = useCallback((e: React.KeyboardEvent, item: TranscriptionListItem) => {
     if (e.key === 'Enter') {
       e.preventDefault()
-      handleRenameSave(item)
+      handleEditSave(item)
     } else if (e.key === 'Escape') {
       setEditingId(null)
+      setEditingField(null)
     }
-  }, [handleRenameSave])
+  }, [handleEditSave])
 
   const supportsRecording = typeof MediaRecorder !== 'undefined'
 
@@ -177,25 +220,39 @@ export function TranscriptionList() {
             className="w-full flex items-center gap-3 px-3 py-2 bg-gray-800 rounded hover:bg-gray-700 text-sm text-left cursor-pointer"
           >
             {editingId === item.id ? (
-              <span className="flex-1 flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+              <span className="flex-1 flex items-center gap-1 min-w-0" onClick={(e) => e.stopPropagation()}>
                 <input
                   ref={inputRef}
                   type="text"
                   value={editValue}
                   onChange={(e) => setEditValue(e.target.value)}
-                  onBlur={() => handleRenameSave(item)}
+                  onBlur={() => handleEditSave(item)}
                   onKeyDown={(e) => handleRenameKeyDown(e, item)}
                   className="bg-gray-700 text-gray-200 px-1 py-0 rounded text-sm flex-1 min-w-0 outline-none focus:ring-1 focus:ring-blue-500"
                 />
-                <span className="text-gray-500 text-xs">{item.original_filename.includes('.') ? '.' + item.original_filename.split('.').pop() : ''}</span>
+                {editingField === 'filename' && (
+                  <span className="text-gray-500 text-xs">{item.original_filename.includes('.') ? '.' + item.original_filename.split('.').pop() : ''}</span>
+                )}
               </span>
             ) : (
-              <span
-                className="text-gray-300 flex-1 truncate"
-                onDoubleClick={(e) => handleRenameStart(e, item)}
-                title={t('transcription.doubleClickToRename')}
-              >
-                {item.original_filename}
+              <span className="flex-1 min-w-0">
+                {item.title ? (
+                  <>
+                    <span className="flex items-center gap-1">
+                      <span className="text-gray-300 truncate">{item.title}</span>
+                      <PencilButton onClick={(e) => handleEditStart(e, item, 'title')} title={t('transcription.editTitle')} />
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span className="text-xs text-gray-500 truncate">{item.original_filename}</span>
+                      <PencilButton onClick={(e) => handleEditStart(e, item, 'filename')} title={t('transcription.editFilename')} />
+                    </span>
+                  </>
+                ) : (
+                  <span className="flex items-center gap-1">
+                    <span className="text-gray-300 truncate">{item.original_filename}</span>
+                    <PencilButton onClick={(e) => handleEditStart(e, item, 'filename')} title={t('transcription.editFilename')} />
+                  </span>
+                )}
               </span>
             )}
             <span className="text-gray-500 text-xs">{item.model}</span>

--- a/frontend/src/components/TranscriptionList/TranscriptionList.tsx
+++ b/frontend/src/components/TranscriptionList/TranscriptionList.tsx
@@ -23,6 +23,7 @@ export function TranscriptionList() {
   const history = useStore((s) => s.transcriptionHistory)
   const setHistory = useStore((s) => s.setTranscriptionHistory)
   const setTranscriptionId = useStore((s) => s.setTranscriptionId)
+  const setTranscriptionTitle = useStore((s) => s.setTranscriptionTitle)
   const setTranscriptionStatus = useStore((s) => s.setTranscriptionStatus)
   const setResult = useStore((s) => s.setTranscriptionResult)
   const setSpeakerMappings = useStore((s) => s.setSpeakerMappings)
@@ -57,6 +58,7 @@ export function TranscriptionList() {
 
   const doSelect = async (item: TranscriptionListItem) => {
     setTranscriptionId(item.id)
+    setTranscriptionTitle(item.title || null)
     setTranscriptionStatus(item.status)
     const ext = item.original_filename.split('.').pop()?.toLowerCase() || ''
     setFile({ id: item.file_id, original_filename: item.original_filename, media_type: ext, file_size: item.file_size })

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -275,7 +275,8 @@
     "unsavedSwitchTab": "Sie haben ungespeicherte Änderungen. Möchten Sie wirklich wechseln? Die aktuelle Transkription wird geschlossen.",
     "systemAudio": "Systemaudio",
     "systemAudioWarning": "Experimentelle Funktion. Ihr Browser wird Sie bitten, einen Tab oder Bildschirm auszuwählen, dessen Audio aufgenommen werden soll. Dies funktioniert am besten mit Chrome/Edge unter Windows. macOS und andere Browser haben eingeschränkte oder keine Unterstützung für System-Audioaufnahme. Führen Sie das Meeting am besten in einem Browser-Tab durch und wählen Sie diesen Tab aus, wenn Sie dazu aufgefordert werden.",
-    "systemAudioFailed": "Systemaudio konnte nicht aufgenommen werden. Möglicherweise haben Sie die Eingabeaufforderung abgebrochen oder Ihr Browser unterstützt diese Funktion nicht."
+    "systemAudioFailed": "Systemaudio konnte nicht aufgenommen werden. Möglicherweise haben Sie die Eingabeaufforderung abgebrochen oder Ihr Browser unterstützt diese Funktion nicht.",
+    "consentReminder": "Nehmen Sie niemanden ohne Erlaubnis auf. Fragen Sie vorher!"
   },
   "player": {
     "subtitles": "Untertitel",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -35,7 +35,9 @@
     "confirmDelete": "Sind Sie sicher, dass Sie diese Transkription löschen möchten? Dies kann nicht rückgängig gemacht werden.",
     "statusPending": "Wartet in der Warteschlange — bitte warten...",
     "statusProcessing": "Audio wird transkribiert — bitte warten, dies kann einige Minuten dauern.",
-    "statusUploading": "Datei wird hochgeladen — bitte warten..."
+    "statusUploading": "Datei wird hochgeladen — bitte warten...",
+    "editTitle": "Titel bearbeiten",
+    "editFilename": "Dateinamen bearbeiten"
   },
   "editor": {
     "subtitles": "Untertitel",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -275,7 +275,8 @@
     "unsavedSwitchTab": "You have unsaved changes. Are you sure you want to switch? Your current transcription will be closed.",
     "systemAudio": "System audio",
     "systemAudioWarning": "Experimental feature. Your browser will ask you to select a tab or screen to capture audio from. This works best on Chrome/Edge on Windows. macOS and other browsers have limited or no support for system audio capture. For best results, run the meeting in a browser tab and select that tab when prompted.",
-    "systemAudioFailed": "Could not capture system audio. You may have cancelled the prompt or your browser does not support this feature."
+    "systemAudioFailed": "Could not capture system audio. You may have cancelled the prompt or your browser does not support this feature.",
+    "consentReminder": "Don't record people without their permission. Ask first!"
   },
   "player": {
     "subtitles": "Subtitles",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -35,7 +35,9 @@
     "confirmDelete": "Are you sure you want to delete this transcription? This cannot be undone.",
     "statusPending": "Waiting in queue — please wait...",
     "statusProcessing": "Transcribing audio — please wait, this may take a few minutes.",
-    "statusUploading": "Uploading file — please wait..."
+    "statusUploading": "Uploading file — please wait...",
+    "editTitle": "Edit title",
+    "editFilename": "Edit filename"
   },
   "editor": {
     "subtitles": "Subtitles",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -11,9 +11,11 @@ interface AppState {
   file: FileInfo | null
   setFile: (file: FileInfo | null) => void
   transcriptionId: string | null
+  transcriptionTitle: string | null
   transcriptionStatus: string | null
   transcriptionResult: TranscriptionResult | null
   setTranscriptionId: (id: string | null) => void
+  setTranscriptionTitle: (title: string | null) => void
   setTranscriptionStatus: (status: string | null) => void
   setTranscriptionResult: (result: TranscriptionResult | null) => void
   speakerMappings: Record<string, string>
@@ -69,9 +71,11 @@ export const useStore = create<AppState>((set) => ({
   file: null,
   setFile: (file) => set({ file }),
   transcriptionId: null,
+  transcriptionTitle: null,
   transcriptionStatus: null,
   transcriptionResult: null,
   setTranscriptionId: (id) => set({ transcriptionId: id }),
+  setTranscriptionTitle: (title) => set({ transcriptionTitle: title }),
   setTranscriptionStatus: (status) => set({ transcriptionStatus: status }),
   setTranscriptionResult: (result) => set({ transcriptionResult: result }),
   speakerMappings: {},
@@ -106,7 +110,7 @@ export const useStore = create<AppState>((set) => ({
   clearRefinement: () => set({ refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const }),
   reset: () => set({
     currentView: 'archive' as const,
-    file: null, transcriptionId: null, transcriptionStatus: null,
+    file: null, transcriptionId: null, transcriptionTitle: null, transcriptionStatus: null,
     transcriptionResult: null, speakerMappings: {},
     currentTime: 0, seekTo: null, activeTab: 'subtitles', unsavedEdits: false,
     refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const,


### PR DESCRIPTION
## Summary

- Auto-generate a short title for transcriptions using the LLM after ASR completes (skipped when no LLM is configured)
- Display title in list view (primary line) and detail view header, with original filename shown alongside
- Both title and filename are editable via pencil icons (replaces double-click to rename)
- New `PATCH /api/transcription/{id}/title` endpoint for title updates
- Adds `title` column to transcriptions table with automatic migration

Closes #75