### PR TITLE
feat(upload): warn before leaving an active upload (#102)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,14 +15,21 @@ import { AnalysisView } from './components/AnalysisView'
 import { useStore, setPopStateFlag } from './store'
 import { api } from './api/client'
 import { PresetsPage } from './components/PresetsPage/PresetsPage'
+import { useBeforeUnloadWarning } from './hooks/useBeforeUnloadWarning'
 
 function BackButton() {
   const { t } = useTranslation()
   const setCurrentView = useStore((s) => s.setCurrentView)
+  const confirmLeaveUpload = useStore((s) => s.confirmLeaveUpload)
+
+  const handleClick = () => {
+    if (!confirmLeaveUpload(t('upload.confirmLeave'))) return
+    setCurrentView('archive')
+  }
 
   return (
     <button
-      onClick={() => setCurrentView('archive')}
+      onClick={handleClick}
       className="flex items-center gap-1 px-6 py-2 text-sm text-gray-400 hover:text-white"
     >
       &larr; {t('nav.backToTranscriptions')}
@@ -133,6 +140,8 @@ function App() {
   const [focusSpeaker, setFocusSpeaker] = useState<string | undefined>(undefined)
   const [playerCollapsed, setPlayerCollapsed] = useState(false)
 
+  useBeforeUnloadWarning()
+
   useEffect(() => {
     setPlayerCollapsed(false)
   }, [file?.id])
@@ -171,6 +180,14 @@ function App() {
   // Sync browser back/forward buttons with view state
   useEffect(() => {
     const handlePopState = (e: PopStateEvent) => {
+      const state = useStore.getState()
+      if (state.uploading) {
+        if (!state.confirmLeaveUpload(t('upload.confirmLeave'))) {
+          // User declined — re-pin the current view so the back nav is undone.
+          history.pushState({ view: state.currentView }, '', '')
+          return
+        }
+      }
       setPopStateFlag(true)
       isPopStateNav.current = true
       setCurrentView(e.state?.view ?? 'archive')
@@ -178,7 +195,7 @@ function App() {
     }
     window.addEventListener('popstate', handlePopState)
     return () => window.removeEventListener('popstate', handlePopState)
-  }, [setCurrentView])
+  }, [setCurrentView, t])
 
   // Update browser tab title based on current view
   useEffect(() => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -46,10 +46,10 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
 export const api = {
   getConfig: () => request<ConfigResponse>('/api/config'),
 
-  uploadFile: async (file: File): Promise<FileInfo> => {
+  uploadFile: async (file: File, signal?: AbortSignal): Promise<FileInfo> => {
     const formData = new FormData()
     formData.append('file', file)
-    const response = await fetch(`${BASE}/api/upload`, { method: 'POST', body: formData })
+    const response = await fetch(`${BASE}/api/upload`, { method: 'POST', body: formData, signal })
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: response.statusText }))
       throw new Error(error.detail || response.statusText)

--- a/frontend/src/components/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/FileUpload/FileUpload.tsx
@@ -13,6 +13,7 @@ export function FileUpload() {
   const reset = useStore((s) => s.reset)
   const uploading = useStore((s) => s.uploading)
   const setUploading = useStore((s) => s.setUploading)
+  const setUploadAbortController = useStore((s) => s.setUploadAbortController)
   const [error, setError] = useState<string | null>(null)
 
   const setCurrentView = useStore((s) => s.setCurrentView)
@@ -37,16 +38,21 @@ export function FileUpload() {
       setError(t('upload.fileTooLarge'))
       return
     }
+    const controller = new AbortController()
+    setUploadAbortController(controller)
     setUploading(true)
     try {
-      const fileInfo = await api.uploadFile(selectedFile)
+      const fileInfo = await api.uploadFile(selectedFile, controller.signal)
       setFile(fileInfo)
     } catch (e) {
+      // AbortError is a user-initiated cancel; don't show an error banner.
+      if (e instanceof Error && e.name === 'AbortError') return
       setError(e instanceof Error ? e.message : 'Upload failed')
     } finally {
       setUploading(false)
+      setUploadAbortController(null)
     }
-  }, [setFile, t])
+  }, [setFile, setUploading, setUploadAbortController, t])
 
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault()

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -17,7 +17,11 @@ export function Header() {
       </div>
       <div className="flex flex-wrap items-center gap-4">
         <button
-          onClick={() => useStore.getState().setCurrentView('presets')}
+          onClick={() => {
+            const state = useStore.getState()
+            if (!state.confirmLeaveUpload(t('upload.confirmLeave'))) return
+            state.setCurrentView('presets')
+          }}
           className="text-sm text-gray-300 hover:text-white"
         >
           {t('nav.presets')}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -36,7 +36,10 @@ export function Header() {
         </button>
         {config?.logout_url && (
           <button
-            onClick={() => { window.location.href = config.logout_url }}
+            onClick={() => {
+              if (!useStore.getState().confirmLeaveUpload(t('upload.confirmLeave'))) return
+              window.location.href = config.logout_url
+            }}
             className="text-sm text-red-400 hover:text-red-300"
           >
             {t('common.logout')}

--- a/frontend/src/hooks/useBeforeUnloadWarning.ts
+++ b/frontend/src/hooks/useBeforeUnloadWarning.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { useStore } from '../store'
+
+/**
+ * Adds a `beforeunload` listener while an upload is in progress so the browser
+ * shows its native "leave site?" warning on tab close / refresh / external nav.
+ * Modern browsers ignore custom messages and show a generic dialog.
+ */
+export function useBeforeUnloadWarning() {
+  const uploading = useStore((s) => s.uploading)
+
+  useEffect(() => {
+    if (!uploading) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [uploading])
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -6,7 +6,8 @@
     "uploadedFile": "Hochgeladene Datei",
     "deleteFile": "Datei löschen",
     "supportedFormats": "Unterstützte Formate: MP3, WAV, MP4, WebM, M4A, MOV, AAC, Opus, OGG (max 1GB)",
-    "fileTooLarge": "Datei ist zu groß. Maximale Größe ist 1 GB."
+    "fileTooLarge": "Datei ist zu groß. Maximale Größe ist 1 GB.",
+    "confirmLeave": "Ein Upload läuft gerade. Wenn Sie die Seite verlassen, wird er abgebrochen. Fortfahren?"
   },
   "settings": {
     "language": "Sprache für die Transkription",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -6,7 +6,8 @@
     "uploadedFile": "Uploaded file",
     "deleteFile": "Delete file",
     "supportedFormats": "Supported formats: MP3, WAV, MP4, WebM, M4A, MOV, AAC, Opus, OGG (max 1GB)",
-    "fileTooLarge": "File is too large. Maximum size is 1 GB."
+    "fileTooLarge": "File is too large. Maximum size is 1 GB.",
+    "confirmLeave": "An upload is in progress. Leaving this page will cancel it. Continue?"
   },
   "settings": {
     "language": "Transcription language",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -12,6 +12,9 @@ interface AppState {
   setFile: (file: FileInfo | null) => void
   uploading: boolean
   setUploading: (uploading: boolean) => void
+  uploadAbortController: AbortController | null
+  setUploadAbortController: (controller: AbortController | null) => void
+  confirmLeaveUpload: (message: string) => boolean
   transcriptionId: string | null
   transcriptionTitle: string | null
   transcriptionStatus: string | null
@@ -68,7 +71,7 @@ export function setPopStateFlag(value: boolean) {
   isPopStateNavigation = value
 }
 
-export const useStore = create<AppState>((set) => ({
+export const useStore = create<AppState>((set, get) => ({
   currentView: 'archive' as const,
   setCurrentView: (view) => {
     const current = useStore.getState().currentView
@@ -83,6 +86,20 @@ export const useStore = create<AppState>((set) => ({
   setFile: (file) => set({ file }),
   uploading: false,
   setUploading: (uploading) => set({ uploading }),
+  uploadAbortController: null,
+  setUploadAbortController: (controller) => set({ uploadAbortController: controller }),
+  confirmLeaveUpload: (message) => {
+    if (!get().uploading) return true
+    if (!window.confirm(message)) return false
+    // Re-read state after the (synchronous) confirm dialog — upload may have
+    // completed while the dialog was open.
+    const state = get()
+    if (state.uploading && state.uploadAbortController) {
+      state.uploadAbortController.abort()
+    }
+    set({ uploading: false, uploadAbortController: null })
+    return true
+  },
   transcriptionId: null,
   transcriptionTitle: null,
   transcriptionStatus: null,
@@ -132,7 +149,7 @@ export const useStore = create<AppState>((set) => ({
   clearRefinement: () => set({ refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const }),
   reset: () => set({
     currentView: 'archive' as const,
-    file: null, uploading: false, transcriptionId: null, transcriptionTitle: null, transcriptionStatus: null,
+    file: null, uploading: false, uploadAbortController: null, transcriptionId: null, transcriptionTitle: null, transcriptionStatus: null,
     transcriptionResult: null, speakerMappings: {},
     currentTime: 0, seekTo: null, activeTab: 'subtitles', unsavedEdits: false,
     refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const,


### PR DESCRIPTION
## Summary

Closes #102.

Warns the user via `window.confirm()` before navigation that would interrupt an in-progress file upload, and aborts the upload fetch if the user confirms leaving — so behavior matches what the warning says.

## Design

- **Store:** a single `AbortController` lives in Zustand while an upload is in flight. A `confirmLeaveUpload(message): boolean` action is the central guard: returns `true` if no upload is active, otherwise shows the confirm dialog and — on accept — aborts the controller and clears state. After the (synchronous-blocking) `confirm()` returns, state is re-read to handle the race where the upload completes while the dialog is open.
- **API:** `uploadFile` accepts an optional `AbortSignal` and passes it to `fetch`. `uploadRecording` is intentionally left alone.
- **FileUpload:** creates the controller, stores it, passes the signal, and swallows `AbortError` so user cancellation does not render a red error banner.
- **In-app nav guards** (`BackButton`, Header Presets button, Header Logout button) — each checks `confirmLeaveUpload` and short-circuits on decline.
- **Browser back button:** the existing popstate listener now prompts on `uploading`; on decline it re-pins the current view via `history.pushState`, on accept it falls through to the existing nav path.
- **Tab close / refresh:** a new `useBeforeUnloadWarning` hook attaches a `beforeunload` listener while `uploading` is true. Browsers show their native "leave site?" dialog.

## Not guarded (unreachable during an active upload)

- `TranscriptionList` — only rendered on the archive view.
- `FileUpload.handleDelete` — delete button only renders after upload completes.
- `InputPanel` — dead code, not imported anywhere.
- `DetailActions.handleDelete` — only rendered on the detail view.

## Out of scope

- Background uploads that survive navigation (issue reporter's alternative).
- Recorder navigation guard.
- Custom styled modal (project uses native `window.confirm()` consistently).