### PR TITLE
feat: user presets with composable bundles and auto-pipeline

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -108,6 +108,7 @@ CREATE TABLE IF NOT EXISTS preset_bundles (
     transcription_preset_id TEXT REFERENCES transcription_presets(id) ON DELETE SET NULL,
     analysis_preset_id TEXT REFERENCES analysis_presets(id) ON DELETE SET NULL,
     refinement_preset_id TEXT REFERENCES refinement_presets(id) ON DELETE SET NULL,
+    translate_language TEXT,
     is_default INTEGER DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -127,6 +128,7 @@ MIGRATIONS = [
     ("is_archived", "files", "is_archived INTEGER DEFAULT 0"),
     ("title", "transcriptions", "title TEXT"),
     ("has_video", "files", "has_video INTEGER"),
+    ("translate_language", "preset_bundles", "translate_language TEXT"),
 ]
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -64,6 +64,54 @@ CREATE TABLE IF NOT EXISTS analyses (
     llm_model TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS transcription_presets (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id),
+    name TEXT NOT NULL,
+    language TEXT,
+    model TEXT DEFAULT 'base',
+    min_speakers INTEGER DEFAULT 0,
+    max_speakers INTEGER DEFAULT 0,
+    initial_prompt TEXT,
+    hotwords TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS analysis_presets (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id),
+    name TEXT NOT NULL,
+    template TEXT,
+    custom_prompt TEXT,
+    language TEXT,
+    chapter_hints TEXT,
+    agenda TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS refinement_presets (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id),
+    name TEXT NOT NULL,
+    context TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS preset_bundles (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id),
+    name TEXT NOT NULL,
+    transcription_preset_id TEXT REFERENCES transcription_presets(id) ON DELETE SET NULL,
+    analysis_preset_id TEXT REFERENCES analysis_presets(id) ON DELETE SET NULL,
+    refinement_preset_id TEXT REFERENCES refinement_presets(id) ON DELETE SET NULL,
+    is_default INTEGER DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 """
 
 _db_path: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db, get_db
-from app.routers import config_router, upload, transcription, refinement, analysis, translation
+from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets
 from app.metrics import inc, cleanup_runs_total, cleanup_items_deleted_total
 from app.services.audio import has_video_stream
 
@@ -121,6 +121,7 @@ app.include_router(transcription.router)
 app.include_router(refinement.router)
 app.include_router(analysis.router)
 app.include_router(translation.router)
+app.include_router(presets.router)
 
 # Serve frontend static files (only when built files exist, i.e., in Docker)
 from fastapi.staticfiles import StaticFiles

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -204,3 +204,67 @@ class ConfigResponse(BaseModel):
     llm_available: bool
     logout_url: str
     popular_languages: list[str] = []
+
+
+# --- Presets ---
+
+class TranscriptionPresetCreate(BaseModel):
+    name: str
+    language: str | None = None
+    model: str = "base"
+    min_speakers: int = 0
+    max_speakers: int = 0
+    initial_prompt: str | None = None
+    hotwords: str | None = None
+
+
+class TranscriptionPresetResponse(TranscriptionPresetCreate):
+    id: str
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class AnalysisPresetCreate(BaseModel):
+    name: str
+    template: str | None = None
+    custom_prompt: str | None = None
+    language: str | None = None
+    chapter_hints: list[ChapterHint] | None = None
+    agenda: str | None = None
+
+
+class AnalysisPresetResponse(AnalysisPresetCreate):
+    id: str
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class RefinementPresetCreate(BaseModel):
+    name: str
+    context: str | None = None
+
+
+class RefinementPresetResponse(RefinementPresetCreate):
+    id: str
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class BundleCreate(BaseModel):
+    name: str
+    transcription_preset_id: str | None = None
+    analysis_preset_id: str | None = None
+    refinement_preset_id: str | None = None
+
+
+class BundleResponse(BundleCreate):
+    id: str
+    is_default: bool = False
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class BundleExpandedResponse(BundleResponse):
+    transcription_preset: TranscriptionPresetResponse | None = None
+    analysis_preset: AnalysisPresetResponse | None = None
+    refinement_preset: RefinementPresetResponse | None = None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -255,6 +255,7 @@ class BundleCreate(BaseModel):
     transcription_preset_id: str | None = None
     analysis_preset_id: str | None = None
     refinement_preset_id: str | None = None
+    translate_language: str | None = None
 
 
 class BundleResponse(BundleCreate):

--- a/backend/app/routers/presets.py
+++ b/backend/app/routers/presets.py
@@ -1,0 +1,492 @@
+import json
+import uuid
+from fastapi import APIRouter, Depends, HTTPException
+from app.dependencies import get_current_user
+from app.models import (
+    UserInfo,
+    TranscriptionPresetCreate,
+    TranscriptionPresetResponse,
+    AnalysisPresetCreate,
+    AnalysisPresetResponse,
+    RefinementPresetCreate,
+    RefinementPresetResponse,
+    BundleCreate,
+    BundleResponse,
+    BundleExpandedResponse,
+    ChapterHint,
+)
+from app.database import get_db
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _row_to_transcription_preset(row) -> TranscriptionPresetResponse:
+    return TranscriptionPresetResponse(
+        id=row["id"],
+        name=row["name"],
+        language=row["language"],
+        model=row["model"] or "base",
+        min_speakers=row["min_speakers"] or 0,
+        max_speakers=row["max_speakers"] or 0,
+        initial_prompt=row["initial_prompt"],
+        hotwords=row["hotwords"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _row_to_analysis_preset(row) -> AnalysisPresetResponse:
+    chapter_hints = None
+    if row["chapter_hints"]:
+        raw = json.loads(row["chapter_hints"])
+        chapter_hints = [ChapterHint(**ch) for ch in raw]
+    return AnalysisPresetResponse(
+        id=row["id"],
+        name=row["name"],
+        template=row["template"],
+        custom_prompt=row["custom_prompt"],
+        language=row["language"],
+        chapter_hints=chapter_hints,
+        agenda=row["agenda"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _row_to_refinement_preset(row) -> RefinementPresetResponse:
+    return RefinementPresetResponse(
+        id=row["id"],
+        name=row["name"],
+        context=row["context"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _row_to_bundle(row) -> BundleResponse:
+    return BundleResponse(
+        id=row["id"],
+        name=row["name"],
+        transcription_preset_id=row["transcription_preset_id"],
+        analysis_preset_id=row["analysis_preset_id"],
+        refinement_preset_id=row["refinement_preset_id"],
+        is_default=bool(row["is_default"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transcription Presets
+# ---------------------------------------------------------------------------
+
+@router.get("/api/presets/transcription", response_model=list[TranscriptionPresetResponse])
+async def list_transcription_presets(user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM transcription_presets WHERE user_id = ? ORDER BY created_at DESC",
+            (user.id,),
+        )
+        rows = await cursor.fetchall()
+    return [_row_to_transcription_preset(r) for r in rows]
+
+
+@router.post("/api/presets/transcription", response_model=TranscriptionPresetResponse, status_code=201)
+async def create_transcription_preset(body: TranscriptionPresetCreate, user: UserInfo = Depends(get_current_user)):
+    preset_id = str(uuid.uuid4())
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO transcription_presets
+               (id, user_id, name, language, model, min_speakers, max_speakers, initial_prompt, hotwords)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (preset_id, user.id, body.name, body.language, body.model,
+             body.min_speakers, body.max_speakers, body.initial_prompt, body.hotwords),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM transcription_presets WHERE id = ?", (preset_id,))
+        row = await cursor.fetchone()
+    return _row_to_transcription_preset(row)
+
+
+@router.get("/api/presets/transcription/{preset_id}", response_model=TranscriptionPresetResponse)
+async def get_transcription_preset(preset_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM transcription_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        row = await cursor.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Transcription preset not found")
+    return _row_to_transcription_preset(row)
+
+
+@router.put("/api/presets/transcription/{preset_id}", response_model=TranscriptionPresetResponse)
+async def update_transcription_preset(preset_id: str, body: TranscriptionPresetCreate, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT id FROM transcription_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        if not await cursor.fetchone():
+            raise HTTPException(status_code=404, detail="Transcription preset not found")
+        await db.execute(
+            """UPDATE transcription_presets
+               SET name = ?, language = ?, model = ?, min_speakers = ?, max_speakers = ?,
+                   initial_prompt = ?, hotwords = ?, updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (body.name, body.language, body.model, body.min_speakers, body.max_speakers,
+             body.initial_prompt, body.hotwords, preset_id),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM transcription_presets WHERE id = ?", (preset_id,))
+        row = await cursor.fetchone()
+    return _row_to_transcription_preset(row)
+
+
+@router.delete("/api/presets/transcription/{preset_id}")
+async def delete_transcription_preset(preset_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "DELETE FROM transcription_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        await db.commit()
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Transcription preset not found")
+    return {"status": "deleted"}
+
+
+# ---------------------------------------------------------------------------
+# Analysis Presets
+# ---------------------------------------------------------------------------
+
+@router.get("/api/presets/analysis", response_model=list[AnalysisPresetResponse])
+async def list_analysis_presets(user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM analysis_presets WHERE user_id = ? ORDER BY created_at DESC",
+            (user.id,),
+        )
+        rows = await cursor.fetchall()
+    return [_row_to_analysis_preset(r) for r in rows]
+
+
+@router.post("/api/presets/analysis", response_model=AnalysisPresetResponse, status_code=201)
+async def create_analysis_preset(body: AnalysisPresetCreate, user: UserInfo = Depends(get_current_user)):
+    preset_id = str(uuid.uuid4())
+    chapter_hints_json = json.dumps([ch.model_dump() for ch in body.chapter_hints]) if body.chapter_hints else None
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO analysis_presets
+               (id, user_id, name, template, custom_prompt, language, chapter_hints, agenda)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (preset_id, user.id, body.name, body.template, body.custom_prompt,
+             body.language, chapter_hints_json, body.agenda),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM analysis_presets WHERE id = ?", (preset_id,))
+        row = await cursor.fetchone()
+    return _row_to_analysis_preset(row)
+
+
+@router.get("/api/presets/analysis/{preset_id}", response_model=AnalysisPresetResponse)
+async def get_analysis_preset(preset_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM analysis_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        row = await cursor.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Analysis preset not found")
+    return _row_to_analysis_preset(row)
+
+
+@router.put("/api/presets/analysis/{preset_id}", response_model=AnalysisPresetResponse)
+async def update_analysis_preset(preset_id: str, body: AnalysisPresetCreate, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT id FROM analysis_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        if not await cursor.fetchone():
+            raise HTTPException(status_code=404, detail="Analysis preset not found")
+        chapter_hints_json = json.dumps([ch.model_dump() for ch in body.chapter_hints]) if body.chapter_hints else None
+        await db.execute(
+            """UPDATE analysis_presets
+               SET name = ?, template = ?, custom_prompt = ?, language = ?,
+                   chapter_hints = ?, agenda = ?, updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (body.name, body.template, body.custom_prompt, body.language,
+             chapter_hints_json, body.agenda, preset_id),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM analysis_presets WHERE id = ?", (preset_id,))
+        row = await cursor.fetchone()
+    return _row_to_analysis_preset(row)
+
+
+@router.delete("/api/presets/analysis/{preset_id}")
+async def delete_analysis_preset(preset_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "DELETE FROM analysis_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        await db.commit()
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Analysis preset not found")
+    return {"status": "deleted"}
+
+
+# ---------------------------------------------------------------------------
+# Refinement Presets
+# ---------------------------------------------------------------------------
+
+@router.get("/api/presets/refinement", response_model=list[RefinementPresetResponse])
+async def list_refinement_presets(user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM refinement_presets WHERE user_id = ? ORDER BY created_at DESC",
+            (user.id,),
+        )
+        rows = await cursor.fetchall()
+    return [_row_to_refinement_preset(r) for r in rows]
+
+
+@router.post("/api/presets/refinement", response_model=RefinementPresetResponse, status_code=201)
+async def create_refinement_preset(body: RefinementPresetCreate, user: UserInfo = Depends(get_current_user)):
+    preset_id = str(uuid.uuid4())
+    async with get_db() as db:
+        await db.execute(
+            "INSERT INTO refinement_presets (id, user_id, name, context) VALUES (?, ?, ?, ?)",
+            (preset_id, user.id, body.name, body.context),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM refinement_presets WHERE id = ?", (preset_id,))
+        row = await cursor.fetchone()
+    return _row_to_refinement_preset(row)
+
+
+@router.get("/api/presets/refinement/{preset_id}", response_model=RefinementPresetResponse)
+async def get_refinement_preset(preset_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM refinement_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        row = await cursor.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Refinement preset not found")
+    return _row_to_refinement_preset(row)
+
+
+@router.put("/api/presets/refinement/{preset_id}", response_model=RefinementPresetResponse)
+async def update_refinement_preset(preset_id: str, body: RefinementPresetCreate, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT id FROM refinement_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        if not await cursor.fetchone():
+            raise HTTPException(status_code=404, detail="Refinement preset not found")
+        await db.execute(
+            """UPDATE refinement_presets
+               SET name = ?, context = ?, updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (body.name, body.context, preset_id),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM refinement_presets WHERE id = ?", (preset_id,))
+        row = await cursor.fetchone()
+    return _row_to_refinement_preset(row)
+
+
+@router.delete("/api/presets/refinement/{preset_id}")
+async def delete_refinement_preset(preset_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "DELETE FROM refinement_presets WHERE id = ? AND user_id = ?",
+            (preset_id, user.id),
+        )
+        await db.commit()
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Refinement preset not found")
+    return {"status": "deleted"}
+
+
+# ---------------------------------------------------------------------------
+# Bundles
+# ---------------------------------------------------------------------------
+
+@router.get("/api/presets/bundles", response_model=list[BundleResponse])
+async def list_bundles(user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM preset_bundles WHERE user_id = ? ORDER BY created_at DESC",
+            (user.id,),
+        )
+        rows = await cursor.fetchall()
+    return [_row_to_bundle(r) for r in rows]
+
+
+@router.post("/api/presets/bundles", response_model=BundleResponse, status_code=201)
+async def create_bundle(body: BundleCreate, user: UserInfo = Depends(get_current_user)):
+    bundle_id = str(uuid.uuid4())
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO preset_bundles
+               (id, user_id, name, transcription_preset_id, analysis_preset_id, refinement_preset_id)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (bundle_id, user.id, body.name, body.transcription_preset_id,
+             body.analysis_preset_id, body.refinement_preset_id),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM preset_bundles WHERE id = ?", (bundle_id,))
+        row = await cursor.fetchone()
+    return _row_to_bundle(row)
+
+
+@router.get("/api/presets/bundles/{bundle_id}", response_model=BundleResponse)
+async def get_bundle(bundle_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM preset_bundles WHERE id = ? AND user_id = ?",
+            (bundle_id, user.id),
+        )
+        row = await cursor.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Bundle not found")
+    return _row_to_bundle(row)
+
+
+@router.put("/api/presets/bundles/{bundle_id}", response_model=BundleResponse)
+async def update_bundle(bundle_id: str, body: BundleCreate, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT id FROM preset_bundles WHERE id = ? AND user_id = ?",
+            (bundle_id, user.id),
+        )
+        if not await cursor.fetchone():
+            raise HTTPException(status_code=404, detail="Bundle not found")
+        await db.execute(
+            """UPDATE preset_bundles
+               SET name = ?, transcription_preset_id = ?, analysis_preset_id = ?,
+                   refinement_preset_id = ?, updated_at = CURRENT_TIMESTAMP
+               WHERE id = ?""",
+            (body.name, body.transcription_preset_id, body.analysis_preset_id,
+             body.refinement_preset_id, bundle_id),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM preset_bundles WHERE id = ?", (bundle_id,))
+        row = await cursor.fetchone()
+    return _row_to_bundle(row)
+
+
+@router.delete("/api/presets/bundles/{bundle_id}")
+async def delete_bundle(bundle_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "DELETE FROM preset_bundles WHERE id = ? AND user_id = ?",
+            (bundle_id, user.id),
+        )
+        await db.commit()
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Bundle not found")
+    return {"status": "deleted"}
+
+
+@router.put("/api/presets/bundles/{bundle_id}/default", response_model=BundleResponse)
+async def set_default_bundle(bundle_id: str, user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT id FROM preset_bundles WHERE id = ? AND user_id = ?",
+            (bundle_id, user.id),
+        )
+        if not await cursor.fetchone():
+            raise HTTPException(status_code=404, detail="Bundle not found")
+        # Clear any existing default for this user
+        await db.execute(
+            "UPDATE preset_bundles SET is_default = 0 WHERE user_id = ?",
+            (user.id,),
+        )
+        await db.execute(
+            "UPDATE preset_bundles SET is_default = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (bundle_id,),
+        )
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM preset_bundles WHERE id = ?", (bundle_id,))
+        row = await cursor.fetchone()
+    return _row_to_bundle(row)
+
+
+@router.delete("/api/presets/default")
+async def clear_default_bundle(user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        await db.execute(
+            "UPDATE preset_bundles SET is_default = 0, updated_at = CURRENT_TIMESTAMP WHERE user_id = ? AND is_default = 1",
+            (user.id,),
+        )
+        await db.commit()
+    return {"status": "deleted"}
+
+
+@router.get("/api/presets/default", response_model=BundleExpandedResponse | None)
+async def get_default_bundle(user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT * FROM preset_bundles WHERE user_id = ? AND is_default = 1",
+            (user.id,),
+        )
+        bundle_row = await cursor.fetchone()
+        if not bundle_row:
+            return None
+
+        transcription_preset = None
+        if bundle_row["transcription_preset_id"]:
+            cursor = await db.execute(
+                "SELECT * FROM transcription_presets WHERE id = ?",
+                (bundle_row["transcription_preset_id"],),
+            )
+            tp_row = await cursor.fetchone()
+            if tp_row:
+                transcription_preset = _row_to_transcription_preset(tp_row)
+
+        analysis_preset = None
+        if bundle_row["analysis_preset_id"]:
+            cursor = await db.execute(
+                "SELECT * FROM analysis_presets WHERE id = ?",
+                (bundle_row["analysis_preset_id"],),
+            )
+            ap_row = await cursor.fetchone()
+            if ap_row:
+                analysis_preset = _row_to_analysis_preset(ap_row)
+
+        refinement_preset = None
+        if bundle_row["refinement_preset_id"]:
+            cursor = await db.execute(
+                "SELECT * FROM refinement_presets WHERE id = ?",
+                (bundle_row["refinement_preset_id"],),
+            )
+            rp_row = await cursor.fetchone()
+            if rp_row:
+                refinement_preset = _row_to_refinement_preset(rp_row)
+
+    return BundleExpandedResponse(
+        id=bundle_row["id"],
+        name=bundle_row["name"],
+        transcription_preset_id=bundle_row["transcription_preset_id"],
+        analysis_preset_id=bundle_row["analysis_preset_id"],
+        refinement_preset_id=bundle_row["refinement_preset_id"],
+        is_default=bool(bundle_row["is_default"]),
+        created_at=bundle_row["created_at"],
+        updated_at=bundle_row["updated_at"],
+        transcription_preset=transcription_preset,
+        analysis_preset=analysis_preset,
+        refinement_preset=refinement_preset,
+    )

--- a/backend/app/routers/presets.py
+++ b/backend/app/routers/presets.py
@@ -74,6 +74,7 @@ def _row_to_bundle(row) -> BundleResponse:
         transcription_preset_id=row["transcription_preset_id"],
         analysis_preset_id=row["analysis_preset_id"],
         refinement_preset_id=row["refinement_preset_id"],
+        translate_language=row["translate_language"],
         is_default=bool(row["is_default"]),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -341,10 +342,10 @@ async def create_bundle(body: BundleCreate, user: UserInfo = Depends(get_current
     async with get_db() as db:
         await db.execute(
             """INSERT INTO preset_bundles
-               (id, user_id, name, transcription_preset_id, analysis_preset_id, refinement_preset_id)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+               (id, user_id, name, transcription_preset_id, analysis_preset_id, refinement_preset_id, translate_language)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (bundle_id, user.id, body.name, body.transcription_preset_id,
-             body.analysis_preset_id, body.refinement_preset_id),
+             body.analysis_preset_id, body.refinement_preset_id, body.translate_language),
         )
         await db.commit()
         cursor = await db.execute("SELECT * FROM preset_bundles WHERE id = ?", (bundle_id,))
@@ -377,10 +378,10 @@ async def update_bundle(bundle_id: str, body: BundleCreate, user: UserInfo = Dep
         await db.execute(
             """UPDATE preset_bundles
                SET name = ?, transcription_preset_id = ?, analysis_preset_id = ?,
-                   refinement_preset_id = ?, updated_at = CURRENT_TIMESTAMP
+                   refinement_preset_id = ?, translate_language = ?, updated_at = CURRENT_TIMESTAMP
                WHERE id = ?""",
             (body.name, body.transcription_preset_id, body.analysis_preset_id,
-             body.refinement_preset_id, bundle_id),
+             body.refinement_preset_id, body.translate_language, bundle_id),
         )
         await db.commit()
         cursor = await db.execute("SELECT * FROM preset_bundles WHERE id = ?", (bundle_id,))
@@ -483,6 +484,7 @@ async def get_default_bundle(user: UserInfo = Depends(get_current_user)):
         transcription_preset_id=bundle_row["transcription_preset_id"],
         analysis_preset_id=bundle_row["analysis_preset_id"],
         refinement_preset_id=bundle_row["refinement_preset_id"],
+        translate_language=bundle_row["translate_language"],
         is_default=bool(bundle_row["is_default"]),
         created_at=bundle_row["created_at"],
         updated_at=bundle_row["updated_at"],

--- a/backend/tests/test_presets.py
+++ b/backend/tests/test_presets.py
@@ -1,0 +1,145 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from app.main import app
+from app.database import init_db, get_db
+
+DEV_HEADERS = {"X-Auth-Request-User": "test-user", "X-Auth-Request-Email": "test@test.com"}
+
+TEST_USERS = ["test-user", "user-a", "user-b"]
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    await init_db(db_path)
+    # Pre-insert users to satisfy the FK constraint on user_id columns
+    async with get_db() as db:
+        for user_id in TEST_USERS:
+            await db.execute(
+                "INSERT OR IGNORE INTO users (id, email) VALUES (?, ?)",
+                (user_id, f"{user_id}@test.com"),
+            )
+        await db.commit()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_transcription_preset_crud(client):
+    # Create
+    resp = await client.post("/api/presets/transcription", json={"name": "Lecture DE", "language": "de", "model": "large-v3"}, headers=DEV_HEADERS)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Lecture DE"
+    assert data["language"] == "de"
+    preset_id = data["id"]
+
+    # List
+    resp = await client.get("/api/presets/transcription", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # Update
+    resp = await client.put(f"/api/presets/transcription/{preset_id}", json={"name": "Lecture DE v2", "language": "de", "model": "large-v3-turbo"}, headers=DEV_HEADERS)
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Lecture DE v2"
+
+    # Delete
+    resp = await client.delete(f"/api/presets/transcription/{preset_id}", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+
+    # Verify deleted
+    resp = await client.get("/api/presets/transcription", headers=DEV_HEADERS)
+    assert len(resp.json()) == 0
+
+
+@pytest.mark.asyncio
+async def test_analysis_preset_crud(client):
+    resp = await client.post("/api/presets/analysis", json={"name": "Summary EN", "template": "summary", "language": "en"}, headers=DEV_HEADERS)
+    assert resp.status_code == 201
+    preset_id = resp.json()["id"]
+
+    resp = await client.get("/api/presets/analysis", headers=DEV_HEADERS)
+    assert len(resp.json()) == 1
+
+    resp = await client.delete(f"/api/presets/analysis/{preset_id}", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_refinement_preset_crud(client):
+    resp = await client.post("/api/presets/refinement", json={"name": "CS Lecture", "context": "Computer science lecture"}, headers=DEV_HEADERS)
+    assert resp.status_code == 201
+    preset_id = resp.json()["id"]
+
+    resp = await client.get("/api/presets/refinement", headers=DEV_HEADERS)
+    assert len(resp.json()) == 1
+
+    resp = await client.delete(f"/api/presets/refinement/{preset_id}", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_bundle_crud_and_default(client):
+    # Create a transcription preset first
+    resp = await client.post("/api/presets/transcription", json={"name": "T1"}, headers=DEV_HEADERS)
+    t_id = resp.json()["id"]
+
+    # Create bundle
+    resp = await client.post("/api/presets/bundles", json={"name": "My Workflow", "transcription_preset_id": t_id}, headers=DEV_HEADERS)
+    assert resp.status_code == 201
+    bundle_id = resp.json()["id"]
+    assert resp.json()["is_default"] is False
+
+    # Set default
+    resp = await client.put(f"/api/presets/bundles/{bundle_id}/default", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+
+    # Get default (expanded)
+    resp = await client.get("/api/presets/default", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_default"] is True
+    assert data["transcription_preset"]["name"] == "T1"
+
+    # Clear default
+    resp = await client.delete("/api/presets/default", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/presets/default", headers=DEV_HEADERS)
+    assert resp.json() is None
+
+    # Delete bundle
+    resp = await client.delete(f"/api/presets/bundles/{bundle_id}", headers=DEV_HEADERS)
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_preset_nullifies_bundle_reference(client):
+    # Create preset and bundle referencing it
+    resp = await client.post("/api/presets/transcription", json={"name": "T1"}, headers=DEV_HEADERS)
+    t_id = resp.json()["id"]
+    resp = await client.post("/api/presets/bundles", json={"name": "Bundle", "transcription_preset_id": t_id}, headers=DEV_HEADERS)
+    bundle_id = resp.json()["id"]
+
+    # Delete the preset
+    await client.delete(f"/api/presets/transcription/{t_id}", headers=DEV_HEADERS)
+
+    # Bundle should still exist but with null reference
+    resp = await client.get("/api/presets/bundles", headers=DEV_HEADERS)
+    bundles = resp.json()
+    assert len(bundles) == 1
+    assert bundles[0]["transcription_preset_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_user_isolation(client):
+    # Create preset as user A
+    resp = await client.post("/api/presets/transcription", json={"name": "A preset"}, headers={"X-Auth-Request-User": "user-a"})
+    assert resp.status_code == 201
+
+    # User B should not see it
+    resp = await client.get("/api/presets/transcription", headers={"X-Auth-Request-User": "user-b"})
+    assert len(resp.json()) == 0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -193,12 +193,16 @@ function App() {
   const setRefinementMetadata = useStore((s) => s.setRefinementMetadata)
   const setActiveView = useStore((s) => s.setActiveView)
   const addAnalysis = useStore((s) => s.addAnalysis)
-  const [autoPipelineRan, setAutoPipelineRan] = useState(false)
+  const setTranslatedUtterances = useStore((s) => s.setTranslatedUtterances)
+  const setTranslationLanguage = useStore((s) => s.setTranslationLanguage)
+  const autoPipelineRanRef = useRef(false)
+  const [pipelineStatus, setPipelineStatus] = useState<{ key: string; step: 'refine' | 'analyze' | 'translate'; params?: Record<string, string> } | null>(null)
 
   // Reset auto-pipeline flag when a new transcription starts
   useEffect(() => {
     if (transcriptionStatus && transcriptionStatus !== 'completed') {
-      setAutoPipelineRan(false)
+      autoPipelineRanRef.current = false
+      setPipelineStatus(null)
     }
   }, [transcriptionStatus])
 
@@ -215,7 +219,7 @@ function App() {
 
   // Auto-run refinement & analysis when transcription completes with an active bundle
   useEffect(() => {
-    if (transcriptionStatus !== 'completed' || !transcriptionResult || autoPipelineRan) return
+    if (transcriptionStatus !== 'completed' || !transcriptionResult || autoPipelineRanRef.current) return
     const bundleId = useStore.getState().activeBundleId
     if (!bundleId) return
     const bundles = useStore.getState().bundles
@@ -229,13 +233,14 @@ function App() {
     const analysisPresets = useStore.getState().analysisPresets
     const hasRefinement = bundle.refinement_preset_id && refinementPresets.find((p) => p.id === bundle.refinement_preset_id)
     const hasAnalysis = bundle.analysis_preset_id && analysisPresets.find((p) => p.id === bundle.analysis_preset_id)
+    const hasTranslation = bundle.translate_language
 
-    if (!hasRefinement && !hasAnalysis) return
-    setAutoPipelineRan(true)
+    if (!hasRefinement && !hasAnalysis && !hasTranslation) return
+    autoPipelineRanRef.current = true
 
     const run = async () => {
-      // Refinement first (if linked)
       if (hasRefinement) {
+        setPipelineStatus({ key: 'editor.refining', step: 'refine' })
         try {
           const result = await api.generateRefinement(transcriptionId, hasRefinement.context || undefined)
           setRefinedUtterances(result.utterances)
@@ -246,8 +251,8 @@ function App() {
         }
       }
 
-      // Then analysis (if linked)
       if (hasAnalysis) {
+        setPipelineStatus({ key: 'analysis.generating', step: 'analyze' })
         try {
           const result = await api.generateAnalysis(transcriptionId, {
             template: hasAnalysis.template,
@@ -269,10 +274,21 @@ function App() {
           console.error('Auto-analysis failed:', e)
         }
       }
+      if (hasTranslation) {
+        setPipelineStatus({ key: 'pipeline.translating', step: 'translate', params: { language: t(`languages.${hasTranslation}`) } })
+        try {
+          const result = await api.translateTranscription(transcriptionId, hasTranslation)
+          setTranslatedUtterances(result.utterances)
+          setTranslationLanguage(result.language)
+        } catch (e) {
+          console.error('Auto-translation failed:', e)
+        }
+      }
+      setPipelineStatus(null)
     }
 
     run()
-  }, [transcriptionStatus, transcriptionResult, autoPipelineRan, setRefinedUtterances, setRefinementMetadata, setActiveView, addAnalysis])
+  }, [transcriptionStatus, transcriptionResult, setRefinedUtterances, setRefinementMetadata, setActiveView, addAnalysis, setTranslatedUtterances, setTranslationLanguage])
 
   if (!config) return <div className="min-h-screen bg-gray-900 flex items-center justify-center text-gray-400">{t('common.loading')}</div>
 
@@ -324,6 +340,24 @@ function App() {
           )}
           <DetailActions />
           <ProgressBar />
+          {pipelineStatus && (
+            <div className={`mx-6 my-2 px-4 py-2 rounded-lg flex items-center gap-3 ${
+              pipelineStatus.step === 'refine' ? 'bg-amber-900/30 border border-amber-700/50' :
+              pipelineStatus.step === 'translate' ? 'bg-purple-900/30 border border-purple-700/50' :
+              'bg-blue-900/30 border border-blue-700/50'
+            }`}>
+              <div className={`animate-spin h-4 w-4 border-2 border-t-transparent rounded-full shrink-0 ${
+                pipelineStatus.step === 'refine' ? 'border-amber-400' :
+                pipelineStatus.step === 'translate' ? 'border-purple-400' :
+                'border-blue-400'
+              }`} />
+              <span className={`text-sm ${
+                pipelineStatus.step === 'refine' ? 'text-amber-200' :
+                pipelineStatus.step === 'translate' ? 'text-purple-200' :
+                'text-blue-200'
+              }`}>{t(pipelineStatus.key, pipelineStatus.params)}</span>
+            </div>
+          )}
           {showEditor && file && (
             <>
               <MediaPlayer

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { TabBar } from './components/TabBar'
 import { AnalysisView } from './components/AnalysisView'
 import { useStore, setPopStateFlag } from './store'
 import { api } from './api/client'
+import { PresetsPage } from './components/PresetsPage/PresetsPage'
 
 function BackButton() {
   const { t } = useTranslation()
@@ -141,9 +142,28 @@ function App() {
     setSpeakerModalOpen(true)
   }
 
+  const setTranscriptionPresets = useStore((s) => s.setTranscriptionPresets)
+  const setAnalysisPresets = useStore((s) => s.setAnalysisPresets)
+  const setRefinementPresets = useStore((s) => s.setRefinementPresets)
+  const setBundles = useStore((s) => s.setBundles)
+  const setActiveBundleId = useStore((s) => s.setActiveBundleId)
+
   useEffect(() => {
     api.getConfig().then(setConfig).catch(console.error)
-  }, [setConfig])
+    Promise.all([
+      api.getTranscriptionPresets(),
+      api.getAnalysisPresets(),
+      api.getRefinementPresets(),
+      api.getBundles(),
+      api.getDefaultBundle(),
+    ]).then(([tp, ap, rp, bundles, defaultBundle]) => {
+      setTranscriptionPresets(tp)
+      setAnalysisPresets(ap)
+      setRefinementPresets(rp)
+      setBundles(bundles)
+      if (defaultBundle) setActiveBundleId(defaultBundle.id)
+    }).catch(console.error)
+  }, [setConfig, setTranscriptionPresets, setAnalysisPresets, setRefinementPresets, setBundles, setActiveBundleId])
 
   // Track whether current navigation was triggered by browser back/forward
   const isPopStateNav = useRef(false)
@@ -190,6 +210,13 @@ function App() {
 
       {currentView === 'archive' && (
         <TranscriptionList />
+      )}
+
+      {currentView === 'presets' && (
+        <>
+          <BackButton />
+          <PresetsPage />
+        </>
       )}
 
       {currentView === 'upload' && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -189,6 +189,19 @@ function App() {
     }
   }, [currentView, file, t])
 
+  const setRefinedUtterances = useStore((s) => s.setRefinedUtterances)
+  const setRefinementMetadata = useStore((s) => s.setRefinementMetadata)
+  const setActiveView = useStore((s) => s.setActiveView)
+  const addAnalysis = useStore((s) => s.addAnalysis)
+  const [autoPipelineRan, setAutoPipelineRan] = useState(false)
+
+  // Reset auto-pipeline flag when a new transcription starts
+  useEffect(() => {
+    if (transcriptionStatus && transcriptionStatus !== 'completed') {
+      setAutoPipelineRan(false)
+    }
+  }, [transcriptionStatus])
+
   // Auto-navigate to detail view when transcription completes
   useEffect(() => {
     if (isPopStateNav.current) {
@@ -199,6 +212,67 @@ function App() {
       setCurrentView('detail')
     }
   }, [transcriptionStatus, transcriptionResult, currentView, setCurrentView])
+
+  // Auto-run refinement & analysis when transcription completes with an active bundle
+  useEffect(() => {
+    if (transcriptionStatus !== 'completed' || !transcriptionResult || autoPipelineRan) return
+    const bundleId = useStore.getState().activeBundleId
+    if (!bundleId) return
+    const bundles = useStore.getState().bundles
+    const bundle = bundles.find((b) => b.id === bundleId)
+    if (!bundle) return
+
+    const transcriptionId = useStore.getState().transcriptionId
+    if (!transcriptionId) return
+
+    const refinementPresets = useStore.getState().refinementPresets
+    const analysisPresets = useStore.getState().analysisPresets
+    const hasRefinement = bundle.refinement_preset_id && refinementPresets.find((p) => p.id === bundle.refinement_preset_id)
+    const hasAnalysis = bundle.analysis_preset_id && analysisPresets.find((p) => p.id === bundle.analysis_preset_id)
+
+    if (!hasRefinement && !hasAnalysis) return
+    setAutoPipelineRan(true)
+
+    const run = async () => {
+      // Refinement first (if linked)
+      if (hasRefinement) {
+        try {
+          const result = await api.generateRefinement(transcriptionId, hasRefinement.context || undefined)
+          setRefinedUtterances(result.utterances)
+          setRefinementMetadata(result.metadata)
+          setActiveView('refined')
+        } catch (e) {
+          console.error('Auto-refinement failed:', e)
+        }
+      }
+
+      // Then analysis (if linked)
+      if (hasAnalysis) {
+        try {
+          const result = await api.generateAnalysis(transcriptionId, {
+            template: hasAnalysis.template,
+            custom_prompt: hasAnalysis.custom_prompt,
+            language: hasAnalysis.language,
+            chapter_hints: hasAnalysis.chapter_hints,
+            agenda: hasAnalysis.agenda,
+          })
+          const analysisResult = result as { id: string; template?: string; language?: string; llm_provider?: string; llm_model?: string; created_at?: string }
+          addAnalysis({
+            id: analysisResult.id,
+            template: analysisResult.template || null,
+            language: analysisResult.language || null,
+            llm_provider: analysisResult.llm_provider || null,
+            llm_model: analysisResult.llm_model || null,
+            created_at: analysisResult.created_at || null,
+          })
+        } catch (e) {
+          console.error('Auto-analysis failed:', e)
+        }
+      }
+    }
+
+    run()
+  }, [transcriptionStatus, transcriptionResult, autoPipelineRan, setRefinedUtterances, setRefinementMetadata, setActiveView, addAnalysis])
 
   if (!config) return <div className="min-h-screen bg-gray-900 flex items-center justify-center text-gray-400">{t('common.loading')}</div>
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,10 @@ import type {
   TranscriptionResult, TranscriptionListItem, ConfigResponse,
   RefinementResult,
   AnalysisTemplate, AnalysisGenerateRequest, AnalysisListItem, Utterance,
+  TranscriptionPreset, TranscriptionPresetCreate,
+  AnalysisPreset, AnalysisPresetCreate,
+  RefinementPreset, RefinementPresetCreate,
+  PresetBundle, PresetBundleCreate, PresetBundleExpanded,
 } from './types'
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '')
@@ -153,4 +157,43 @@ export const api = {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     return new WebSocket(`${protocol}//${window.location.host}${BASE}/api/ws/status/${transcriptionId}`)
   },
+
+  // --- Presets ---
+
+  getTranscriptionPresets: () => request<TranscriptionPreset[]>('/api/presets/transcription'),
+  createTranscriptionPreset: (data: TranscriptionPresetCreate) =>
+    request<TranscriptionPreset>('/api/presets/transcription', { method: 'POST', body: JSON.stringify(data) }),
+  updateTranscriptionPreset: (id: string, data: TranscriptionPresetCreate) =>
+    request<TranscriptionPreset>(`/api/presets/transcription/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deleteTranscriptionPreset: (id: string) =>
+    request<{ status: string }>(`/api/presets/transcription/${id}`, { method: 'DELETE' }),
+
+  getAnalysisPresets: () => request<AnalysisPreset[]>('/api/presets/analysis'),
+  createAnalysisPreset: (data: AnalysisPresetCreate) =>
+    request<AnalysisPreset>('/api/presets/analysis', { method: 'POST', body: JSON.stringify(data) }),
+  updateAnalysisPreset: (id: string, data: AnalysisPresetCreate) =>
+    request<AnalysisPreset>(`/api/presets/analysis/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deleteAnalysisPreset: (id: string) =>
+    request<{ status: string }>(`/api/presets/analysis/${id}`, { method: 'DELETE' }),
+
+  getRefinementPresets: () => request<RefinementPreset[]>('/api/presets/refinement'),
+  createRefinementPreset: (data: RefinementPresetCreate) =>
+    request<RefinementPreset>('/api/presets/refinement', { method: 'POST', body: JSON.stringify(data) }),
+  updateRefinementPreset: (id: string, data: RefinementPresetCreate) =>
+    request<RefinementPreset>(`/api/presets/refinement/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deleteRefinementPreset: (id: string) =>
+    request<{ status: string }>(`/api/presets/refinement/${id}`, { method: 'DELETE' }),
+
+  getBundles: () => request<PresetBundle[]>('/api/presets/bundles'),
+  createBundle: (data: PresetBundleCreate) =>
+    request<PresetBundle>('/api/presets/bundles', { method: 'POST', body: JSON.stringify(data) }),
+  updateBundle: (id: string, data: PresetBundleCreate) =>
+    request<PresetBundle>(`/api/presets/bundles/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deleteBundle: (id: string) =>
+    request<{ status: string }>(`/api/presets/bundles/${id}`, { method: 'DELETE' }),
+  setDefaultBundle: (id: string) =>
+    request<{ status: string }>(`/api/presets/bundles/${id}/default`, { method: 'PUT' }),
+  clearDefaultBundle: () =>
+    request<{ status: string }>('/api/presets/default', { method: 'DELETE' }),
+  getDefaultBundle: () => request<PresetBundleExpanded | null>('/api/presets/default'),
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -223,6 +223,7 @@ export interface PresetBundle {
   transcription_preset_id: string | null
   analysis_preset_id: string | null
   refinement_preset_id: string | null
+  translate_language: string | null
   is_default: boolean
   created_at: string | null
   updated_at: string | null
@@ -233,6 +234,7 @@ export interface PresetBundleCreate {
   transcription_preset_id?: string | null
   analysis_preset_id?: string | null
   refinement_preset_id?: string | null
+  translate_language?: string | null
 }
 
 export interface PresetBundleExpanded extends PresetBundle {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -157,3 +157,86 @@ export interface ErrorResponse {
   error: string
   detail: string
 }
+
+// --- Presets ---
+
+export interface TranscriptionPreset {
+  id: string
+  name: string
+  language: string | null
+  model: string
+  min_speakers: number
+  max_speakers: number
+  initial_prompt: string | null
+  hotwords: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface TranscriptionPresetCreate {
+  name: string
+  language?: string | null
+  model?: string
+  min_speakers?: number
+  max_speakers?: number
+  initial_prompt?: string | null
+  hotwords?: string | null
+}
+
+export interface AnalysisPreset {
+  id: string
+  name: string
+  template: string | null
+  custom_prompt: string | null
+  language: string | null
+  chapter_hints: ChapterHint[] | null
+  agenda: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface AnalysisPresetCreate {
+  name: string
+  template?: string | null
+  custom_prompt?: string | null
+  language?: string | null
+  chapter_hints?: ChapterHint[] | null
+  agenda?: string | null
+}
+
+export interface RefinementPreset {
+  id: string
+  name: string
+  context: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface RefinementPresetCreate {
+  name: string
+  context?: string | null
+}
+
+export interface PresetBundle {
+  id: string
+  name: string
+  transcription_preset_id: string | null
+  analysis_preset_id: string | null
+  refinement_preset_id: string | null
+  is_default: boolean
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface PresetBundleCreate {
+  name: string
+  transcription_preset_id?: string | null
+  analysis_preset_id?: string | null
+  refinement_preset_id?: string | null
+}
+
+export interface PresetBundleExpanded extends PresetBundle {
+  transcription_preset: TranscriptionPreset | null
+  analysis_preset: AnalysisPreset | null
+  refinement_preset: RefinementPreset | null
+}

--- a/frontend/src/components/AnalysisView/AnalysisView.tsx
+++ b/frontend/src/components/AnalysisView/AnalysisView.tsx
@@ -6,6 +6,7 @@ import { ChapterCard } from '../SummaryView/ChapterCard'
 import { ProtocolCard } from '../ProtocolView/ProtocolCard'
 import { formatTime, downloadText, downloadMarkdown } from '../../utils/format'
 import { LanguageSelect } from '../LanguageSelect'
+import { PresetSelect } from '../PresetSelect/PresetSelect'
 import type { AnalysisTemplate, ChapterHint, SummaryChapter } from '../../api/types'
 
 // Type guards for smart result detection
@@ -361,6 +362,12 @@ export function AnalysisView() {
   const file = useStore((s) => s.file)
   const detectedLanguage = useStore((s) => s.transcriptionResult?.language)
 
+  const analysisPresets = useStore((s) => s.analysisPresets)
+  const setAnalysisPresets = useStore((s) => s.setAnalysisPresets)
+  const bundles = useStore((s) => s.bundles)
+  const activeBundleId = useStore((s) => s.activeBundleId)
+
+  const [selectedAnalysisPresetId, setSelectedAnalysisPresetId] = useState<string | null>(null)
   const [templates, setTemplates] = useState<AnalysisTemplate[]>([])
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null)
   const [customPrompt, setCustomPrompt] = useState('')
@@ -411,6 +418,38 @@ export function AnalysisView() {
       if (tpl) setCustomPrompt(tpl.default_prompt)
     }
   }, [templates])
+
+  const handleLoadAnalysisPreset = useCallback((presetId: string | null) => {
+    setSelectedAnalysisPresetId(presetId)
+    if (!presetId) return
+    const preset = analysisPresets.find((p) => p.id === presetId)
+    if (!preset) return
+    setSelectedTemplate(preset.template)
+    setCustomPrompt(preset.custom_prompt || '')
+    setLanguage(preset.language || 'en')
+    setHints(preset.chapter_hints || [])
+    setAgenda(preset.agenda || '')
+  }, [analysisPresets])
+
+  const handleSaveAnalysisPreset = async (name: string) => {
+    const preset = await api.createAnalysisPreset({
+      name,
+      template: selectedTemplate,
+      custom_prompt: customPrompt || null,
+      language,
+      chapter_hints: hints.length > 0 ? hints : null,
+      agenda: agenda || null,
+    })
+    setAnalysisPresets([...analysisPresets, preset])
+    setSelectedAnalysisPresetId(preset.id)
+  }
+
+  useEffect(() => {
+    if (!activeBundleId) return
+    const bundle = bundles.find((b) => b.id === activeBundleId)
+    if (!bundle?.analysis_preset_id) return
+    handleLoadAnalysisPreset(bundle.analysis_preset_id)
+  }, [activeBundleId, bundles, handleLoadAnalysisPreset])
 
   const handleResetPrompt = useCallback(() => {
     if (selectedTemplate) {
@@ -542,6 +581,17 @@ export function AnalysisView() {
               </button>
             </div>
           )}
+
+          {/* Preset selector */}
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.analysis')}</label>
+            <PresetSelect
+              presets={analysisPresets}
+              selectedId={selectedAnalysisPresetId}
+              onSelect={handleLoadAnalysisPreset}
+              onSave={handleSaveAnalysisPreset}
+            />
+          </div>
 
           {/* Template selector */}
           <div>

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -206,7 +206,9 @@ export function SettingsPanel() {
               ? t('transcription.transcribeWhenReady')
               : uploading && !file
                 ? t('transcription.transcribeWhenReady')
-                : t('transcription.transcribe')}
+                : activeBundleId && bundles.find((b) => b.id === activeBundleId && (b.analysis_preset_id || b.refinement_preset_id || b.translate_language))
+                  ? t('transcription.runPipeline')
+                  : t('transcription.transcribe')}
         </button>
       </div>
       {error && (

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useStore } from '../../store'
 import { api } from '../../api/client'
 import { LanguageSelect } from '../LanguageSelect'
+import { PresetSelect } from '../PresetSelect/PresetSelect'
 
 export function SettingsPanel() {
   const { t } = useTranslation()
@@ -11,7 +12,13 @@ export function SettingsPanel() {
   const uploading = useStore((s) => s.uploading)
   const setTranscriptionId = useStore((s) => s.setTranscriptionId)
   const setTranscriptionStatus = useStore((s) => s.setTranscriptionStatus)
+  const transcriptionPresets = useStore((s) => s.transcriptionPresets)
+  const setTranscriptionPresets = useStore((s) => s.setTranscriptionPresets)
+  const bundles = useStore((s) => s.bundles)
+  const activeBundleId = useStore((s) => s.activeBundleId)
+  const setActiveBundleId = useStore((s) => s.setActiveBundleId)
 
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null)
   const [language, setLanguage] = useState<string>('auto')
   const [model, setModel] = useState(config?.default_model || 'base')
   const [detectSpeakers, setDetectSpeakers] = useState(true)
@@ -23,6 +30,44 @@ export function SettingsPanel() {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [pendingTranscription, setPendingTranscription] = useState(false)
+
+  const handleLoadPreset = (presetId: string | null) => {
+    setSelectedPresetId(presetId)
+    if (!presetId) return
+    const preset = transcriptionPresets.find((p) => p.id === presetId)
+    if (!preset) return
+    setLanguage(preset.language || 'auto')
+    setModel(preset.model)
+    setDetectSpeakers(preset.min_speakers > 0 || preset.max_speakers > 0)
+    setMinSpeakers(preset.min_speakers || 1)
+    setMaxSpeakers(preset.max_speakers || 2)
+    setInitialPrompt(preset.initial_prompt || '')
+    setHotwords(preset.hotwords || '')
+  }
+
+  const handleSavePreset = async (name: string) => {
+    const preset = await api.createTranscriptionPreset({
+      name,
+      language: language === 'auto' ? null : language,
+      model,
+      min_speakers: detectSpeakers ? minSpeakers : 0,
+      max_speakers: detectSpeakers ? maxSpeakers : 0,
+      initial_prompt: initialPrompt || null,
+      hotwords: hotwords || null,
+    })
+    setTranscriptionPresets([...transcriptionPresets, preset])
+    setSelectedPresetId(preset.id)
+  }
+
+  const handleLoadBundle = (bundleId: string | null) => {
+    setActiveBundleId(bundleId)
+    if (!bundleId) return
+    const bundle = bundles.find((b) => b.id === bundleId)
+    if (!bundle) return
+    if (bundle.transcription_preset_id) {
+      handleLoadPreset(bundle.transcription_preset_id)
+    }
+  }
 
   const handleTranscribe = useCallback(async () => {
     if (!file && uploading) {
@@ -67,6 +112,46 @@ export function SettingsPanel() {
 
   return (
     <div className="px-6 py-3 bg-gray-800 border-b border-gray-700 space-y-3">
+      {(transcriptionPresets.length > 0 || bundles.length > 0) && (
+        <div className="flex flex-wrap gap-4 items-center mb-2">
+          {bundles.length > 0 && (
+            <div className="min-w-0">
+              <label className="block text-xs text-gray-400 mb-1">{t('presets.bundles')}</label>
+              <select
+                value={activeBundleId || ''}
+                onChange={(e) => handleLoadBundle(e.target.value || null)}
+                className="bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+              >
+                <option value="">{t('presets.selectBundle')}</option>
+                {bundles.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.name}{b.is_default ? ` (${t('presets.bundle.isDefault')})` : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div className="min-w-0">
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.transcription')}</label>
+            <PresetSelect
+              presets={transcriptionPresets}
+              selectedId={selectedPresetId}
+              onSelect={handleLoadPreset}
+              onSave={handleSavePreset}
+            />
+          </div>
+        </div>
+      )}
+      {transcriptionPresets.length === 0 && bundles.length === 0 && (
+        <div className="flex justify-end mb-1">
+          <PresetSelect
+            presets={[]}
+            selectedId={null}
+            onSelect={() => {}}
+            onSave={handleSavePreset}
+          />
+        </div>
+      )}
       <div className="flex flex-wrap gap-4 items-end">
         <div className="min-w-0">
           <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -17,6 +17,12 @@ export function Header() {
       </div>
       <div className="flex flex-wrap items-center gap-4">
         <button
+          onClick={() => useStore.getState().setCurrentView('presets')}
+          className="text-sm text-gray-300 hover:text-white"
+        >
+          {t('nav.presets')}
+        </button>
+        <button
           onClick={toggleLanguage}
           className="text-sm text-gray-300 hover:text-white"
           title={i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}

--- a/frontend/src/components/PresetSelect/PresetSelect.tsx
+++ b/frontend/src/components/PresetSelect/PresetSelect.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface PresetItem {
+  id: string
+  name: string
+}
+
+interface PresetSelectProps {
+  presets: PresetItem[]
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+  onSave: (name: string) => void
+  placeholder?: string
+}
+
+export function PresetSelect({ presets, selectedId, onSelect, onSave, placeholder }: PresetSelectProps) {
+  const { t } = useTranslation()
+  const [showSave, setShowSave] = useState(false)
+  const [saveName, setSaveName] = useState('')
+
+  const handleSave = () => {
+    const trimmed = saveName.trim()
+    if (!trimmed) return
+    onSave(trimmed)
+    setSaveName('')
+    setShowSave(false)
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        value={selectedId || ''}
+        onChange={(e) => onSelect(e.target.value || null)}
+        className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 min-w-[140px]"
+      >
+        <option value="">{placeholder || t('presets.selectPreset')}</option>
+        {presets.map((p) => (
+          <option key={p.id} value={p.id}>{p.name}</option>
+        ))}
+      </select>
+
+      {showSave ? (
+        <div className="flex items-center gap-1">
+          <input
+            type="text"
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); if (e.key === 'Escape') setShowSave(false) }}
+            placeholder={t('presets.namePlaceholder')}
+            className="bg-gray-700 text-white text-sm rounded px-2 py-1 w-36"
+            autoFocus
+          />
+          <button onClick={handleSave} className="text-green-400 hover:text-green-300 text-sm px-1">
+            ✓
+          </button>
+          <button onClick={() => setShowSave(false)} className="text-gray-400 hover:text-gray-300 text-sm px-1">
+            ✕
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setShowSave(true)}
+          className="text-xs text-blue-400 hover:text-blue-300 whitespace-nowrap"
+        >
+          {t('presets.saveAs')}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -1,0 +1,760 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useStore } from '../../store'
+import { api } from '../../api/client'
+import type {
+  TranscriptionPreset,
+  TranscriptionPresetCreate,
+  AnalysisPreset,
+  AnalysisPresetCreate,
+  RefinementPreset,
+  RefinementPresetCreate,
+  PresetBundle,
+  PresetBundleCreate,
+} from '../../api/types'
+
+// ---------------------------------------------------------------------------
+// TranscriptionPresetsList
+// ---------------------------------------------------------------------------
+
+function TranscriptionPresetsList() {
+  const { t } = useTranslation()
+  const config = useStore((s) => s.config)
+  const presets = useStore((s) => s.transcriptionPresets)
+  const setPresets = useStore((s) => s.setTranscriptionPresets)
+
+  const emptyForm: TranscriptionPresetCreate = { name: '', language: null, model: '', initial_prompt: null, hotwords: null }
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState<TranscriptionPresetCreate>(emptyForm)
+  const [saving, setSaving] = useState(false)
+
+  const models = config?.whisper_models ?? []
+  const defaultModel = config?.default_model ?? ''
+
+  const openNew = () => {
+    setEditingId(null)
+    setForm({ ...emptyForm, model: defaultModel })
+    setShowForm(true)
+  }
+
+  const openEdit = (p: TranscriptionPreset) => {
+    setEditingId(p.id)
+    setForm({ name: p.name, language: p.language, model: p.model, initial_prompt: p.initial_prompt, hotwords: p.hotwords })
+    setShowForm(true)
+  }
+
+  const handleCancel = () => {
+    setShowForm(false)
+    setEditingId(null)
+    setForm(emptyForm)
+  }
+
+  const handleSave = async () => {
+    if (!form.name.trim()) return
+    setSaving(true)
+    try {
+      if (editingId) {
+        const updated = await api.updateTranscriptionPreset(editingId, form)
+        setPresets(presets.map((p) => (p.id === editingId ? updated : p)))
+      } else {
+        const created = await api.createTranscriptionPreset(form)
+        setPresets([...presets, created])
+      }
+      handleCancel()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm(t('presets.confirmDelete'))) return
+    try {
+      await api.deleteTranscriptionPreset(id)
+      setPresets(presets.filter((p) => p.id !== id))
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {presets.length === 0 && !showForm && (
+        <p className="text-gray-500 text-sm">{t('presets.noPresets')}</p>
+      )}
+
+      {presets.map((p) => (
+        <div key={p.id} className="bg-gray-800 rounded-lg p-4 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="font-medium text-white truncate">{p.name}</p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              {p.model}{p.language ? ` · ${p.language}` : ''}{p.hotwords ? ` · ${p.hotwords}` : ''}
+            </p>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button onClick={() => openEdit(p)} className="text-sm text-blue-400 hover:text-blue-300">
+              {t('presets.edit')}
+            </button>
+            <button onClick={() => handleDelete(p.id)} className="text-sm text-red-400 hover:text-red-300">
+              {t('presets.delete')}
+            </button>
+          </div>
+        </div>
+      ))}
+
+      {showForm && (
+        <div className="bg-gray-800 rounded-lg p-4 space-y-3">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.name')}</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder={t('presets.namePlaceholder')}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
+            <input
+              type="text"
+              value={form.language ?? ''}
+              onChange={(e) => setForm({ ...form, language: e.target.value || null })}
+              placeholder="en, de, fr…"
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
+            <select
+              value={form.model ?? defaultModel}
+              onChange={(e) => setForm({ ...form, model: e.target.value })}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              {models.map((m) => (
+                <option key={m} value={m}>{t(`settings.modelLabels.${m}`, { defaultValue: m })}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('settings.hotwords')}</label>
+            <input
+              type="text"
+              value={form.hotwords ?? ''}
+              onChange={(e) => setForm({ ...form, hotwords: e.target.value || null })}
+              placeholder={t('settings.hotwordsHelp')}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('settings.initialPrompt')}</label>
+            <textarea
+              value={form.initial_prompt ?? ''}
+              onChange={(e) => setForm({ ...form, initial_prompt: e.target.value || null })}
+              placeholder={t('settings.initialPromptHelp')}
+              rows={2}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+            />
+          </div>
+          <div className="flex gap-2 justify-end">
+            <button onClick={handleCancel} className="text-sm text-gray-400 hover:text-white px-3 py-1.5">
+              {t('common.cancel')}
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving || !form.name.trim()}
+              className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
+            >
+              {saving ? '…' : t('presets.saved')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!showForm && (
+        <button
+          onClick={openNew}
+          className="text-sm text-blue-400 hover:text-blue-300"
+        >
+          + {t('presets.create')}
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// AnalysisPresetsList
+// ---------------------------------------------------------------------------
+
+const ANALYSIS_TEMPLATES = ['summary', 'protocol', 'agenda', 'custom'] as const
+
+function AnalysisPresetsList() {
+  const { t } = useTranslation()
+  const presets = useStore((s) => s.analysisPresets)
+  const setPresets = useStore((s) => s.setAnalysisPresets)
+
+  const emptyForm: AnalysisPresetCreate = { name: '', template: 'summary', custom_prompt: null, language: null }
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState<AnalysisPresetCreate>(emptyForm)
+  const [saving, setSaving] = useState(false)
+
+  const openNew = () => {
+    setEditingId(null)
+    setForm(emptyForm)
+    setShowForm(true)
+  }
+
+  const openEdit = (p: AnalysisPreset) => {
+    setEditingId(p.id)
+    setForm({ name: p.name, template: p.template, custom_prompt: p.custom_prompt, language: p.language })
+    setShowForm(true)
+  }
+
+  const handleCancel = () => {
+    setShowForm(false)
+    setEditingId(null)
+    setForm(emptyForm)
+  }
+
+  const handleSave = async () => {
+    if (!form.name.trim()) return
+    setSaving(true)
+    try {
+      if (editingId) {
+        const updated = await api.updateAnalysisPreset(editingId, form)
+        setPresets(presets.map((p) => (p.id === editingId ? updated : p)))
+      } else {
+        const created = await api.createAnalysisPreset(form)
+        setPresets([...presets, created])
+      }
+      handleCancel()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm(t('presets.confirmDelete'))) return
+    try {
+      await api.deleteAnalysisPreset(id)
+      setPresets(presets.filter((p) => p.id !== id))
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const templateLabel = (tmpl: string | null) => {
+    if (!tmpl) return t('analysis.customPrompt')
+    if (tmpl === 'summary') return t('analysis.templateSummary')
+    if (tmpl === 'protocol') return t('analysis.templateProtocol')
+    if (tmpl === 'agenda') return t('analysis.templateAgenda')
+    return tmpl
+  }
+
+  return (
+    <div className="space-y-3">
+      {presets.length === 0 && !showForm && (
+        <p className="text-gray-500 text-sm">{t('presets.noPresets')}</p>
+      )}
+
+      {presets.map((p) => (
+        <div key={p.id} className="bg-gray-800 rounded-lg p-4 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="font-medium text-white truncate">{p.name}</p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              {templateLabel(p.template)}{p.language ? ` · ${p.language}` : ''}
+            </p>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button onClick={() => openEdit(p)} className="text-sm text-blue-400 hover:text-blue-300">
+              {t('presets.edit')}
+            </button>
+            <button onClick={() => handleDelete(p.id)} className="text-sm text-red-400 hover:text-red-300">
+              {t('presets.delete')}
+            </button>
+          </div>
+        </div>
+      ))}
+
+      {showForm && (
+        <div className="bg-gray-800 rounded-lg p-4 space-y-3">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.name')}</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder={t('presets.namePlaceholder')}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('analysis.selectTemplate')}</label>
+            <select
+              value={form.template ?? 'custom'}
+              onChange={(e) => setForm({ ...form, template: e.target.value === 'custom' ? null : e.target.value })}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              {ANALYSIS_TEMPLATES.map((tmpl) => (
+                <option key={tmpl} value={tmpl}>{templateLabel(tmpl === 'custom' ? null : tmpl)}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
+            <input
+              type="text"
+              value={form.language ?? ''}
+              onChange={(e) => setForm({ ...form, language: e.target.value || null })}
+              placeholder="en, de, fr…"
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          {(form.template === null || form.template === 'custom') && (
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">{t('analysis.customizePrompt')}</label>
+              <textarea
+                value={form.custom_prompt ?? ''}
+                onChange={(e) => setForm({ ...form, custom_prompt: e.target.value || null })}
+                rows={3}
+                className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+              />
+            </div>
+          )}
+          <div className="flex gap-2 justify-end">
+            <button onClick={handleCancel} className="text-sm text-gray-400 hover:text-white px-3 py-1.5">
+              {t('common.cancel')}
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving || !form.name.trim()}
+              className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
+            >
+              {saving ? '…' : t('presets.saved')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!showForm && (
+        <button onClick={openNew} className="text-sm text-blue-400 hover:text-blue-300">
+          + {t('presets.create')}
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// RefinementPresetsList
+// ---------------------------------------------------------------------------
+
+function RefinementPresetsList() {
+  const { t } = useTranslation()
+  const presets = useStore((s) => s.refinementPresets)
+  const setPresets = useStore((s) => s.setRefinementPresets)
+
+  const emptyForm: RefinementPresetCreate = { name: '', context: null }
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState<RefinementPresetCreate>(emptyForm)
+  const [saving, setSaving] = useState(false)
+
+  const openNew = () => {
+    setEditingId(null)
+    setForm(emptyForm)
+    setShowForm(true)
+  }
+
+  const openEdit = (p: RefinementPreset) => {
+    setEditingId(p.id)
+    setForm({ name: p.name, context: p.context })
+    setShowForm(true)
+  }
+
+  const handleCancel = () => {
+    setShowForm(false)
+    setEditingId(null)
+    setForm(emptyForm)
+  }
+
+  const handleSave = async () => {
+    if (!form.name.trim()) return
+    setSaving(true)
+    try {
+      if (editingId) {
+        const updated = await api.updateRefinementPreset(editingId, form)
+        setPresets(presets.map((p) => (p.id === editingId ? updated : p)))
+      } else {
+        const created = await api.createRefinementPreset(form)
+        setPresets([...presets, created])
+      }
+      handleCancel()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm(t('presets.confirmDelete'))) return
+    try {
+      await api.deleteRefinementPreset(id)
+      setPresets(presets.filter((p) => p.id !== id))
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {presets.length === 0 && !showForm && (
+        <p className="text-gray-500 text-sm">{t('presets.noPresets')}</p>
+      )}
+
+      {presets.map((p) => (
+        <div key={p.id} className="bg-gray-800 rounded-lg p-4 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="font-medium text-white truncate">{p.name}</p>
+            {p.context && <p className="text-xs text-gray-400 mt-0.5 truncate">{p.context}</p>}
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button onClick={() => openEdit(p)} className="text-sm text-blue-400 hover:text-blue-300">
+              {t('presets.edit')}
+            </button>
+            <button onClick={() => handleDelete(p.id)} className="text-sm text-red-400 hover:text-red-300">
+              {t('presets.delete')}
+            </button>
+          </div>
+        </div>
+      ))}
+
+      {showForm && (
+        <div className="bg-gray-800 rounded-lg p-4 space-y-3">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.name')}</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder={t('presets.namePlaceholder')}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('editor.refinementContext')}</label>
+            <textarea
+              value={form.context ?? ''}
+              onChange={(e) => setForm({ ...form, context: e.target.value || null })}
+              placeholder={t('editor.refinementContextPlaceholder')}
+              rows={3}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+            />
+          </div>
+          <div className="flex gap-2 justify-end">
+            <button onClick={handleCancel} className="text-sm text-gray-400 hover:text-white px-3 py-1.5">
+              {t('common.cancel')}
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving || !form.name.trim()}
+              className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
+            >
+              {saving ? '…' : t('presets.saved')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!showForm && (
+        <button onClick={openNew} className="text-sm text-blue-400 hover:text-blue-300">
+          + {t('presets.create')}
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// BundlesList
+// ---------------------------------------------------------------------------
+
+function BundlesList() {
+  const { t } = useTranslation()
+  const bundles = useStore((s) => s.bundles)
+  const setBundles = useStore((s) => s.setBundles)
+  const activeBundleId = useStore((s) => s.activeBundleId)
+  const setActiveBundleId = useStore((s) => s.setActiveBundleId)
+  const transcriptionPresets = useStore((s) => s.transcriptionPresets)
+  const analysisPresets = useStore((s) => s.analysisPresets)
+  const refinementPresets = useStore((s) => s.refinementPresets)
+
+  const emptyForm: PresetBundleCreate = { name: '', transcription_preset_id: null, analysis_preset_id: null, refinement_preset_id: null }
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState<PresetBundleCreate>(emptyForm)
+  const [saving, setSaving] = useState(false)
+
+  const openNew = () => {
+    setEditingId(null)
+    setForm(emptyForm)
+    setShowForm(true)
+  }
+
+  const openEdit = (b: PresetBundle) => {
+    setEditingId(b.id)
+    setForm({
+      name: b.name,
+      transcription_preset_id: b.transcription_preset_id,
+      analysis_preset_id: b.analysis_preset_id,
+      refinement_preset_id: b.refinement_preset_id,
+    })
+    setShowForm(true)
+  }
+
+  const handleCancel = () => {
+    setShowForm(false)
+    setEditingId(null)
+    setForm(emptyForm)
+  }
+
+  const handleSave = async () => {
+    if (!form.name.trim()) return
+    setSaving(true)
+    try {
+      if (editingId) {
+        const updated = await api.updateBundle(editingId, form)
+        setBundles(bundles.map((b) => (b.id === editingId ? updated : b)))
+      } else {
+        const created = await api.createBundle(form)
+        setBundles([...bundles, created])
+      }
+      handleCancel()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm(t('presets.bundle.confirmDelete'))) return
+    try {
+      await api.deleteBundle(id)
+      setBundles(bundles.filter((b) => b.id !== id))
+      if (activeBundleId === id) setActiveBundleId(null)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handleToggleDefault = async (b: PresetBundle) => {
+    try {
+      if (activeBundleId === b.id) {
+        await api.clearDefaultBundle()
+        setActiveBundleId(null)
+        setBundles(bundles.map((x) => ({ ...x, is_default: false })))
+      } else {
+        await api.setDefaultBundle(b.id)
+        setActiveBundleId(b.id)
+        setBundles(bundles.map((x) => ({ ...x, is_default: x.id === b.id })))
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const presetName = (
+    list: { id: string; name: string }[],
+    id: string | null
+  ) => (id ? (list.find((p) => p.id === id)?.name ?? id) : null)
+
+  return (
+    <div className="space-y-3">
+      {bundles.length === 0 && !showForm && (
+        <p className="text-gray-500 text-sm">{t('presets.noBundles')}</p>
+      )}
+
+      {bundles.map((b) => {
+        const tpName = presetName(transcriptionPresets, b.transcription_preset_id)
+        const apName = presetName(analysisPresets, b.analysis_preset_id)
+        const rpName = presetName(refinementPresets, b.refinement_preset_id)
+        const isDefault = activeBundleId === b.id
+
+        return (
+          <div key={b.id} className="bg-gray-800 rounded-lg p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="font-medium text-white truncate">{b.name}</p>
+                  {isDefault && (
+                    <span className="text-xs bg-blue-900 text-blue-300 rounded px-1.5 py-0.5">
+                      {t('presets.bundle.isDefault')}
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1.5 mt-1.5">
+                  {tpName && (
+                    <span className="text-xs bg-gray-700 text-gray-300 rounded px-2 py-0.5">
+                      {t('presets.transcription')}: {tpName}
+                    </span>
+                  )}
+                  {apName && (
+                    <span className="text-xs bg-gray-700 text-gray-300 rounded px-2 py-0.5">
+                      {t('presets.analysis')}: {apName}
+                    </span>
+                  )}
+                  {rpName && (
+                    <span className="text-xs bg-gray-700 text-gray-300 rounded px-2 py-0.5">
+                      {t('presets.refinement')}: {rpName}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="flex gap-2 shrink-0 items-center">
+                <button
+                  onClick={() => handleToggleDefault(b)}
+                  className={`text-sm ${isDefault ? 'text-yellow-400 hover:text-yellow-300' : 'text-gray-400 hover:text-yellow-400'}`}
+                  title={isDefault ? t('presets.bundle.clearDefault') : t('presets.bundle.setDefault')}
+                >
+                  ★
+                </button>
+                <button onClick={() => openEdit(b)} className="text-sm text-blue-400 hover:text-blue-300">
+                  {t('presets.edit')}
+                </button>
+                <button onClick={() => handleDelete(b.id)} className="text-sm text-red-400 hover:text-red-300">
+                  {t('presets.delete')}
+                </button>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+
+      {showForm && (
+        <div className="bg-gray-800 rounded-lg p-4 space-y-3">
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.name')}</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder={t('presets.namePlaceholder')}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.bundle.selectTranscription')}</label>
+            <select
+              value={form.transcription_preset_id ?? ''}
+              onChange={(e) => setForm({ ...form, transcription_preset_id: e.target.value || null })}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="">{t('presets.bundle.none')}</option>
+              {transcriptionPresets.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.bundle.selectAnalysis')}</label>
+            <select
+              value={form.analysis_preset_id ?? ''}
+              onChange={(e) => setForm({ ...form, analysis_preset_id: e.target.value || null })}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="">{t('presets.bundle.none')}</option>
+              {analysisPresets.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.bundle.selectRefinement')}</label>
+            <select
+              value={form.refinement_preset_id ?? ''}
+              onChange={(e) => setForm({ ...form, refinement_preset_id: e.target.value || null })}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="">{t('presets.bundle.none')}</option>
+              {refinementPresets.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex gap-2 justify-end">
+            <button onClick={handleCancel} className="text-sm text-gray-400 hover:text-white px-3 py-1.5">
+              {t('common.cancel')}
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving || !form.name.trim()}
+              className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
+            >
+              {saving ? '…' : t('presets.saved')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!showForm && (
+        <button onClick={openNew} className="text-sm text-blue-400 hover:text-blue-300">
+          + {t('presets.bundle.create')}
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// PresetsPage
+// ---------------------------------------------------------------------------
+
+type Tab = 'transcription' | 'analysis' | 'refinement' | 'bundles'
+
+export function PresetsPage() {
+  const { t } = useTranslation()
+  const [activeTab, setActiveTab] = useState<Tab>('transcription')
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'transcription', label: t('presets.transcription') },
+    { key: 'analysis', label: t('presets.analysis') },
+    { key: 'refinement', label: t('presets.refinement') },
+    { key: 'bundles', label: t('presets.bundles') },
+  ]
+
+  return (
+    <div className="px-6 py-4">
+      <h2 className="text-xl font-semibold text-white mb-4">{t('presets.title')}</h2>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-gray-700 mb-5">
+        {tabs.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              activeTab === key
+                ? 'text-white border-b-2 border-blue-400 -mb-px'
+                : 'text-gray-400 hover:text-gray-200'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'transcription' && <TranscriptionPresetsList />}
+      {activeTab === 'analysis' && <AnalysisPresetsList />}
+      {activeTab === 'refinement' && <RefinementPresetsList />}
+      {activeTab === 'bundles' && <BundlesList />}
+    </div>
+  )
+}

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../../store'
 import { api } from '../../api/client'
+import { LANGUAGES } from '../../utils/languages'
 import type {
   TranscriptionPreset,
   TranscriptionPresetCreate,
@@ -118,13 +119,16 @@ function TranscriptionPresetsList() {
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
-            <input
-              type="text"
+            <select
               value={form.language ?? ''}
               onChange={(e) => setForm({ ...form, language: e.target.value || null })}
-              placeholder="en, de, fr…"
               className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
-            />
+            >
+              <option value="">{t('languages.auto')}</option>
+              {LANGUAGES.map((code) => (
+                <option key={code} value={code}>{t(`languages.${code}`)}</option>
+              ))}
+            </select>
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
@@ -167,7 +171,7 @@ function TranscriptionPresetsList() {
               disabled={saving || !form.name.trim()}
               className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
             >
-              {saving ? '…' : t('presets.saved')}
+              {saving ? '…' : t('presets.save')}
             </button>
           </div>
         </div>
@@ -308,13 +312,16 @@ function AnalysisPresetsList() {
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
-            <input
-              type="text"
+            <select
               value={form.language ?? ''}
               onChange={(e) => setForm({ ...form, language: e.target.value || null })}
-              placeholder="en, de, fr…"
               className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
-            />
+            >
+              <option value="">{t('languages.auto')}</option>
+              {LANGUAGES.map((code) => (
+                <option key={code} value={code}>{t(`languages.${code}`)}</option>
+              ))}
+            </select>
           </div>
           {(form.template === null || form.template === 'custom') && (
             <div>
@@ -336,7 +343,7 @@ function AnalysisPresetsList() {
               disabled={saving || !form.name.trim()}
               className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
             >
-              {saving ? '…' : t('presets.saved')}
+              {saving ? '…' : t('presets.save')}
             </button>
           </div>
         </div>
@@ -467,7 +474,7 @@ function RefinementPresetsList() {
               disabled={saving || !form.name.trim()}
               className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
             >
-              {saving ? '…' : t('presets.saved')}
+              {saving ? '…' : t('presets.save')}
             </button>
           </div>
         </div>
@@ -515,6 +522,7 @@ function BundlesList() {
       transcription_preset_id: b.transcription_preset_id,
       analysis_preset_id: b.analysis_preset_id,
       refinement_preset_id: b.refinement_preset_id,
+      translate_language: b.translate_language,
     })
     setShowForm(true)
   }
@@ -616,6 +624,11 @@ function BundlesList() {
                       {t('presets.refinement')}: {rpName}
                     </span>
                   )}
+                  {b.translate_language && (
+                    <span className="text-xs bg-gray-700 text-gray-300 rounded px-2 py-0.5">
+                      {t('editor.translate')}: {b.translate_language}
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="flex gap-2 shrink-0 items-center">
@@ -689,6 +702,19 @@ function BundlesList() {
               ))}
             </select>
           </div>
+          <div>
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.bundle.translateLanguage')}</label>
+            <select
+              value={form.translate_language ?? ''}
+              onChange={(e) => setForm({ ...form, translate_language: e.target.value || null })}
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="">{t('presets.bundle.none')}</option>
+              {LANGUAGES.map((code) => (
+                <option key={code} value={code}>{t(`languages.${code}`)}</option>
+              ))}
+            </select>
+          </div>
           <div className="flex gap-2 justify-end">
             <button onClick={handleCancel} className="text-sm text-gray-400 hover:text-white px-3 py-1.5">
               {t('common.cancel')}
@@ -698,7 +724,7 @@ function BundlesList() {
               disabled={saving || !form.name.trim()}
               className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
             >
-              {saving ? '…' : t('presets.saved')}
+              {saving ? '…' : t('presets.save')}
             </button>
           </div>
         </div>

--- a/frontend/src/components/SubtitleEditor/SubtitleEditor.tsx
+++ b/frontend/src/components/SubtitleEditor/SubtitleEditor.tsx
@@ -4,6 +4,7 @@ import { useStore } from '../../store'
 import { api } from '../../api/client'
 import { SubtitleRow } from './SubtitleRow'
 import { LanguageSelect } from '../LanguageSelect'
+import { PresetSelect } from '../PresetSelect/PresetSelect'
 import type { Utterance } from '../../api/types'
 
 interface SubtitleEditorProps {
@@ -38,6 +39,10 @@ export function SubtitleEditor({ onOpenSpeakerModal }: SubtitleEditorProps) {
   const setTranslationLanguage = useStore((s) => s.setTranslationLanguage)
   const clearTranslation = useStore((s) => s.clearTranslation)
   const config = useStore((s) => s.config)
+  const refinementPresets = useStore((s) => s.refinementPresets)
+  const setRefinementPresets = useStore((s) => s.setRefinementPresets)
+  const activeBundleId = useStore((s) => s.activeBundleId)
+  const bundles = useStore((s) => s.bundles)
   const llmAvailable = config?.llm_available ?? false
   const activeRef = useRef<HTMLTableRowElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -48,6 +53,30 @@ export function SubtitleEditor({ onOpenSpeakerModal }: SubtitleEditorProps) {
   const [showRefineModal, setShowRefineModal] = useState(false)
   const [refineContext, setRefineContext] = useState('')
   const [refining, setRefining] = useState(false)
+  const [selectedRefinementPresetId, setSelectedRefinementPresetId] = useState<string | null>(null)
+
+  const handleLoadRefinementPreset = (presetId: string | null) => {
+    setSelectedRefinementPresetId(presetId)
+    if (!presetId) return
+    const preset = refinementPresets.find((p) => p.id === presetId)
+    if (preset) setRefineContext(preset.context || '')
+  }
+
+  const handleSaveRefinementPreset = async (name: string) => {
+    const preset = await api.createRefinementPreset({ name, context: refineContext || null })
+    setRefinementPresets([...refinementPresets, preset])
+    setSelectedRefinementPresetId(preset.id)
+  }
+
+  // Auto-load refinement preset from active bundle
+  useEffect(() => {
+    if (activeBundleId && showRefineModal && !selectedRefinementPresetId) {
+      const bundle = bundles.find((b) => b.id === activeBundleId)
+      if (bundle?.refinement_preset_id) {
+        handleLoadRefinementPreset(bundle.refinement_preset_id)
+      }
+    }
+  }, [activeBundleId, bundles, showRefineModal]) // eslint-disable-line react-hooks/exhaustive-deps
   const [showTranslateModal, setShowTranslateModal] = useState(false)
   const [translateLanguage, setTranslateLanguage] = useState('en')
   const [translating, setTranslating] = useState(false)
@@ -675,6 +704,14 @@ export function SubtitleEditor({ onOpenSpeakerModal }: SubtitleEditorProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
           <div className="bg-gray-800 border border-gray-700 rounded-lg shadow-xl w-full max-w-md mx-4 p-5">
             <h3 className="text-sm font-medium text-gray-200 mb-3">{t('editor.refineTranscription')}</h3>
+            <div className="mb-3">
+              <PresetSelect
+                presets={refinementPresets}
+                selectedId={selectedRefinementPresetId}
+                onSelect={handleLoadRefinementPreset}
+                onSave={handleSaveRefinementPreset}
+              />
+            </div>
             <label className="block text-xs text-gray-400 mb-1">{t('editor.refinementContext')}</label>
             <textarea
               value={refineContext}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -173,6 +173,39 @@
     "confirmDeleteAnalysis": "Diese Analyse löschen? Dies kann nicht rückgängig gemacht werden.",
     "collapseForm": "Abbrechen"
   },
+  "presets": {
+    "title": "Meine Voreinstellungen",
+    "transcription": "Transkription",
+    "analysis": "Analyse",
+    "refinement": "Verfeinerung",
+    "bundles": "Pakete",
+    "create": "Neue Voreinstellung",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "confirmDelete": "Voreinstellung löschen? Pakete, die sie verwenden, verlieren die Referenz.",
+    "saveAs": "Als Voreinstellung speichern",
+    "loadPreset": "Voreinstellung laden",
+    "selectPreset": "Voreinstellung wählen...",
+    "selectBundle": "Paket wählen...",
+    "name": "Name",
+    "namePlaceholder": "Name der Voreinstellung",
+    "noPresets": "Noch keine Voreinstellungen",
+    "noBundles": "Noch keine Pakete",
+    "bundle": {
+      "setDefault": "Als Standard setzen",
+      "clearDefault": "Standard entfernen",
+      "isDefault": "Standard",
+      "create": "Neues Paket",
+      "confirmDelete": "Dieses Paket löschen?",
+      "linkedPresets": "Verknüpfte Voreinstellungen",
+      "selectTranscription": "Transkriptions-Voreinstellung...",
+      "selectAnalysis": "Analyse-Voreinstellung...",
+      "selectRefinement": "Verfeinerungs-Voreinstellung...",
+      "none": "Keine"
+    },
+    "saved": "Voreinstellung gespeichert",
+    "deleted": "Voreinstellung gelöscht"
+  },
   "languages": {
     "auto": "Automatisch erkennen",
     "af": "Afrikaans",
@@ -319,7 +352,8 @@
   "nav": {
     "backToTranscriptions": "Transkriptionen",
     "newUpload": "Hochladen",
-    "newRecording": "Aufnehmen"
+    "newRecording": "Aufnehmen",
+    "presets": "Voreinstellungen"
   },
   "common": {
     "loading": "Laden...",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -31,6 +31,7 @@
   },
   "transcription": {
     "transcribe": "Transkribieren",
+    "runPipeline": "Pipeline starten",
     "transcribeWhenReady": "Transkribieren wenn bereit",
     "inProgress": "Transkription läuft...",
     "success": "Transkription erfolgreich!",
@@ -201,10 +202,16 @@
       "selectTranscription": "Transkriptions-Voreinstellung...",
       "selectAnalysis": "Analyse-Voreinstellung...",
       "selectRefinement": "Verfeinerungs-Voreinstellung...",
-      "none": "Keine"
+      "none": "Keine",
+      "translateLanguage": "Übersetzen nach",
+      "translatePlaceholder": "z.B. en, de, fr (leer lassen zum Überspringen)"
     },
+    "save": "Speichern",
     "saved": "Voreinstellung gespeichert",
     "deleted": "Voreinstellung gelöscht"
+  },
+  "pipeline": {
+    "translating": "Übersetze nach {{language}}..."
   },
   "languages": {
     "auto": "Automatisch erkennen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -173,6 +173,39 @@
     "confirmDeleteAnalysis": "Delete this analysis? This cannot be undone.",
     "collapseForm": "Cancel"
   },
+  "presets": {
+    "title": "My Presets",
+    "transcription": "Transcription",
+    "analysis": "Analysis",
+    "refinement": "Refinement",
+    "bundles": "Bundles",
+    "create": "New preset",
+    "edit": "Edit",
+    "delete": "Delete",
+    "confirmDelete": "Delete this preset? Bundles using it will lose the reference.",
+    "saveAs": "Save as preset",
+    "loadPreset": "Load preset",
+    "selectPreset": "Select a preset...",
+    "selectBundle": "Select a bundle...",
+    "name": "Name",
+    "namePlaceholder": "Preset name",
+    "noPresets": "No presets yet",
+    "noBundles": "No bundles yet",
+    "bundle": {
+      "setDefault": "Set as default",
+      "clearDefault": "Clear default",
+      "isDefault": "Default",
+      "create": "New bundle",
+      "confirmDelete": "Delete this bundle?",
+      "linkedPresets": "Linked presets",
+      "selectTranscription": "Transcription preset...",
+      "selectAnalysis": "Analysis preset...",
+      "selectRefinement": "Refinement preset...",
+      "none": "None"
+    },
+    "saved": "Preset saved",
+    "deleted": "Preset deleted"
+  },
   "languages": {
     "auto": "Auto-detect",
     "af": "Afrikaans",
@@ -319,7 +352,8 @@
   "nav": {
     "backToTranscriptions": "Transcriptions",
     "newUpload": "Upload",
-    "newRecording": "Record"
+    "newRecording": "Record",
+    "presets": "Presets"
   },
   "common": {
     "loading": "Loading...",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -31,6 +31,7 @@
   },
   "transcription": {
     "transcribe": "Transcribe",
+    "runPipeline": "Run pipeline",
     "transcribeWhenReady": "Transcribe when ready",
     "inProgress": "Transcription in progress...",
     "success": "Transcription successful!",
@@ -201,10 +202,16 @@
       "selectTranscription": "Transcription preset...",
       "selectAnalysis": "Analysis preset...",
       "selectRefinement": "Refinement preset...",
-      "none": "None"
+      "none": "None",
+      "translateLanguage": "Translate to",
+      "translatePlaceholder": "e.g. en, de, fr (leave empty to skip)"
     },
+    "save": "Save",
     "saved": "Preset saved",
     "deleted": "Preset deleted"
+  },
+  "pipeline": {
+    "translating": "Translating to {{language}}..."
   },
   "languages": {
     "auto": "Auto-detect",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { FileInfo, TranscriptionResult, TranscriptionListItem, ConfigResponse, Utterance, RefinementMetadata, AnalysisListItem } from '../api/types'
+import type { FileInfo, TranscriptionResult, TranscriptionListItem, ConfigResponse, Utterance, RefinementMetadata, AnalysisListItem, TranscriptionPreset, AnalysisPreset, RefinementPreset, PresetBundle } from '../api/types'
 
 type AppView = 'archive' | 'upload' | 'record' | 'detail'
 
@@ -47,6 +47,17 @@ interface AppState {
   setAnalyses: (analyses: AnalysisListItem[]) => void
   addAnalysis: (item: AnalysisListItem) => void
   removeAnalysis: (id: string) => void
+  // Presets
+  transcriptionPresets: TranscriptionPreset[]
+  analysisPresets: AnalysisPreset[]
+  refinementPresets: RefinementPreset[]
+  bundles: PresetBundle[]
+  activeBundleId: string | null
+  setTranscriptionPresets: (presets: TranscriptionPreset[]) => void
+  setAnalysisPresets: (presets: AnalysisPreset[]) => void
+  setRefinementPresets: (presets: RefinementPreset[]) => void
+  setBundles: (bundles: PresetBundle[]) => void
+  setActiveBundleId: (id: string | null) => void
   clearRefinement: () => void
   reset: () => void
 }
@@ -107,6 +118,17 @@ export const useStore = create<AppState>((set) => ({
   setAnalyses: (analyses) => set({ analyses }),
   addAnalysis: (item) => set((s) => ({ analyses: [item, ...s.analyses] })),
   removeAnalysis: (id) => set((s) => ({ analyses: s.analyses.filter((a) => a.id !== id) })),
+  // Presets
+  transcriptionPresets: [],
+  analysisPresets: [],
+  refinementPresets: [],
+  bundles: [],
+  activeBundleId: null,
+  setTranscriptionPresets: (presets) => set({ transcriptionPresets: presets }),
+  setAnalysisPresets: (presets) => set({ analysisPresets: presets }),
+  setRefinementPresets: (presets) => set({ refinementPresets: presets }),
+  setBundles: (bundles) => set({ bundles }),
+  setActiveBundleId: (id) => set({ activeBundleId: id }),
   clearRefinement: () => set({ refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const }),
   reset: () => set({
     currentView: 'archive' as const,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import type { FileInfo, TranscriptionResult, TranscriptionListItem, ConfigResponse, Utterance, RefinementMetadata, AnalysisListItem, TranscriptionPreset, AnalysisPreset, RefinementPreset, PresetBundle } from '../api/types'
 
-type AppView = 'archive' | 'upload' | 'record' | 'detail'
+type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets'
 
 interface AppState {
   currentView: AppView


### PR DESCRIPTION
## Summary

- Users can save reusable **presets** for transcription, analysis, and refinement settings
- Presets can be grouped into **bundles** for one-click workflow configuration
- Selecting a bundle and clicking **"Run pipeline"** auto-runs transcription → refinement → analysis → translation in sequence
- Color-coded progress indicator shows each pipeline step (amber/blue/purple)
- Dedicated **Presets page** for full CRUD management, plus inline load/save controls in SettingsPanel, AnalysisView, and refinement modal
- One bundle can be marked as **default** to auto-load on app start
- Full i18n support (English + German)

### Backend
- 4 new SQLite tables: `transcription_presets`, `analysis_presets`, `refinement_presets`, `preset_bundles`
- New `/api/presets/` router with full CRUD for all types + bundle default management
- 6 API tests covering CRUD, bundles, cascade deletion, and user isolation

### Frontend
- `PresetSelect` reusable component for inline preset loading/saving
- `PresetsPage` with tabbed management UI (transcription/analysis/refinement/bundles)
- Zustand store extended with preset state
- Auto-pipeline logic in App.tsx triggered on transcription completion when bundle is active

Closes #95