### PR TITLE
feat: code-split heavy views with React.lazy

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,38 @@
-import { useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Header } from './components/Header'
 import { SettingsPanel } from './components/FileUpload'
 import { FileUpload } from './components/FileUpload'
-import { RecorderPanel } from './components/Recorder'
 import { ProgressBar } from './components/ProgressBar'
 import { TranscriptionList } from './components/TranscriptionList'
-import { MediaPlayer } from './components/MediaPlayer'
-import { SubtitleEditor } from './components/SubtitleEditor'
-import { SpeakerMapping } from './components/SpeakerMapping'
-import { FormatViewer } from './components/FormatViewer'
 import { TabBar } from './components/TabBar'
-import { AnalysisView } from './components/AnalysisView'
 import { useStore, setPopStateFlag } from './store'
 import { api } from './api/client'
-import { PresetsPage } from './components/PresetsPage/PresetsPage'
 import { useBeforeUnloadWarning } from './hooks/useBeforeUnloadWarning'
+import { LoadingFallback } from './components/LoadingFallback'
+import { ChunkErrorBoundary } from './components/ChunkErrorBoundary'
+
+const RecorderPanel = lazy(() =>
+  import('./components/Recorder').then((m) => ({ default: m.RecorderPanel }))
+)
+const MediaPlayer = lazy(() =>
+  import('./components/MediaPlayer').then((m) => ({ default: m.MediaPlayer }))
+)
+const SubtitleEditor = lazy(() =>
+  import('./components/SubtitleEditor').then((m) => ({ default: m.SubtitleEditor }))
+)
+const SpeakerMapping = lazy(() =>
+  import('./components/SpeakerMapping').then((m) => ({ default: m.SpeakerMapping }))
+)
+const FormatViewer = lazy(() =>
+  import('./components/FormatViewer').then((m) => ({ default: m.FormatViewer }))
+)
+const AnalysisView = lazy(() =>
+  import('./components/AnalysisView').then((m) => ({ default: m.AnalysisView }))
+)
+const PresetsPage = lazy(() =>
+  import('./components/PresetsPage/PresetsPage').then((m) => ({ default: m.PresetsPage }))
+)
 
 function BackButton() {
   const { t } = useTranslation()
@@ -329,7 +346,11 @@ function App() {
       {currentView === 'presets' && (
         <>
           <BackButton />
-          <PresetsPage />
+          <ChunkErrorBoundary errorMessage={t('common.loadError')} reloadLabel={t('common.reload')}>
+            <Suspense fallback={<LoadingFallback />}>
+              <PresetsPage />
+            </Suspense>
+          </ChunkErrorBoundary>
         </>
       )}
 
@@ -345,7 +366,11 @@ function App() {
       {currentView === 'record' && (
         <>
           <BackButton />
-          <RecorderPanel />
+          <ChunkErrorBoundary errorMessage={t('common.loadError')} reloadLabel={t('common.reload')}>
+            <Suspense fallback={<LoadingFallback />}>
+              <RecorderPanel />
+            </Suspense>
+          </ChunkErrorBoundary>
           {(file || uploading) && !showEditor && <SettingsPanel />}
           <ProgressBar />
         </>
@@ -401,25 +426,27 @@ function App() {
             </div>
           )}
           {showEditor && file && (
-            <>
-              <MediaPlayer
-                fileId={file.id}
-                mediaType={file.media_type}
-                hasVideo={file.has_video}
-                onCollapsedChange={setPlayerCollapsed}
-              />
-              <TabBar onSpeakerNamesClick={() => handleOpenSpeakerModal()} />
+            <ChunkErrorBoundary errorMessage={t('common.loadError')} reloadLabel={t('common.reload')}>
+              <Suspense fallback={<LoadingFallback />}>
+                <MediaPlayer
+                  fileId={file.id}
+                  mediaType={file.media_type}
+                  hasVideo={file.has_video}
+                  onCollapsedChange={setPlayerCollapsed}
+                />
+                <TabBar onSpeakerNamesClick={() => handleOpenSpeakerModal()} />
 
-              <div className={`mx-6 my-2 ${!file.has_video || playerCollapsed ? 'max-h-[calc(100vh-14rem)]' : 'max-h-[calc(100vh-22rem)]'} overflow-auto`}>
-                {activeTab === 'subtitles' && <SubtitleEditor onOpenSpeakerModal={handleOpenSpeakerModal} />}
-                {activeTab === 'analysis' && <AnalysisView />}
-                {['srt', 'vtt', 'json', 'txt'].includes(activeTab) && (
-                  <FormatViewer format={activeTab} />
-                )}
-              </div>
+                <div className={`mx-6 my-2 ${!file.has_video || playerCollapsed ? 'max-h-[calc(100vh-14rem)]' : 'max-h-[calc(100vh-22rem)]'} overflow-auto`}>
+                  {activeTab === 'subtitles' && <SubtitleEditor onOpenSpeakerModal={handleOpenSpeakerModal} />}
+                  {activeTab === 'analysis' && <AnalysisView />}
+                  {['srt', 'vtt', 'json', 'txt'].includes(activeTab) && (
+                    <FormatViewer format={activeTab} />
+                  )}
+                </div>
 
-              <SpeakerMapping isOpen={speakerModalOpen} onClose={() => { setSpeakerModalOpen(false); setFocusSpeaker(undefined) }} focusSpeaker={focusSpeaker} />
-            </>
+                <SpeakerMapping isOpen={speakerModalOpen} onClose={() => { setSpeakerModalOpen(false); setFocusSpeaker(undefined) }} focusSpeaker={focusSpeaker} />
+              </Suspense>
+            </ChunkErrorBoundary>
           )}
         </>
       )}

--- a/frontend/src/components/ChunkErrorBoundary.tsx
+++ b/frontend/src/components/ChunkErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+  errorMessage: string
+  reloadLabel: string
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class ChunkErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('ChunkErrorBoundary caught error:', error)
+  }
+
+  handleReload = () => {
+    window.location.reload()
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children
+    return (
+      <div className="mx-6 my-6 p-6 bg-red-900/30 rounded-lg border border-red-700/50">
+        <div className="flex items-center gap-3 mb-4">
+          <svg className="w-6 h-6 text-red-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <span className="text-red-300 text-sm">{this.props.errorMessage}</span>
+        </div>
+        <button
+          onClick={this.handleReload}
+          className="px-4 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors"
+        >
+          {this.props.reloadLabel}
+        </button>
+      </div>
+    )
+  }
+}

