### PR TITLE
docs(readme): document user-defined presets and bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - Editable LLM prompts — view and customize the prompt before generating analysis results.
 - LLM-powered transcription refinement to fix spelling, punctuation, terminology, filler words, and disfluencies — with original/refined toggle, per-utterance diff view, and changes summary.
 - LLM-powered caption translation to any supported language with Original/Translated view toggle and cached results.
+- User-defined presets for transcription, analysis, and refinement — bundle them together to auto-run a full pipeline (transcribe → refine → analyze → translate) on upload with a single click.
 - Inline file renaming in transcription history.
 - Copy, download, and delete generated analysis results.
 - LLM provider and model attribution display on generated content.


### PR DESCRIPTION
## Summary

Adds a Features bullet for the user-defined presets and bundles feature shipped in #100. The Presets page and bundle auto-pipeline were already in the product for several releases but never got documented in the README.