### PR TITLE
feat: settings during upload and system-audio-only recording

### DIFF
--- a/frontend/src/components/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/FileUpload/FileUpload.tsx
@@ -11,7 +11,8 @@ export function FileUpload() {
   const transcriptionId = useStore((s) => s.transcriptionId)
   const transcriptionTitle = useStore((s) => s.transcriptionTitle)
   const reset = useStore((s) => s.reset)
-  const [uploading, setUploading] = useState(false)
+  const uploading = useStore((s) => s.uploading)
+  const setUploading = useStore((s) => s.setUploading)
   const [error, setError] = useState<string | null>(null)
 
   const setCurrentView = useStore((s) => s.setCurrentView)

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../../store'
 import { api } from '../../api/client'
@@ -8,6 +8,7 @@ export function SettingsPanel() {
   const { t } = useTranslation()
   const config = useStore((s) => s.config)
   const file = useStore((s) => s.file)
+  const uploading = useStore((s) => s.uploading)
   const setTranscriptionId = useStore((s) => s.setTranscriptionId)
   const setTranscriptionStatus = useStore((s) => s.setTranscriptionStatus)
 
@@ -21,8 +22,26 @@ export function SettingsPanel() {
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [pendingTranscription, setPendingTranscription] = useState(false)
+
+  useEffect(() => {
+    if (pendingTranscription && file) {
+      setPendingTranscription(false)
+      handleTranscribe()
+    }
+  }, [file, pendingTranscription])
+
+  useEffect(() => {
+    if (pendingTranscription && !uploading && !file) {
+      setPendingTranscription(false)
+    }
+  }, [uploading, file, pendingTranscription])
 
   const handleTranscribe = async () => {
+    if (!file && uploading) {
+      setPendingTranscription(true)
+      return
+    }
     if (!file) return
     setSubmitting(true)
     setError(null)
@@ -89,8 +108,20 @@ export function SettingsPanel() {
         <button onClick={() => setShowAdvanced(!showAdvanced)} className="text-sm text-blue-400 hover:text-blue-300 shrink-0">
           {t('settings.advancedOptions')} {showAdvanced ? '▲' : '▼'}
         </button>
-        <button onClick={handleTranscribe} disabled={!file || submitting} className="ml-auto px-4 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-500 disabled:opacity-50 shrink-0">
-          {submitting ? t('common.loading') : t('transcription.transcribe')}
+        <button
+          onClick={handleTranscribe}
+          disabled={(!file && !uploading) || submitting}
+          className={`ml-auto px-4 py-1.5 text-white text-sm rounded disabled:opacity-50 shrink-0 ${
+            pendingTranscription ? 'bg-amber-600 hover:bg-amber-500' : 'bg-blue-600 hover:bg-blue-500'
+          }`}
+        >
+          {submitting
+            ? t('common.loading')
+            : pendingTranscription
+              ? t('transcription.transcribeWhenReady')
+              : uploading && !file
+                ? t('transcription.transcribeWhenReady')
+                : t('transcription.transcribe')}
         </button>
       </div>
       {error && (

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../../store'
 import { api } from '../../api/client'
@@ -24,20 +24,7 @@ export function SettingsPanel() {
   const [error, setError] = useState<string | null>(null)
   const [pendingTranscription, setPendingTranscription] = useState(false)
 
-  useEffect(() => {
-    if (pendingTranscription && file) {
-      setPendingTranscription(false)
-      handleTranscribe()
-    }
-  }, [file, pendingTranscription])
-
-  useEffect(() => {
-    if (pendingTranscription && !uploading && !file) {
-      setPendingTranscription(false)
-    }
-  }, [uploading, file, pendingTranscription])
-
-  const handleTranscribe = async () => {
+  const handleTranscribe = useCallback(async () => {
     if (!file && uploading) {
       setPendingTranscription(true)
       return
@@ -63,7 +50,20 @@ export function SettingsPanel() {
     } finally {
       setSubmitting(false)
     }
-  }
+  }, [file, uploading, language, model, detectSpeakers, minSpeakers, maxSpeakers, initialPrompt, hotwords, setTranscriptionId, setTranscriptionStatus])
+
+  useEffect(() => {
+    if (pendingTranscription && file) {
+      setPendingTranscription(false)
+      handleTranscribe()
+    }
+  }, [file, pendingTranscription, handleTranscribe])
+
+  useEffect(() => {
+    if (pendingTranscription && !uploading && !file) {
+      setPendingTranscription(false)
+    }
+  }, [uploading, file, pendingTranscription])
 
   return (
     <div className="px-6 py-3 bg-gray-800 border-b border-gray-700 space-y-3">

--- a/frontend/src/components/Recorder/DeviceSelector.tsx
+++ b/frontend/src/components/Recorder/DeviceSelector.tsx
@@ -14,6 +14,8 @@ const warningKey: Record<string, string> = {
 interface DeviceSelectorProps {
   useCamera: boolean
   onUseCameraChange: (useCamera: boolean) => void
+  useMicrophone: boolean
+  onUseMicrophoneChange: (use: boolean) => void
   audioDeviceId: string
   onAudioDeviceChange: (id: string) => void
   videoDeviceId: string
@@ -28,6 +30,8 @@ interface DeviceSelectorProps {
 export function DeviceSelector({
   useCamera,
   onUseCameraChange,
+  useMicrophone,
+  onUseMicrophoneChange,
   audioDeviceId,
   onAudioDeviceChange,
   videoDeviceId,
@@ -96,22 +100,24 @@ export function DeviceSelector({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-3 min-w-0">
-        <label className="text-sm text-gray-300 min-w-24 shrink-0">{t('recorder.selectMic')}</label>
-        <select
-          value={audioDeviceId}
-          onChange={(e) => onAudioDeviceChange(e.target.value)}
-          disabled={disabled}
-          className="flex-1 min-w-0 bg-gray-700 text-white rounded-lg px-3 py-2 text-sm disabled:opacity-50"
-        >
-          {audioDevices.map((d) => (
-            <option key={d.deviceId} value={d.deviceId}>
-              {d.label || `Microphone ${d.deviceId.slice(0, 8)}`}
-            </option>
-          ))}
-          {audioDevices.length === 0 && <option value="">—</option>}
-        </select>
-      </div>
+      {useMicrophone && (
+        <div className="flex items-center gap-3 min-w-0">
+          <label className="text-sm text-gray-300 min-w-24 shrink-0">{t('recorder.selectMic')}</label>
+          <select
+            value={audioDeviceId}
+            onChange={(e) => onAudioDeviceChange(e.target.value)}
+            disabled={disabled}
+            className="flex-1 min-w-0 bg-gray-700 text-white rounded-lg px-3 py-2 text-sm disabled:opacity-50"
+          >
+            {audioDevices.map((d) => (
+              <option key={d.deviceId} value={d.deviceId}>
+                {d.label || `Microphone ${d.deviceId.slice(0, 8)}`}
+              </option>
+            ))}
+            {audioDevices.length === 0 && <option value="">—</option>}
+          </select>
+        </div>
+      )}
 
       {systemAudioSupport === 'unsupported' ? (
         <p className="text-xs text-gray-500">{t('recorder.systemAudioUnsupported')}</p>
@@ -143,7 +149,29 @@ export function DeviceSelector({
         </div>
       )}
 
-      {captureSystemAudio && systemAudioSupport === 'dual-device' && (
+      {captureSystemAudio && (
+        <div className="flex items-center gap-3">
+          <label className="text-sm text-gray-300 min-w-24">{t('recorder.useMicrophone')}</label>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={useMicrophone}
+            onClick={() => onUseMicrophoneChange(!useMicrophone)}
+            disabled={disabled}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
+              useMicrophone ? 'bg-blue-600' : 'bg-gray-600'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                useMicrophone ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </div>
+      )}
+
+      {captureSystemAudio && useMicrophone && systemAudioSupport === 'dual-device' && (
         <div className="flex items-center gap-3 min-w-0">
           <label className="text-sm text-gray-300 min-w-24 shrink-0">{t('recorder.selectSecondDevice')}</label>
           <select

--- a/frontend/src/components/Recorder/RecorderPanel.tsx
+++ b/frontend/src/components/Recorder/RecorderPanel.tsx
@@ -34,15 +34,19 @@ export function RecorderPanel() {
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [captureSystemAudio, setCaptureSystemAudio] = useState(false)
   const [secondAudioDeviceId, setSecondAudioDeviceId] = useState('')
+  const [useMicrophone, setUseMicrophone] = useState(true)
 
   const handleCaptureSystemAudioChange = useCallback((capture: boolean) => {
     setCaptureSystemAudio(capture)
     if (capture) setUseCamera(false)
-    if (!capture) setSecondAudioDeviceId('')
+    if (!capture) {
+      setSecondAudioDeviceId('')
+      setUseMicrophone(true)
+    }
   }, [])
 
   const { state, blob, stream, duration, error, start, pause, resume, stop, discard } =
-    useMediaRecorder({ audioDeviceId, videoDeviceId, useCamera, captureSystemAudio, secondAudioDeviceId })
+    useMediaRecorder({ audioDeviceId, videoDeviceId, useCamera, captureSystemAudio, secondAudioDeviceId, useMicrophone })
 
   const videoPreviewRef = useRef<HTMLVideoElement>(null)
 
@@ -138,6 +142,8 @@ export function RecorderPanel() {
           onCaptureSystemAudioChange={handleCaptureSystemAudioChange}
           secondAudioDeviceId={secondAudioDeviceId}
           onSecondAudioDeviceChange={setSecondAudioDeviceId}
+          useMicrophone={useMicrophone}
+          onUseMicrophoneChange={setUseMicrophone}
           disabled={isActive}
         />
       )}

--- a/frontend/src/components/Recorder/useMediaRecorder.ts
+++ b/frontend/src/components/Recorder/useMediaRecorder.ts
@@ -330,7 +330,9 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
       setState('recording')
       startTimer()
     } catch (err) {
-      if (options.useCamera && err instanceof DOMException && err.name === 'NotAllowedError') {
+      if (options.captureSystemAudio && options.useMicrophone === false) {
+        setError('systemAudioFailed')
+      } else if (options.useCamera && err instanceof DOMException && err.name === 'NotAllowedError') {
         setError('cameraFailed')
       } else {
         setError('micRequired')

--- a/frontend/src/components/Recorder/useMediaRecorder.ts
+++ b/frontend/src/components/Recorder/useMediaRecorder.ts
@@ -8,6 +8,7 @@ interface UseMediaRecorderOptions {
   useCamera?: boolean
   captureSystemAudio?: boolean
   secondAudioDeviceId?: string
+  useMicrophone?: boolean
 }
 
 interface UseMediaRecorderReturn {
@@ -131,42 +132,24 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
     resetTimer()
 
     try {
-      // Step 1: Get microphone stream
-      const constraints: MediaStreamConstraints = {
-        audio: options.audioDeviceId
-          ? { deviceId: { exact: options.audioDeviceId } }
-          : true,
-      }
-      if (options.useCamera && !options.captureSystemAudio) {
-        constraints.video = options.videoDeviceId
-          ? { deviceId: { exact: options.videoDeviceId } }
-          : true
-      }
+      let recordingStream: MediaStream
 
-      const micStream = await navigator.mediaDevices.getUserMedia(constraints)
-      streamRef.current = micStream
-
-      let recordingStream: MediaStream = micStream
-
-      // Step 2: If system audio, either mix two devices or use getDisplayMedia
-      if (options.captureSystemAudio) {
+      if (options.captureSystemAudio && options.useMicrophone === false) {
+        // System audio only — no microphone
         if (options.secondAudioDeviceId) {
-          // Dual-device mode: mix mic + second audio input (no getDisplayMedia)
+          // Dual-device mode: use second device directly as the only audio source
           let secondStream: MediaStream
           try {
             secondStream = await navigator.mediaDevices.getUserMedia({
               audio: { deviceId: { exact: options.secondAudioDeviceId } },
             })
           } catch {
-            micStream.getTracks().forEach((t) => t.stop())
-            streamRef.current = null
             setError('secondDeviceFailed')
             return
           }
 
           secondStreamRef.current = secondStream
 
-          // Listen for second device disconnection
           const secondAudioTrack = secondStream.getAudioTracks()[0]
           const onSecondEnded = () => {
             if (recorderRef.current && recorderRef.current.state !== 'inactive') {
@@ -176,17 +159,9 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
           secondAudioTrack.addEventListener('ended', onSecondEnded)
           displayEndedHandlerRef.current = onSecondEnded
 
-          const audioCtx = new AudioContext()
-          const micSource = audioCtx.createMediaStreamSource(micStream)
-          const secondSource = audioCtx.createMediaStreamSource(secondStream)
-          const destination = audioCtx.createMediaStreamDestination()
-          micSource.connect(destination)
-          secondSource.connect(destination)
-
-          mixAudioContextRef.current = audioCtx
-          recordingStream = destination.stream
+          recordingStream = secondStream
         } else {
-          // Existing getDisplayMedia path (unchanged)
+          // getDisplayMedia mode: use display audio directly
           let displayStream: MediaStream
           try {
             displayStream = await navigator.mediaDevices.getDisplayMedia({
@@ -194,8 +169,6 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
               video: true,
             })
           } catch {
-            micStream.getTracks().forEach((t) => t.stop())
-            streamRef.current = null
             setError('systemAudioFailed')
             return
           }
@@ -204,8 +177,6 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
 
           if (displayStream.getAudioTracks().length === 0) {
             displayStream.getTracks().forEach((t) => t.stop())
-            micStream.getTracks().forEach((t) => t.stop())
-            streamRef.current = null
             setError('systemAudioFailed')
             return
           }
@@ -221,21 +192,114 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
           displayAudioTrack.addEventListener('ended', onDisplayEnded)
           displayEndedHandlerRef.current = onDisplayEnded
 
-          const audioCtx = new AudioContext()
-          const micSource = audioCtx.createMediaStreamSource(micStream)
-          const displaySource = audioCtx.createMediaStreamSource(displayStream)
-          const destination = audioCtx.createMediaStreamDestination()
-          micSource.connect(destination)
-          displaySource.connect(destination)
+          recordingStream = displayStream
+        }
+      } else {
+        // Standard path: microphone (with optional system audio mixing)
+        const constraints: MediaStreamConstraints = {
+          audio: options.audioDeviceId
+            ? { deviceId: { exact: options.audioDeviceId } }
+            : true,
+        }
+        if (options.useCamera && !options.captureSystemAudio) {
+          constraints.video = options.videoDeviceId
+            ? { deviceId: { exact: options.videoDeviceId } }
+            : true
+        }
 
-          mixAudioContextRef.current = audioCtx
-          recordingStream = destination.stream
+        const micStream = await navigator.mediaDevices.getUserMedia(constraints)
+        streamRef.current = micStream
+
+        recordingStream = micStream
+
+        if (options.captureSystemAudio) {
+          if (options.secondAudioDeviceId) {
+            // Dual-device mode: mix mic + second audio input
+            let secondStream: MediaStream
+            try {
+              secondStream = await navigator.mediaDevices.getUserMedia({
+                audio: { deviceId: { exact: options.secondAudioDeviceId } },
+              })
+            } catch {
+              micStream.getTracks().forEach((t) => t.stop())
+              streamRef.current = null
+              setError('secondDeviceFailed')
+              return
+            }
+
+            secondStreamRef.current = secondStream
+
+            const secondAudioTrack = secondStream.getAudioTracks()[0]
+            const onSecondEnded = () => {
+              if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+                recorderRef.current.stop()
+              }
+            }
+            secondAudioTrack.addEventListener('ended', onSecondEnded)
+            displayEndedHandlerRef.current = onSecondEnded
+
+            const audioCtx = new AudioContext()
+            const micSource = audioCtx.createMediaStreamSource(micStream)
+            const secondSource = audioCtx.createMediaStreamSource(secondStream)
+            const destination = audioCtx.createMediaStreamDestination()
+            micSource.connect(destination)
+            secondSource.connect(destination)
+
+            mixAudioContextRef.current = audioCtx
+            recordingStream = destination.stream
+          } else {
+            // getDisplayMedia path: mix mic + display audio
+            let displayStream: MediaStream
+            try {
+              displayStream = await navigator.mediaDevices.getDisplayMedia({
+                audio: true,
+                video: true,
+              })
+            } catch {
+              micStream.getTracks().forEach((t) => t.stop())
+              streamRef.current = null
+              setError('systemAudioFailed')
+              return
+            }
+
+            displayStream.getVideoTracks().forEach((t) => t.stop())
+
+            if (displayStream.getAudioTracks().length === 0) {
+              displayStream.getTracks().forEach((t) => t.stop())
+              micStream.getTracks().forEach((t) => t.stop())
+              streamRef.current = null
+              setError('systemAudioFailed')
+              return
+            }
+
+            displayStreamRef.current = displayStream
+
+            const displayAudioTrack = displayStream.getAudioTracks()[0]
+            const onDisplayEnded = () => {
+              if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+                recorderRef.current.stop()
+              }
+            }
+            displayAudioTrack.addEventListener('ended', onDisplayEnded)
+            displayEndedHandlerRef.current = onDisplayEnded
+
+            const audioCtx = new AudioContext()
+            const micSource = audioCtx.createMediaStreamSource(micStream)
+            const displaySource = audioCtx.createMediaStreamSource(displayStream)
+            const destination = audioCtx.createMediaStreamDestination()
+            micSource.connect(destination)
+            displaySource.connect(destination)
+
+            mixAudioContextRef.current = audioCtx
+            recordingStream = destination.stream
+          }
         }
       }
 
       setStream(recordingStream)
 
-      const mimeType = getPreferredMimeType(!!options.useCamera && !options.captureSystemAudio)
+      const hasVideo = !!options.useCamera && !options.captureSystemAudio
+      const mimeType = getPreferredMimeType(hasVideo)
       const recorder = new MediaRecorder(recordingStream, mimeType ? { mimeType } : undefined)
 
       recorder.ondataavailable = (e) => {
@@ -243,7 +307,6 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
       }
 
       recorder.onstop = () => {
-        // Skip blob creation if we're discarding
         if (discardingRef.current) {
           discardingRef.current = false
           return
@@ -253,19 +316,17 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
         setBlob(recordedBlob)
         setState('stopped')
         if (timerRef.current) pauseTimer()
-        // Stop tracks after blob is created so MediaRecorder gets all data
         stopAllTracks()
       }
 
       recorder.onerror = () => {
-        // Let onstop create blob from partial chunks so user can save their recording
         setError('deviceDisconnected')
         if (recorderRef.current?.state !== 'inactive') recorderRef.current?.stop()
         stopAllTracks()
       }
 
       recorderRef.current = recorder
-      recorder.start(1000) // collect chunks every second
+      recorder.start(1000)
       setState('recording')
       startTimer()
     } catch (err) {
@@ -275,7 +336,7 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
         setError('micRequired')
       }
     }
-  }, [options.audioDeviceId, options.videoDeviceId, options.useCamera, options.captureSystemAudio, options.secondAudioDeviceId, resetTimer, startTimer, pauseTimer, stopAllTracks])
+  }, [options.audioDeviceId, options.videoDeviceId, options.useCamera, options.captureSystemAudio, options.secondAudioDeviceId, options.useMicrophone, resetTimer, startTimer, pauseTimer, stopAllTracks])
 
   const pause = useCallback(() => {
     if (recorderRef.current?.state === 'recording') {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -31,6 +31,7 @@
   },
   "transcription": {
     "transcribe": "Transkribieren",
+    "transcribeWhenReady": "Transkribieren wenn bereit",
     "inProgress": "Transkription läuft...",
     "success": "Transkription erfolgreich!",
     "failed": "Transkription fehlgeschlagen",
@@ -291,6 +292,7 @@
     "deviceDisconnected": "Aufnahmegerät getrennt. Ihre bisherige Aufnahme wurde gespeichert.",
     "unsavedRecording": "Sie haben eine nicht gespeicherte Aufnahme. Möchten Sie die Seite wirklich verlassen?",
     "useCamera": "Kamera verwenden",
+    "useMicrophone": "Mikrofon aufnehmen",
     "selectMic": "Mikrofon",
     "selectCamera": "Kamera",
     "recordingNotSupported": "Aufnahme wird in diesem Browser nicht unterstützt.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -31,6 +31,7 @@
   },
   "transcription": {
     "transcribe": "Transcribe",
+    "transcribeWhenReady": "Transcribe when ready",
     "inProgress": "Transcription in progress...",
     "success": "Transcription successful!",
     "failed": "Transcription failed",
@@ -291,6 +292,7 @@
     "deviceDisconnected": "Recording device disconnected. Your recording up to this point has been saved.",
     "unsavedRecording": "You have an unsaved recording. Are you sure you want to leave?",
     "useCamera": "Use camera",
+    "useMicrophone": "Record microphone",
     "selectMic": "Microphone",
     "selectCamera": "Camera",
     "recordingNotSupported": "Recording is not supported in this browser.",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -10,6 +10,8 @@ interface AppState {
   setConfig: (config: ConfigResponse) => void
   file: FileInfo | null
   setFile: (file: FileInfo | null) => void
+  uploading: boolean
+  setUploading: (uploading: boolean) => void
   transcriptionId: string | null
   transcriptionTitle: string | null
   transcriptionStatus: string | null
@@ -68,6 +70,8 @@ export const useStore = create<AppState>((set) => ({
   setConfig: (config) => set({ config }),
   file: null,
   setFile: (file) => set({ file }),
+  uploading: false,
+  setUploading: (uploading) => set({ uploading }),
   transcriptionId: null,
   transcriptionTitle: null,
   transcriptionStatus: null,
@@ -106,7 +110,7 @@ export const useStore = create<AppState>((set) => ({
   clearRefinement: () => set({ refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const }),
   reset: () => set({
     currentView: 'archive' as const,
-    file: null, transcriptionId: null, transcriptionTitle: null, transcriptionStatus: null,
+    file: null, uploading: false, transcriptionId: null, transcriptionTitle: null, transcriptionStatus: null,
     transcriptionResult: null, speakerMappings: {},
     currentTime: 0, seekTo: null, activeTab: 'subtitles', unsavedEdits: false,
     refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const,


### PR DESCRIPTION
## Summary

- **Settings during upload (#84):** Users can now configure transcription settings (language, model, speakers, etc.) while a file is uploading. Clicking "Transcribe" during upload queues the transcription to start automatically when the upload completes. The button shows "Transcribe when ready" with an amber style to indicate the queued state.
- **System audio only (#89):** When "System audio" is enabled in the recorder, a new "Record microphone" toggle appears (default: on). Turning it off hides the microphone dropdown and records system audio only — no microphone permission required. The toggle resets when system audio is turned off.

Closes #84
Closes #89