--- a/frontend/src/components/LoadingFallback.tsx
+++ b/frontend/src/components/LoadingFallback.tsx
@@ -1,0 +1,7 @@
+export function LoadingFallback() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <div className="animate-spin h-8 w-8 border-2 border-blue-500 border-t-transparent rounded-full" />
+    </div>
+  )
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -370,6 +370,8 @@
     "retry": "Erneut versuchen",
     "cancel": "Abbrechen",
     "close": "Schließen",
-    "logout": "Abmelden"
+    "logout": "Abmelden",
+    "loadError": "Diese Ansicht konnte nicht geladen werden. Bitte laden Sie die Seite neu.",
+    "reload": "Neu laden"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -370,6 +370,8 @@
     "retry": "Retry",
     "cancel": "Cancel",
     "close": "Close",
-    "logout": "Logout"
+    "logout": "Logout",
+    "loadError": "Failed to load this view. Please reload the page.",
+    "reload": "Reload"
   }
 }


### PR DESCRIPTION
## Summary

Splits the heavy views (`record`, `detail`, `presets`) into separate chunks that load on demand, drastically shrinking the initial JS payload. Motivated by the Vite chunk-size warning and the fact this will be deployed university-wide with varied network conditions.

## Bundle size impact

**Before:** single `index-*.js` at 1,095.77 kB (gzip: 317.20 kB)

**After:** main bundle down to **289.90 kB (gzip: 89.11 kB)** — a 74% reduction in initial download.

Deferred chunks (loaded only when the corresponding view/tab is visited):

| Chunk | Size | gzip |
|---|---|---|
| `MediaPlayer-*.js` | 702.81 kB | 205.83 kB |
| `SubtitleEditor-*.js` | 29.38 kB | 7.32 kB |
| `AnalysisView-*.js` | 19.82 kB | 4.82 kB |
| `PresetsPage-*.js` | 18.78 kB | 3.00 kB |
| `Recorder-*.js` | 18.18 kB | 4.84 kB |
| `SpeakerMapping-*.js` | 2.33 kB | 1.08 kB |
| `FormatViewer-*.js` | 2.35 kB | 1.14 kB |
| `jsx-runtime-*.js` | 16.70 kB | 6.27 kB |
| `languages-*.js` | 0.35 kB | 0.24 kB |

The `MediaPlayer` chunk is still large (WaveSurfer + video libs) but is now only downloaded when a user actually opens a transcription.

## Design

- Seven heavy components in `App.tsx` converted to `React.lazy()` with the `.then((m) => ({ default: m.Name }))` pattern (components are named exports, not defaults).
- Three view bodies wrapped in `<ChunkErrorBoundary><Suspense fallback={<LoadingFallback />}>...</Suspense></ChunkErrorBoundary>`.
- **`LoadingFallback`**: small functional component with a centered spinner matching the existing `border-blue-500` style.
- **`ChunkErrorBoundary`**: class component that catches `React.lazy` failures (e.g., stale chunk after deploy — user's tab was open during a new deploy, old hashed filename no longer exists). Renders a translated "Failed to load" card with a Reload button that calls `window.location.reload()`. Per-view boundaries mean error state resets naturally when the user navigates away.
- `i18n`: new `common.loadError` and `common.reload` strings in en/de.

## Verification

Verified end-to-end against a production build served by the backend, using Playwright to inspect network requests:

- Cold archive load: only `index`, `jsx-runtime`, `languages` — no lazy chunks.
- Click Presets → `PresetsPage-*.js` fetched.
- Click a transcription → `MediaPlayer-*.js` + `SubtitleEditor-*.js` + `SpeakerMapping-*.js` fetched. `AnalysisView` NOT fetched yet.
- Click Analysis tab → `AnalysisView-*.js` fetched.

Each chunk loads exactly when its view/tab is first accessed, never before.

## Not split

- `Header`, `TranscriptionList`, `FileUpload`, `SettingsPanel`, `ProgressBar`, `TabBar` — either the initial view or small/shared across views.
- Archive and upload views stay eager (first view + common entry point).