### PR TITLE
feat(help): add in-app help drawer with bilingual user manual

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,8 +13,11 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^16.5.8",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.1",
         "react-simple-code-editor": "^0.14.1",
+        "rehype-slug": "^6.0.0",
+        "remark-gfm": "^4.0.1",
         "video.js": "^8.23.7",
         "zustand": "^5.0.12"
       },
@@ -1421,18 +1424,59 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1471,6 +1515,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.1",
@@ -1767,6 +1817,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@videojs/http-streaming": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.17.4.tgz",
@@ -1925,6 +1981,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2021,6 +2087,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2036,6 +2112,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/color-convert": {
@@ -2057,6 +2173,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2111,7 +2237,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2125,12 +2250,34 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2140,6 +2287,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-walk": {
@@ -2365,6 +2525,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2374,6 +2544,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2490,6 +2666,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2543,6 +2725,72 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -2567,6 +2815,16 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/i18next": {
@@ -2637,6 +2895,46 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2664,6 +2962,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3058,6 +3378,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3088,6 +3418,861 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/min-document": {
       "version": "2.19.2",
@@ -3130,7 +4315,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mux.js": {
@@ -3246,6 +4430,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3355,6 +4564,16 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3413,6 +4632,33 @@
         }
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-router": {
       "version": "7.13.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
@@ -3459,6 +4705,89 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve-from": {
@@ -3567,6 +4896,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3578,6 +4931,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -3629,6 +5000,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3710,6 +5101,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3758,6 +5236,34 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/video.js": {
@@ -3995,6 +5501,16 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,11 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-i18next": "^16.5.8",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
     "react-simple-code-editor": "^0.14.1",
+    "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "video.js": "^8.23.7",
     "zustand": "^5.0.12"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,9 @@ const AnalysisView = lazy(() =>
 const PresetsPage = lazy(() =>
   import('./components/PresetsPage/PresetsPage').then((m) => ({ default: m.PresetsPage }))
 )
+const HelpDrawer = lazy(() =>
+  import('./components/HelpDrawer').then((m) => ({ default: m.HelpDrawer }))
+)
 
 function BackButton() {
   const { t } = useTranslation()
@@ -153,6 +156,7 @@ function App() {
   const transcriptionTitle = useStore((s) => s.transcriptionTitle)
   const transcriptionResult = useStore((s) => s.transcriptionResult)
   const activeTab = useStore((s) => s.activeTab)
+  const helpOpen = useStore((s) => s.helpOpen)
   const [speakerModalOpen, setSpeakerModalOpen] = useState(false)
   const [focusSpeaker, setFocusSpeaker] = useState<string | undefined>(undefined)
   const [playerCollapsed, setPlayerCollapsed] = useState(false)
@@ -449,6 +453,12 @@ function App() {
             </ChunkErrorBoundary>
           )}
         </>
+      )}
+
+      {helpOpen && (
+        <Suspense fallback={null}>
+          <HelpDrawer />
+        </Suspense>
       )}
     </div>
   )

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -17,6 +17,15 @@ export function Header() {
       </div>
       <div className="flex flex-wrap items-center gap-4">
         <button
+          type="button"
+          onClick={() => useStore.getState().setHelpOpen(true)}
+          aria-label={t('help.open')}
+          title={t('help.open')}
+          className="text-sm text-gray-300 hover:text-white w-6 h-6 rounded-full border border-gray-600 flex items-center justify-center focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+        >
+          ?
+        </button>
+        <button
           onClick={() => {
             const state = useStore.getState()
             if (!state.confirmLeaveUpload(t('upload.confirmLeave'))) return

--- a/frontend/src/components/HelpDrawer/HelpContent.tsx
+++ b/frontend/src/components/HelpDrawer/HelpContent.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeSlug from 'rehype-slug'
+import type { Components } from 'react-markdown'
+import type { HelpSectionId } from './helpSections'
+import { loadContent, assetUrls } from './helpSections'
+
+interface HelpContentProps {
+  sectionId: HelpSectionId
+}
+
+/**
+ * Resolves a markdown image src against Vite's asset URL map.
+ * Accepts relative paths like "./assets/main-flow.svg" or "/src/help/assets/main-flow.svg".
+ */
+function resolveAssetUrl(src: string | undefined): string | undefined {
+  if (!src) return undefined
+  // Normalize: strip leading "./" and make relative paths absolute from /src/help/
+  let key = src
+  if (key.startsWith('./')) key = '/src/help/' + key.slice(2)
+  if (!key.startsWith('/')) key = '/src/help/' + key
+  return assetUrls[key] ?? src
+}
+
+const components: Components = {
+  a: ({ href, children, ...props }) => {
+    const isExternal = href?.startsWith('http://') || href?.startsWith('https://')
+    if (isExternal) {
+      return (
+        <a href={href} target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline" {...props}>
+          {children}
+        </a>
+      )
+    }
+    return (
+      <a href={href} className="text-blue-400 hover:text-blue-300 underline" {...props}>
+        {children}
+      </a>
+    )
+  },
+  code: ({ children, ...props }) => (
+    <code className="bg-gray-800 text-amber-300 px-1 py-0.5 rounded text-sm" {...props}>
+      {children}
+    </code>
+  ),
+  pre: ({ children, ...props }) => (
+    <pre className="bg-gray-800 text-gray-200 p-3 rounded text-sm overflow-x-auto" {...props}>
+      {children}
+    </pre>
+  ),
+  h1: ({ children, ...props }) => (
+    <h1 className="text-2xl font-semibold text-white mt-0 mb-4" {...props}>{children}</h1>
+  ),
+  h2: ({ children, ...props }) => (
+    <h2 className="text-lg font-semibold text-white mt-6 mb-2" {...props}>{children}</h2>
+  ),
+  h3: ({ children, ...props }) => (
+    <h3 className="text-base font-semibold text-gray-200 mt-4 mb-2" {...props}>{children}</h3>
+  ),
+  p: ({ children, ...props }) => (
+    <p className="text-gray-300 leading-relaxed mb-3" {...props}>{children}</p>
+  ),
+  ul: ({ children, ...props }) => (
+    <ul className="list-disc list-inside text-gray-300 mb-3 space-y-1" {...props}>{children}</ul>
+  ),
+  ol: ({ children, ...props }) => (
+    <ol className="list-decimal list-inside text-gray-300 mb-3 space-y-1" {...props}>{children}</ol>
+  ),
+  li: ({ children, ...props }) => (
+    <li className="text-gray-300" {...props}>{children}</li>
+  ),
+  img: ({ src, alt, ...props }) => (
+    <img src={resolveAssetUrl(typeof src === 'string' ? src : undefined)} alt={alt ?? ''} className="my-4 max-w-full rounded border border-gray-700 bg-gray-800/40 p-2" {...props} />
+  ),
+  table: ({ children, ...props }) => (
+    <div className="overflow-x-auto my-3">
+      <table className="text-sm text-gray-300 border-collapse" {...props}>{children}</table>
+    </div>
+  ),
+  th: ({ children, ...props }) => (
+    <th className="border border-gray-700 px-3 py-1 bg-gray-800 text-left font-semibold" {...props}>{children}</th>
+  ),
+  td: ({ children, ...props }) => (
+    <td className="border border-gray-700 px-3 py-1" {...props}>{children}</td>
+  ),
+}
+
+export function HelpContent({ sectionId }: HelpContentProps) {
+  const { i18n, t } = useTranslation()
+  const lang: 'en' | 'de' = i18n.language === 'de' ? 'de' : 'en'
+  const markdown = loadContent(sectionId, lang)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Scroll to top whenever the section changes so users land at the section heading.
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0
+    }
+  }, [sectionId, lang])
+
+  if (!markdown) {
+    return (
+      <div ref={containerRef} className="flex-1 overflow-y-auto p-6">
+        <p className="text-gray-400 italic">{t('help.missingContent')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="flex-1 overflow-y-auto p-6">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSlug]} components={components}>
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/frontend/src/components/HelpDrawer/HelpContent.tsx
+++ b/frontend/src/components/HelpDrawer/HelpContent.tsx
@@ -72,7 +72,7 @@ const components: Components = {
     <li className="text-gray-300" {...props}>{children}</li>
   ),
   img: ({ src, alt, ...props }) => (
-    <img src={resolveAssetUrl(typeof src === 'string' ? src : undefined)} alt={alt ?? ''} className="my-4 max-w-full rounded border border-gray-700 bg-gray-800/40 p-2" {...props} />
+    <img src={resolveAssetUrl(typeof src === 'string' ? src : undefined)} alt={alt ?? ''} className="my-4 w-full rounded border border-gray-700 bg-gray-800/40 p-2" {...props} />
   ),
   table: ({ children, ...props }) => (
     <div className="overflow-x-auto my-3">

--- a/frontend/src/components/HelpDrawer/HelpContent.tsx
+++ b/frontend/src/components/HelpDrawer/HelpContent.tsx
@@ -71,9 +71,28 @@ const components: Components = {
   li: ({ children, ...props }) => (
     <li className="text-gray-300" {...props}>{children}</li>
   ),
-  img: ({ src, alt, ...props }) => (
-    <img src={resolveAssetUrl(typeof src === 'string' ? src : undefined)} alt={alt ?? ''} className="my-4 w-full rounded border border-gray-700 bg-gray-800/40 p-2" {...props} />
-  ),
+  img: ({ src, alt, ...props }) => {
+    const resolved = resolveAssetUrl(typeof src === 'string' ? src : undefined)
+    const dialogRef = useRef<HTMLDialogElement>(null)
+    return (
+      <>
+        <img
+          src={resolved}
+          alt={alt ?? ''}
+          className="my-4 w-full rounded border border-gray-700 bg-gray-800/40 p-2 cursor-pointer hover:border-gray-500 transition-colors"
+          onClick={() => dialogRef.current?.showModal()}
+          {...props}
+        />
+        <dialog
+          ref={dialogRef}
+          onClick={(e) => { if (e.target === e.currentTarget) dialogRef.current?.close() }}
+          className="backdrop:bg-black/70 bg-transparent p-4 max-w-[90vw] max-h-[90vh] m-auto"
+        >
+          <img src={resolved} alt={alt ?? ''} className="w-full h-full object-contain rounded bg-gray-800 p-4" />
+        </dialog>
+      </>
+    )
+  },
   table: ({ children, ...props }) => (
     <div className="overflow-x-auto my-3">
       <table className="text-sm text-gray-300 border-collapse" {...props}>{children}</table>

--- a/frontend/src/components/HelpDrawer/HelpContent.tsx
+++ b/frontend/src/components/HelpDrawer/HelpContent.tsx
@@ -86,9 +86,9 @@ const components: Components = {
         <dialog
           ref={dialogRef}
           onClick={(e) => { if (e.target === e.currentTarget) dialogRef.current?.close() }}
-          className="backdrop:bg-black/70 bg-transparent p-4 max-w-[90vw] max-h-[90vh] m-auto"
+          className="backdrop:bg-black/70 bg-transparent p-4 w-[90vw] max-h-[90vh] m-auto"
         >
-          <img src={resolved} alt={alt ?? ''} className="w-full h-full object-contain rounded bg-gray-800 p-4" />
+          <img src={resolved} alt={alt ?? ''} className="w-full object-contain rounded bg-gray-800 p-6" />
         </dialog>
       </>
     )

--- a/frontend/src/components/HelpDrawer/HelpDrawer.tsx
+++ b/frontend/src/components/HelpDrawer/HelpDrawer.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useStore } from '../../store'
+import { HelpSidebar } from './HelpSidebar'
+import { HelpContent } from './HelpContent'
+import { sections, viewToSection } from './helpSections'
+import type { HelpSectionId } from './helpSections'
+
+type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets'
+
+export function HelpDrawer() {
+  const { t } = useTranslation()
+  const open = useStore((s) => s.helpOpen)
+  const initialSection = useStore((s) => s.helpInitialSection)
+  const closeHelp = useStore((s) => s.closeHelp)
+  const currentView = useStore((s) => s.currentView) as AppView
+
+  // Compute the section to land on when opening.
+  // Because the component unmounts when !open, useState(derivedSection) will
+  // always receive the correct value on the next mount.
+  const derivedSection = useMemo<HelpSectionId>(() => {
+    if (initialSection && sections.some((s) => s.id === initialSection)) {
+      return initialSection as HelpSectionId
+    }
+    return viewToSection[currentView] ?? 'getting-started'
+  }, [initialSection, currentView])
+
+  const [activeId, setActiveId] = useState<HelpSectionId>(derivedSection)
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+
+  // Focus management: trap focus inside the drawer and restore on close.
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null
+      // Defer focus to next frame so the drawer is mounted.
+      requestAnimationFrame(() => {
+        closeButtonRef.current?.focus()
+      })
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus()
+      previousFocusRef.current = null
+    }
+  }, [open])
+
+  // Keyboard handling: Escape closes, Tab stays trapped inside the drawer.
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        closeHelp()
+        return
+      }
+      if (e.key !== 'Tab' || !drawerRef.current) return
+      const focusables = drawerRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, closeHelp])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="help-drawer-title"
+    >
+      <button
+        type="button"
+        aria-label={t('help.close')}
+        onClick={closeHelp}
+        className="absolute inset-0 bg-black/50 cursor-default"
+        tabIndex={-1}
+      />
+      <div
+        ref={drawerRef}
+        className="relative flex flex-col bg-gray-900 border-l border-gray-700 w-full md:w-[35vw] md:min-w-[420px] max-w-[720px] shadow-2xl"
+      >
+        <div className="flex items-center justify-between px-6 py-3 border-b border-gray-700">
+          <h2 id="help-drawer-title" className="text-lg font-semibold text-white">
+            {t('help.title')}
+          </h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={closeHelp}
+            aria-label={t('help.close')}
+            className="text-gray-400 hover:text-white text-xl leading-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="flex flex-1 min-h-0">
+          <HelpSidebar activeId={activeId} onSelect={setActiveId} />
+          <HelpContent sectionId={activeId} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default HelpDrawer

--- a/frontend/src/components/HelpDrawer/HelpSidebar.tsx
+++ b/frontend/src/components/HelpDrawer/HelpSidebar.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next'
+import { sections } from './helpSections'
+import type { HelpSectionId } from './helpSections'
+
+interface HelpSidebarProps {
+  activeId: HelpSectionId
+  onSelect: (id: HelpSectionId) => void
+}
+
+export function HelpSidebar({ activeId, onSelect }: HelpSidebarProps) {
+  const { t } = useTranslation()
+
+  return (
+    <nav
+      aria-label={t('help.title')}
+      className="w-[200px] shrink-0 border-r border-gray-700 overflow-y-auto py-4"
+    >
+      <ul className="space-y-1">
+        {sections.map((section) => {
+          const isActive = section.id === activeId
+          return (
+            <li key={section.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(section.id)}
+                className={`w-full text-left px-4 py-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 ${
+                  isActive
+                    ? 'bg-gray-800 text-white border-l-2 border-blue-500'
+                    : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50 border-l-2 border-transparent'
+                }`}
+              >
+                {t(`help.sections.${section.id}`)}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/frontend/src/components/HelpDrawer/helpSections.ts
+++ b/frontend/src/components/HelpDrawer/helpSections.ts
@@ -1,0 +1,85 @@
+/**
+ * Single source of truth for help drawer sections.
+ * - `sections` is the ordered list rendered in the sidebar.
+ * - `viewToSection` maps the app's current view to its default help section.
+ * - `loadContent(id, lang)` returns the raw markdown string for a section + language,
+ *   or null if the file doesn't exist (e.g., en/de drift).
+ * - `assetUrls` maps source asset paths to Vite-resolved URLs used by the markdown renderer.
+ */
+
+export type HelpSectionId =
+  | 'getting-started'
+  | 'archive'
+  | 'upload'
+  | 'record'
+  | 'transcription-settings'
+  | 'subtitle-editor'
+  | 'speaker-mapping'
+  | 'analysis'
+  | 'translation'
+  | 'refinement'
+  | 'format-viewer'
+  | 'presets'
+  | 'bundles'
+
+export interface HelpSection {
+  id: HelpSectionId
+  filename: string
+}
+
+export const sections: readonly HelpSection[] = [
+  { id: 'getting-started', filename: '01-getting-started.md' },
+  { id: 'archive', filename: '02-archive.md' },
+  { id: 'upload', filename: '03-upload.md' },
+  { id: 'record', filename: '04-record.md' },
+  { id: 'transcription-settings', filename: '05-transcription-settings.md' },
+  { id: 'subtitle-editor', filename: '06-subtitle-editor.md' },
+  { id: 'speaker-mapping', filename: '07-speaker-mapping.md' },
+  { id: 'analysis', filename: '08-analysis.md' },
+  { id: 'translation', filename: '09-translation.md' },
+  { id: 'refinement', filename: '10-refinement.md' },
+  { id: 'format-viewer', filename: '11-format-viewer.md' },
+  { id: 'presets', filename: '12-presets.md' },
+  { id: 'bundles', filename: '13-bundles.md' },
+] as const
+
+type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets'
+
+export const viewToSection: Record<AppView, HelpSectionId> = {
+  archive: 'getting-started',
+  upload: 'upload',
+  record: 'record',
+  detail: 'subtitle-editor',
+  presets: 'presets',
+}
+
+// Vite glob: load every en/*.md and de/*.md as a raw string at build time.
+// Both language bundles live in the same lazy chunk as the drawer, so language
+// switching inside the drawer is instant.
+const enMarkdown = import.meta.glob('/src/help/en/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+const deMarkdown = import.meta.glob('/src/help/de/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+// Vite glob: resolve asset URLs for SVG diagrams referenced from markdown.
+// These are post-build URLs (e.g. "/assets/main-flow-abc123.svg").
+export const assetUrls = import.meta.glob('/src/help/assets/*.{svg,png}', {
+  query: '?url',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+export function loadContent(id: HelpSectionId, lang: 'en' | 'de'): string | null {
+  const section = sections.find((s) => s.id === id)
+  if (!section) return null
+  const map = lang === 'en' ? enMarkdown : deMarkdown
+  const key = `/src/help/${lang}/${section.filename}`
+  return map[key] ?? null
+}

--- a/frontend/src/components/HelpDrawer/index.ts
+++ b/frontend/src/components/HelpDrawer/index.ts
@@ -1,0 +1,1 @@
+export { HelpDrawer } from './HelpDrawer'

--- a/frontend/src/components/TranscriptionList/TranscriptionList.tsx
+++ b/frontend/src/components/TranscriptionList/TranscriptionList.tsx
@@ -282,6 +282,21 @@ export function TranscriptionList() {
       </div>
         </>
       )}
+
+      {history.length === 0 && (
+        <div className="mt-6 px-4 py-3 bg-gray-800/50 border border-gray-700 rounded-lg flex items-center justify-between gap-4">
+          <span className="text-sm text-gray-400">
+            {t('help.emptyStateHint')}
+          </span>
+          <button
+            type="button"
+            onClick={() => useStore.getState().setHelpOpen(true, 'getting-started')}
+            className="text-sm text-blue-400 hover:text-blue-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded"
+          >
+            {t('help.emptyStateLink')} →
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/help/assets/bundle-pipeline.svg
+++ b/frontend/src/help/assets/bundle-pipeline.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" width="720" height="160" role="img" aria-labelledby="bundle-pipeline-title">
+  <title id="bundle-pipeline-title">A bundle composes optional pipeline stages after transcription</title>
+  <style>
+    .stage { stroke-width: 1.5; }
+    .required { fill: #1e3a8a; stroke: #3b82f6; }
+    .optional { fill: #1f2937; stroke: #6b7280; stroke-dasharray: 4 3; }
+    .label { fill: #e5e7eb; font-family: system-ui, sans-serif; font-size: 13px; text-anchor: middle; }
+    .sub { fill: #9ca3af; font-family: system-ui, sans-serif; font-size: 10px; text-anchor: middle; }
+    .arrow { fill: none; stroke: #6b7280; stroke-width: 1.5; }
+    .arrow-head { fill: #6b7280; }
+  </style>
+  <rect class="stage required" x="20" y="50" width="120" height="60" rx="6" />
+  <text class="label" x="80" y="78">Transcription</text>
+  <text class="sub" x="80" y="94">always runs</text>
+  <rect class="stage optional" x="180" y="50" width="120" height="60" rx="6" />
+  <text class="label" x="240" y="78">Refinement</text>
+  <text class="sub" x="240" y="94">optional</text>
+  <rect class="stage optional" x="340" y="50" width="120" height="60" rx="6" />
+  <text class="label" x="400" y="78">Analysis</text>
+  <text class="sub" x="400" y="94">optional</text>
+  <rect class="stage optional" x="500" y="50" width="120" height="60" rx="6" />
+  <text class="label" x="560" y="78">Translation</text>
+  <text class="sub" x="560" y="94">optional</text>
+  <path class="arrow" d="M 140 80 L 175 80" />
+  <polygon class="arrow-head" points="170,77 181,80 170,83" />
+  <path class="arrow" d="M 300 80 L 335 80" />
+  <polygon class="arrow-head" points="330,77 341,80 330,83" />
+  <path class="arrow" d="M 460 80 L 495 80" />
+  <polygon class="arrow-head" points="490,77 501,80 490,83" />
+  <text class="sub" x="360" y="30">A bundle is any subset of these stages</text>
+</svg>

--- a/frontend/src/help/assets/bundle-pipeline.svg
+++ b/frontend/src/help/assets/bundle-pipeline.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" width="720" height="160" role="img" aria-labelledby="bundle-pipeline-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 160" role="img" aria-labelledby="bundle-pipeline-title">
   <title id="bundle-pipeline-title">A bundle composes optional pipeline stages after transcription</title>
   <style>
     .stage { stroke-width: 1.5; }

--- a/frontend/src/help/assets/main-flow.svg
+++ b/frontend/src/help/assets/main-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 140" width="640" height="140" role="img" aria-labelledby="main-flow-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 140" role="img" aria-labelledby="main-flow-title">
   <title id="main-flow-title">Archive → Upload or Record → Detail</title>
   <style>
     .box { fill: #1f2937; stroke: #4b5563; stroke-width: 1.5; }

--- a/frontend/src/help/assets/main-flow.svg
+++ b/frontend/src/help/assets/main-flow.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 140" width="640" height="140" role="img" aria-labelledby="main-flow-title">
+  <title id="main-flow-title">Archive → Upload or Record → Detail</title>
+  <style>
+    .box { fill: #1f2937; stroke: #4b5563; stroke-width: 1.5; }
+    .label { fill: #e5e7eb; font-family: system-ui, sans-serif; font-size: 14px; text-anchor: middle; }
+    .arrow { fill: none; stroke: #6b7280; stroke-width: 1.5; }
+    .arrow-head { fill: #6b7280; }
+  </style>
+  <rect class="box" x="20" y="50" width="120" height="40" rx="6" />
+  <text class="label" x="80" y="75">Archive</text>
+  <rect class="box" x="220" y="20" width="120" height="40" rx="6" />
+  <text class="label" x="280" y="45">Upload</text>
+  <rect class="box" x="220" y="80" width="120" height="40" rx="6" />
+  <text class="label" x="280" y="105">Record</text>
+  <rect class="box" x="440" y="50" width="160" height="40" rx="6" />
+  <text class="label" x="520" y="75">Detail (editor + analysis)</text>
+  <path class="arrow" d="M 140 70 Q 180 70 220 40" />
+  <path class="arrow" d="M 140 70 Q 180 70 220 100" />
+  <path class="arrow" d="M 340 40 Q 390 40 440 70" />
+  <path class="arrow" d="M 340 100 Q 390 100 440 70" />
+  <polygon class="arrow-head" points="215,37 226,40 215,43" />
+  <polygon class="arrow-head" points="215,97 226,100 215,103" />
+  <polygon class="arrow-head" points="435,67 446,70 435,73" />
+  <polygon class="arrow-head" points="435,67 446,70 435,73" />
+</svg>

--- a/frontend/src/help/de/01-getting-started.md
+++ b/frontend/src/help/de/01-getting-started.md
@@ -1,0 +1,24 @@
+# Einführung
+
+## Was diese App macht
+
+Transcription Whisper wandelt Audio- und Videoaufnahmen in bearbeitbare Transkripte um. Sobald ein Transkript fertig ist, kannst du optionale KI-gestützte Schritte ausführen: eine Zusammenfassung generieren, das Transkript in eine andere Sprache übersetzen oder den Text bereinigen, um Füllwörter und Formatierungsfehler zu entfernen. Du kannst Inhalte auf zwei Arten einbringen — eine vorhandene Datei hochladen oder direkt im Browser aufnehmen, mit Mikrofon und optional Kamera oder Systemton.
+
+## Der Hauptablauf
+
+![Hauptablauf: Archiv → Upload oder Aufnahme → Detail](./assets/main-flow.svg)
+
+Jede Sitzung beginnt im Archiv, führt über Upload oder Aufnahme zur Erstellung eines neuen Transkripts und endet in der Detailansicht, wo du dein Ergebnis bearbeitest und exportierst.
+
+## Deine erste Transkription
+
+1. Öffne die App — du landest im Archiv, das alle deine Transkripte auflistet.
+2. Klicke auf **+ Upload**, um eine Datei hochzuladen, oder auf **+ Aufnahme**, um Audio im Browser aufzunehmen.
+3. Konfiguriere die angezeigten Optionen (Sprache, Modell, Sprecheranzahl) und bestätige.
+4. Warte, bis die Transkription verarbeitet ist — eine Statusanzeige zeigt den Fortschritt.
+5. Klicke den fertigen Eintrag im Archiv an, um die Detailansicht zu öffnen.
+6. In der Detailansicht kannst du das Transkript bearbeiten, Analyse oder Übersetzung ausführen und das Ergebnis in deinem bevorzugten Format herunterladen.
+
+## Wo alles zu finden ist
+
+Die Kopfzeile ist deine Hauptnavigation. Klicke auf **?**, um diese Hilfe zu öffnen. Klicke auf **Presets**, um wiederverwendbare Transkriptionseinstellungen zu verwalten. Der Sprachumschalter wechselt die Oberfläche zwischen EN und DE. Der Zurück-Pfeil in jeder Unteransicht bringt dich zurück ins Archiv.

--- a/frontend/src/help/de/02-archive.md
+++ b/frontend/src/help/de/02-archive.md
@@ -1,0 +1,13 @@
+# Archiv
+
+## Deine Transkriptionsliste
+
+Jede Zeile zeigt den Titel der Transkription, den ursprünglichen Dateinamen, das verwendete Modell, ein Statusbadge (abgeschlossen, fehlgeschlagen oder wird verarbeitet) und das Erstellungsdatum. Die Ablaufinformationen werden rechts angezeigt. Klicke auf eine Zeile, um die Transkription in der Detailansicht zu öffnen. Titel und Dateiname sind direkt bearbeitbar — klicke auf das Stift-Symbol neben dem jeweiligen Feld, um es umzubenennen.
+
+## Ablauf und Archivierung
+
+Transkriptionen laufen nach einem Aufbewahrungszeitraum ab und werden danach dauerhaft gelöscht. Wenn du eine Transkription archivierst, wird das Ablaufdatum um 180 Tage ab dem aktuellen Datum verlängert. Ablaufdaten innerhalb von 24 Stunden werden rot hervorgehoben. Du kannst eine Transkription mehrmals archivieren, um das Ablaufdatum immer wieder nach hinten zu verschieben. Sobald eine Transkription abgelaufen und gelöscht wurde, lässt sie sich nicht wiederherstellen.
+
+## Löschen vs. Archivieren
+
+**Löschen** entfernt die Transkription sofort und kann nicht rückgängig gemacht werden. **Archivieren** behält die Transkription, verlängert aber die Aufbewahrung um 180 Tage. Verwende Archivieren, wenn du ein Ergebnis als Referenz behalten möchtest. Lösche nur, wenn du sicher bist, dass du die Transkription nicht mehr benötigst.

--- a/frontend/src/help/de/03-upload.md
+++ b/frontend/src/help/de/03-upload.md
@@ -1,0 +1,21 @@
+# Hochladen
+
+## Unterstützte Formate
+
+Die App akzeptiert MP3, WAV, MP4, WebM, M4A, MOV, AAC, Opus und OGG bis zu 1 GB. Ziehe eine Datei in den Upload-Bereich oder klicke, um den Datei-Browser zu öffnen.
+
+## Sprache wählen
+
+Wähle **Automatisch erkennen**, wenn du die Sprache nicht sicher kennst. Die Erkennung kostet etwas Zeit — wenn du die Sprache bereits kennst, liefert eine manuelle Auswahl schnellere Ergebnisse mit etwas besserer Genauigkeit.
+
+## ASR-Backend wählen
+
+**MurmurAI** ist ein Remote-Dienst — er verarbeitet Dateien schnell und eignet sich gut für längere Aufnahmen. Wähle ihn, wenn Geschwindigkeit wichtig ist.
+
+**WhisperX** läuft lokal und bietet eine feinkörnige Sprechererkennung mit präzisen Zeitstempeln und saubereren Sprechersegmenten. Wähle es, wenn eine genaue Sprechertrennung wichtiger ist als Schnelligkeit.
+
+Es werden nur die Backends angezeigt, die vom Administrator aktiviert wurden.
+
+## Bundles verwenden
+
+Ein Bundle verknüpft Transkriptions-, Verarbeitungs-, Analyse- und Übersetzungsvoreinstellungen zu einem einzigen Schritt. Wähle ein Bundle im Dropdown aus, bevor du startest, um alle vier Stufen automatisch anzuwenden. Bundles kannst du im Abschnitt **Bundles** erstellen und verwalten.

--- a/frontend/src/help/de/04-record.md
+++ b/frontend/src/help/de/04-record.md
@@ -1,0 +1,17 @@
+# Aufnehmen
+
+## Im Browser aufnehmen
+
+Klicke auf **+ Aufnehmen**, um den Recorder zu öffnen. Erteile die Mikrofonberechtigung, wenn du dazu aufgefordert wirst — optional kannst du auch ein Kamerabild aktivieren. Nutze die Steuerung zum Starten, Pausieren, Fortsetzen und Stoppen. Die Aufnahme bleibt im Speicher, bis du auf **Transkribieren** klickst oder sie mit **Verwerfen** löschst. Wenn du die Seite mit einer ungespeicherten Aufnahme verlässt, fragt die App zur Bestätigung nach.
+
+## Aufnahmequalität
+
+Der Browser nimmt im Standard-MediaRecorder-Format auf, meist WebM/Opus. Das reicht für Sprachtranskriptionen aus. Wenn du höhere Audioqualität oder ein bestimmtes Format brauchst, nimm extern mit einer dedizierten Software auf und lade die Datei hoch.
+
+## Systemaudio
+
+Du kannst Systemaudio zusammen mit dem Mikrofon aufnehmen. Die Unterstützung variiert je nach Browser und Betriebssystem — die App zeigt plattformspezifische Hinweise in der Oberfläche an. Auf manchen Plattformen musst du zuerst einen Bildschirm oder Tab zum Teilen auswählen. Nimm nur Inhalte auf, für die du die Berechtigung hast.
+
+## Aufnehmen oder hochladen?
+
+Nutze den Recorder für schnelle In-App-Sitzungen ohne vorhandene Datei. Lade eine Datei hoch, wenn du bereits eine Aufnahme hast oder wenn Audioqualität wichtiger ist — externe Aufnahmen geben dir volle Kontrolle über Format und Bitrate.

--- a/frontend/src/help/de/05-transcription-settings.md
+++ b/frontend/src/help/de/05-transcription-settings.md
@@ -1,0 +1,26 @@
+# Transkriptionseinstellungen
+
+## Sprechererkennung
+
+Die Sprechererkennung (Diarization) erkennt, wer wann gesprochen hat, und versieht jede Äußerung mit einer Bezeichnung wie SPEAKER_00, SPEAKER_01 usw. Schalte sie für Aufnahmen mit mehreren Sprechern ein und für Einzelsprecher-Inhalte aus, um Verarbeitungszeit zu sparen. Optional kannst du eine minimale und maximale Sprecheranzahl angeben, um die Erkennung zu steuern. Die Sprechererkennung erhöht die Verarbeitungszeit spürbar. Nach der Transkription kannst du Sprecher über das **Speaker Mapping** umbenennen.
+
+## Qualität
+
+| Stufe | Geschwindigkeit | Hinweis |
+|---|---|---|
+| Draft | Schnellste | Gut für schnelle Vorschauen langer Dateien |
+| Standard | Schnell | — |
+| Good | Mittel | — |
+| Better | Langsam | — |
+| Best (fast) | Schnell/genau | Empfohlene Standardwahl |
+| Best | Langsamste | Maximale Genauigkeit |
+
+**Best (fast)** ist für die meisten Anwendungsfälle die richtige Wahl.
+
+## Erweiterte Optionen
+
+**Initial Prompt** ermöglicht es, dem Modell einen kurzen Kontext mitzugeben — nützlich für Fachthemen, Eigennamen oder erwartetes Vokabular. **Hotwords** ist eine kommagetrennte Liste von Fachbegriffen, die das Modell bevorzugen soll. Setze beide Optionen sparsam ein; zu viele Vorgaben können Fehler erzeugen.
+
+## Voreinstellungen
+
+Speichere deine aktuellen Einstellungen als benannte Voreinstellung, um sie jederzeit wieder aufzurufen. Voreinstellungen erstellst und verwaltest du auf der Seite **Voreinstellungen**.

--- a/frontend/src/help/de/06-subtitle-editor.md
+++ b/frontend/src/help/de/06-subtitle-editor.md
@@ -1,0 +1,17 @@
+# Untertitel-Editor
+
+## Text bearbeiten
+
+Klicke auf den Text einer Äußerung, um ihn bearbeitbar zu machen. Änderungen werden lokal gehalten, bis du speicherst — du kannst mehrere Äußerungen bearbeiten, bevor du etwas überträgst. Eine Äußerung löschst du, indem du den Text leerst und speicherst. Lange Äußerungen lassen sich an der Cursorposition mit der Teilungsaktion aufteilen, die beim Bearbeiten in der Toolbar erscheint.
+
+## Zeitstempel und Mediaplayer
+
+Der Mediaplayer oben in der Detailansicht bleibt mit dem Editor synchronisiert. Ein Klick auf eine Äußerung springt im Player zur entsprechenden Position. Während der Wiedergabe wird die aktuelle Äußerung automatisch hervorgehoben. Zeitstempel stammen direkt aus der ASR-Ausgabe und sind schreibgeschützt — passe sie an, indem du die Transkription mit anderen Einstellungen neu startest.
+
+## Änderungen speichern
+
+Änderungen werden nicht automatisch gespeichert. Solange du ungespeicherte Änderungen hast, erscheint ein entsprechender Hinweis. Wenn du versuchst, die Seite zu verlassen, fragt ein Bestätigungsdialog, ob du die Änderungen verwerfen möchtest. Nach dem Speichern wird der aktualisierte Text in allen Downloads verwendet — SRT, VTT, Nur-Text und weitere Exportformate.
+
+## Original, verfeinert und übersetzt
+
+Mit dem Ansichts-Umschalter über dem Editor wechselst du zwischen dem Original-Transkript, einer verfeinerten Version und einer übersetzten Version (sofern diese erstellt wurden). Änderungen gelten nur für die jeweils aktive Ansicht. Das Bearbeiten des Originals wirkt sich nicht auf die verfeinerte Ansicht aus und umgekehrt. Weitere Informationen findest du unter **Verfeinerung** und **Übersetzung**.

--- a/frontend/src/help/de/07-speaker-mapping.md
+++ b/frontend/src/help/de/07-speaker-mapping.md
@@ -1,0 +1,17 @@
+# Sprecher zuordnen
+
+## Dialog öffnen
+
+Öffne den Sprecher-Zuordnungsdialog über die Schaltfläche **Sprechernamen** in der Tab-Leiste oder durch einen Klick auf ein Sprecher-Label direkt im Editor. Der Dialog ist nur verfügbar, wenn die Diarisierung Sprecher-Labels für die Aufnahme erzeugt hat.
+
+## Sprecher umbenennen
+
+Für jeden erkannten Sprecher — SPEAKER_00, SPEAKER_01 usw. — gibt es ein Eingabefeld, in das du einen Anzeigenamen eintragen kannst. Nach dem Speichern ersetzt der Anzeigename das generische Label überall: im Editor, in allen Exportformaten sowie in den verfeinerten und übersetzten Ansichten. Lässt du ein Feld leer, wird das ursprüngliche generische Label für diesen Sprecher beibehalten.
+
+## Äußerungen neu zuweisen
+
+Wenn die Diarisierung eine Äußerung dem falschen Sprecher zugeordnet hat, kannst du sie im Editor neu zuweisen, ohne den restlichen Transkript anzufassen. Die Neuzuweisung erfolgt pro Äußerung. Ein sinnvoller Ablauf ist, zunächst die Sprecher umzubenennen, damit die Labels aussagekräftig sind, und dann falsch zugeordnete Äußerungen dem richtigen Sprecher zuzuweisen.
+
+## Wie Zuordnungen gespeichert werden
+
+Zuordnungen werden serverseitig gespeichert und bleiben sitzungsübergreifend erhalten. Nach einem Neuladen der Seite oder beim späteren Öffnen des Transkripts werden dieselben Anzeigenamen angezeigt. Alle Downloadformate verwenden die zugeordneten Namen anstelle der rohen ASR-Labels.

--- a/frontend/src/help/de/08-analysis.md
+++ b/frontend/src/help/de/08-analysis.md
@@ -1,0 +1,27 @@
+# Analyse
+
+## Was Analyse bedeutet
+
+Die Analyse sendet dein Transkript an ein Sprachmodell, um ein übergeordnetes Ergebnis zu erzeugen — eine Zusammenfassung, ein strukturiertes Protokoll, Kapitelmarker oder was auch immer du anforderst. Das Transkript wird dabei nicht verändert. Die ursprünglichen Äußerungen bleiben unabhängig vom Analyseergebnis unverändert.
+
+## Integrierte Vorlagen
+
+Drei Vorlagen stehen direkt zur Verfügung:
+
+- **Allgemeine Zusammenfassung** — ein kompakter Überblick über den Inhalt der Aufnahme
+- **Besprechungsprotokoll** — strukturierte Ausgabe mit Teilnehmenden, Entscheidungen und Aufgaben
+- **Kapitelmarker** — mit Zeitstempeln versehene Abschnitte mit Titeln, nützlich für lange Aufnahmen
+
+Wähle die Vorlage, die am besten zum Inhalt passt.
+
+## Eigene Prompts
+
+Statt einer Vorlage kannst du einen eigenen Prompt eingeben. Das Modell erhält den vollständigen Transkripttext zusammen mit deinem Prompt und gibt zurück, was du anforderst. Formuliere Prompts direkt und konkret. Vermeide Fragen nach Informationen, die im Transkript nicht enthalten sind — das Modell neigt dazu, Lücken mit Vermutungen zu füllen.
+
+## Kapitel-Hinweise und Agenda
+
+Bei langen Aufnahmen mit bekannter Agenda füge diese in das Agenda-Feld ein (ein Thema pro Zeile). Das Modell nutzt sie als Kontext für genauere Kapitelmarker und um Diskussionen den richtigen Tagesordnungspunkten zuzuordnen.
+
+## Mehrere Analysen
+
+Du kannst die Analyse beliebig oft mit verschiedenen Vorlagen oder Prompts ausführen. Jedes Ergebnis wird separat gespeichert und im Analyseverlauf angezeigt. Von dort aus kannst du Ergebnisse vergleichen, ältere löschen oder eine beliebige Konfiguration erneut ausführen.

--- a/frontend/src/help/de/09-translation.md
+++ b/frontend/src/help/de/09-translation.md
@@ -1,0 +1,13 @@
+# Übersetzung
+
+## Was die Übersetzung liefert
+
+Die Übersetzung erzeugt einen parallelen Satz von Äußerungen in der gewählten Zielsprache, die 1:1 mit der Quelle ausgerichtet sind. Jede Quell-Äußerung entspricht einer übersetzten Äußerung an derselben Position. Das Original-Transkript wird nicht ersetzt — die Übersetzung fügt eine zweite Ansicht hinzu, die über den Ansichts-Umschalter im **Untertitel-Editor** zugänglich ist. Nach der Erstellung wird die Übersetzung gespeichert und bleibt sitzungsübergreifend erhalten.
+
+## Zielsprache wählen
+
+Wähle vor dem Ausführen der Übersetzung die Zielsprache aus dem Dropdown aus. Die Liste der unterstützten Sprachen hängt von deinem konfigurierten LLM-Anbieter ab. Für beste Qualität wähle eine gut unterstützte Sprache. Weniger verbreitete Sprachen können je nach Modell akzeptable, aber ungleichmäßige Ergebnisse liefern.
+
+## Manuell oder per Bundle
+
+Du kannst die Übersetzung jederzeit manuell aus der Detailansicht heraus starten, nachdem die Transkription abgeschlossen ist. Alternativ kannst du eine Zielsprache in einer Bundle-Konfiguration festlegen, damit die Übersetzung automatisch als Teil der Pipeline ausgeführt wird. In einem Bundle läuft die Übersetzung nach Verfeinerung und Analyse, sodass nachgelagerte Übersetzungsschritte den vollständig bereinigten Text erhalten. Weitere Informationen zur Reihenfolge der Schritte findest du unter **Verfeinerung**.

--- a/frontend/src/help/de/10-refinement.md
+++ b/frontend/src/help/de/10-refinement.md
@@ -1,0 +1,17 @@
+# Verfeinerung
+
+## Was Verfeinerung bewirkt
+
+Die Verfeinerung führt einen Bereinigungsdurchlauf mit einem Sprachmodell über dein Transkript aus. Sie entfernt Füllwörter (äh, ähm, also), behebt Sprecherzuordnungsfehler, bei denen mitten im Satz der falsche Sprecher getaggt wurde, und glättet fragmentierte oder zu lange Sätze zu lesbarem Text. Das Original-Transkript bleibt vollständig erhalten — die Verfeinerung erzeugt eine eigene Ansicht, keine direkte Bearbeitung. Sie bleibt in der Ausgangssprache; sie ist keine Übersetzung.
+
+## Wann sie hilft
+
+Die Verfeinerung ist am nützlichsten bei rauschreichen Quellen: informellen Gesprächen, Interviews, Gruppendiskussionen mit Überlappungen oder Aufnahmen mit vielen Füllwörtern und Sprechunflüssigkeiten. Sie hilft auch dann, wenn die Diarisierung Zuordnungsfehler bei aufeinanderfolgenden Äußerungen gemacht hat. Das verfeinerte Transkript ist oft deutlich lesbarer als die rohe ASR-Ausgabe.
+
+## Wann du sie überspringen solltest
+
+Bei sauberen Einzelsprecher-Aufnahmen — Vorlesungen, Kommentaren, vorbereiteten Reden — ist die rohe ASR-Ausgabe in der Regel bereits von hoher Qualität. Die Verfeinerung verursacht dann LLM-Kosten und Verarbeitungszeit ohne nennenswerten Gewinn. Überspringe sie, wenn das Original bereits gut lesbar ist.
+
+## Reihenfolge mit anderen Schritten
+
+In einer Bundle-Pipeline läuft die Verfeinerung immer vor Analyse und Übersetzung. Das bedeutet, dass nachgelagerte Schritte den bereinigten Text erhalten, nicht die rohe ASR-Ausgabe. Wenn du die Verfeinerung manuell ausführst, nachdem eine Analyse bereits abgeschlossen ist, werden die vorhandenen Analyseergebnisse nicht aktualisiert — starte die Analyse erneut, wenn sie die verfeinerte Version berücksichtigen soll. Weitere Informationen findest du unter **Analyse** und **Übersetzung**.

--- a/frontend/src/help/de/11-format-viewer.md
+++ b/frontend/src/help/de/11-format-viewer.md
@@ -1,0 +1,23 @@
+# Formatansicht
+
+## Die vier Formate
+
+Die Detailansicht bietet vier Exportformate, die sich für unterschiedliche Anwendungsfälle eignen:
+
+- **SRT** — Das am weitesten verbreitete Untertitelformat. Nummerierte Einträge mit `HH:MM:SS,mmm`-Zeitstempeln. Funktioniert mit nahezu jedem Videoplayer und Schnittprogramm.
+- **VTT** — Der moderne WebVTT-Standard für HTML5-Video. Ähnlich aufgebaut wie SRT, aber mit übersichtlicherer Syntax und nativer Browser-Unterstützung.
+- **JSON** — Strukturierte Daten mit allen Informationen: Sprecherbeschriftungen, Zeitstempel auf Wortebene und Konfidenzwerte. Die richtige Wahl, wenn du das Transkript programmatisch weiterverarbeiten möchtest.
+- **TXT** — Reiner Text mit Sprecherbeschriftungen, aber ohne Zeitstempel. Leicht lesbar, teilbar oder in ein Dokument einfügbar.
+
+## Herunterladen
+
+Jedes Format hat seinen eigenen Reiter. Klicke auf einen Reiter, um eine Vorschau anzuzeigen, und klicke dann auf **Herunterladen**, um die Datei zu speichern. Namen, die du im Speaker Mapping vergeben hast, werden in allen vier Formaten übernommen.
+
+## Welches Format passt?
+
+| Ziel | Bestes Format |
+|---|---|
+| Untertitel zu einem Video hinzufügen | SRT oder VTT |
+| Programmatisch weiterverarbeiten | JSON |
+| Transkript lesen oder teilen | TXT |
+| In einen Web-Player einbetten | VTT |

--- a/frontend/src/help/de/12-presets.md
+++ b/frontend/src/help/de/12-presets.md
@@ -1,0 +1,17 @@
+# Voreinstellungen
+
+## Transkriptions-Voreinstellungen
+
+Eine Transkriptions-Voreinstellung speichert deine bevorzugte Kombination aus Sprache, Qualitätsstufe, Diarisierung, initialem Prompt und Hotwords. Wähle eine gespeicherte Voreinstellung in der Upload- oder Aufnahme-Ansicht aus, anstatt jede Option jedes Mal manuell einzustellen. Voreinstellungen erstellst und verwaltest du auf der **Voreinstellungen**-Seite, die du über die Kopfzeile erreichst.
+
+## Analyse-Voreinstellungen
+
+Eine Analyse-Voreinstellung speichert eine Vorlage oder einen eigenen Prompt zusammen mit der Ausgabesprache, Kapitelhinweisen und einer Agenda. Praktisch für wiederkehrende Analysemuster — zum Beispiel „Besprechungsprotokoll auf Deutsch mit fester Agenda erstellen". Wähle die Voreinstellung beim Ausführen einer Analyse aus.
+
+## Verfeinerungs-Voreinstellungen
+
+Eine Verfeinerungs-Voreinstellung speichert ein einzelnes Kontextfeld: eine kurze Beschreibung, die dem LLM bessere Bereinigungsentscheidungen ermöglicht — zum Beispiel „technisches Interview über Datenbanken". Es ist der einfachste Voreinstellungstyp, kann aber die Verfeinerungsqualität für gleichartige Aufnahmen spürbar verbessern.
+
+## Bearbeiten und löschen
+
+Öffne die **Voreinstellungen**-Seite, um eine Voreinstellung zu bearbeiten oder vollständig zu entfernen. Das Löschen einer Voreinstellung entfernt sie nur aus dem Dropdown-Menü — vergangene Transkriptionen, die sie genutzt haben, bleiben unverändert. Die Löschung ist dauerhaft.

--- a/frontend/src/help/de/13-bundles.md
+++ b/frontend/src/help/de/13-bundles.md
@@ -1,0 +1,23 @@
+# Bundles
+
+## Was ein Bundle ist
+
+Ein Bundle ist eine benannte Zusammenstellung von Pipeline-Stufen: Transkription, Verfeinerung, Analyse und Übersetzung. Jede Stufe ist optional außer der Transkription, und jede Stufe enthält eine Voreinstellung (oder eine Zielsprache für die Übersetzung). Wenn du in der Upload- oder Aufnahme-Ansicht ein Bundle auswählst, laufen alle konfigurierten Stufen nach Abschluss der Transkription automatisch nacheinander ab — kein manuelles Auslösen nötig.
+
+## Die Pipeline
+
+![Bundle pipeline](./assets/bundle-pipeline.svg)
+
+Die Stufen laufen immer in dieser Reihenfolge: **Transkription → Verfeinerung → Analyse → Übersetzung**. Jede Stufe erhält die Ausgabe der vorherigen — die Verfeinerung verbessert das Rohtranskript, die Analyse liest den verfeinerten Text, und die Übersetzung arbeitet mit dem Analyseergebnis oder, falls keine Analyse enthalten ist, direkt mit dem Transkript.
+
+## Standard-Bundle und Automatik
+
+Du kannst ein Bundle als Standard markieren. Es wird dann für jeden neuen Upload und jede Aufnahme vorausgewählt. Sobald die Transkription abgeschlossen ist, starten die verbleibenden Stufen automatisch, und Fortschrittsanzeigen zeigen den Status jeder Stufe. Wenn eine einzelne Stufe fehlschlägt, kannst du den Fehler schließen und weitermachen, ohne die gesamte Pipeline neu zu starten.
+
+## Bundles erstellen und verwenden
+
+Erstelle Bundles auf der **Voreinstellungen**-Seite, indem du pro Stufe eine Voreinstellung auswählst und dem Bundle einen Namen gibst. Markiere es als Standard, wenn es automatisch angewendet werden soll. In der Upload- oder Aufnahme-Ansicht kannst du das aktive Bundle jederzeit über das Bundle-Dropdown wechseln.
+
+## Bundle oder manuelle Schritte?
+
+Nutze ein Bundle, wenn du dieselbe Pipeline regelmäßig anwendest — zum Beispiel „jede Besprechungsaufnahme: verfeinern, dann auf Englisch zusammenfassen, dann ins Deutsche übersetzen". Wähle manuelle Schritte für einmalige Aufnahmen, die eine andere Behandlung benötigen, oder wenn du Zwischenergebnisse prüfen möchtest, bevor du weitermachst.

--- a/frontend/src/help/en/01-getting-started.md
+++ b/frontend/src/help/en/01-getting-started.md
@@ -1,0 +1,24 @@
+# Getting Started
+
+## What this app does
+
+Transcription Whisper turns audio and video recordings into editable transcripts. Once a transcription is ready, you can run optional LLM-powered steps: generate a summary, translate the transcript into another language, or refine the text to clean up filler words and formatting. You feed the app content in one of two ways — upload an existing file, or record directly in the browser using your microphone and optionally a camera or system audio.
+
+## The main flow
+
+![Main flow: Archive → Upload or Record → Detail](./assets/main-flow.svg)
+
+Every session starts in the Archive, moves through Upload or Record to create a new transcript, and lands in the Detail view where you edit and export your results.
+
+## Your first transcription
+
+1. Open the app — you land in the Archive, which lists all your transcriptions.
+2. Click **+ Upload** to upload a file, or **+ Record** to capture audio in the browser.
+3. Configure any options shown (language, model, speaker count) and confirm.
+4. Wait for the transcription to process — a status indicator shows progress.
+5. Click the finished entry in the Archive to open the Detail view.
+6. In the Detail view, edit the transcript, run analysis or translation, and download the result in your preferred format.
+
+## Where things live
+
+The header is your main navigation. Click **?** to open this help drawer. Click **Presets** to manage reusable transcription settings. The language toggle switches the interface between EN and DE. The back arrow in any sub-view returns you to the Archive.

--- a/frontend/src/help/en/02-archive.md
+++ b/frontend/src/help/en/02-archive.md
@@ -1,0 +1,13 @@
+# Archive
+
+## Your transcription list
+
+Each row shows the transcription title, the original filename, the model used, a status badge (completed, failed, or processing), and the creation date. Expiration info is shown on the right. Click any row to open the transcription in the detail view. Both the title and the filename are editable inline — click the pencil icon next to either one to rename it.
+
+## Expiration and archiving
+
+Transcriptions expire after a retention window and are permanently deleted when that window closes. Archiving a transcription extends its expiration by 180 days from the current date. Expiration dates within 24 hours are shown in red as a warning. You can archive a transcription multiple times to keep pushing the expiration date forward. Once a transcription expires and is deleted, it cannot be recovered.
+
+## Delete vs archive
+
+**Delete** removes the transcription immediately and cannot be undone. **Archive** keeps the transcription but extends its retention by 180 days. Use Archive when you want to hold on to a result for reference. Use Delete only when you are certain you no longer need it.

--- a/frontend/src/help/en/03-upload.md
+++ b/frontend/src/help/en/03-upload.md
@@ -1,0 +1,21 @@
+# Upload
+
+## Supported formats
+
+The app accepts MP3, WAV, MP4, WebM, M4A, MOV, AAC, Opus, and OGG files up to 1 GB. Drag a file onto the upload area or click to open the file browser.
+
+## Choosing a language
+
+Use **Auto-detect** when you are unsure of the language. Detection adds a small overhead, so if you know the language in advance, selecting it manually gives faster results and slightly better accuracy.
+
+## Choosing an ASR backend
+
+**MurmurAI** is a remote service — it processes files quickly and handles longer recordings well. Choose it when turnaround time matters.
+
+**WhisperX** runs locally and provides fine-grained speaker diarization, giving more precise timestamps and cleaner speaker segments. Choose it when accurate speaker separation is more important than speed.
+
+Only the backends your administrator has enabled appear in the interface.
+
+## Using a bundle
+
+A bundle chains transcription, refinement, analysis, and translation presets into a single step. Select one from the bundle dropdown before starting to apply all four stages automatically. You can create and manage bundles on the **Bundles** section.

--- a/frontend/src/help/en/04-record.md
+++ b/frontend/src/help/en/04-record.md
@@ -1,0 +1,17 @@
+# Record
+
+## Recording in the browser
+
+Click **+ Record** to open the recorder. Grant microphone access when prompted — you can also enable an optional camera feed. Use the controls to start, pause, resume, and stop. The recording is held in memory until you click **Transcribe** to submit it or **Discard** to delete it. If you navigate away with an unsaved recording, the app asks for confirmation before discarding it.
+
+## Recording quality
+
+The browser records using the default MediaRecorder format, typically WebM/Opus. This is adequate for speech transcription. If you need higher audio quality or a specific format, record externally with dedicated software and upload the file instead.
+
+## System audio
+
+You can capture system audio alongside the microphone. Support varies by browser and operating system — the app shows platform-specific warnings in the UI. On some platforms you need to select a screen or tab to share before audio capture starts. Only record content you have permission to capture.
+
+## When to record vs upload
+
+Use the recorder for quick in-app sessions when you have no existing file. Upload when you already have a recording or when audio quality is more important — external recordings give you full control over format and bitrate.

--- a/frontend/src/help/en/05-transcription-settings.md
+++ b/frontend/src/help/en/05-transcription-settings.md
@@ -1,0 +1,26 @@
+# Transcription Settings
+
+## Speaker diarization
+
+Diarization detects who spoke when and tags each utterance with a label like SPEAKER_00, SPEAKER_01, and so on. Turn it on for multi-speaker recordings and off for single-speaker content to save processing time. You can optionally set minimum and maximum speaker counts to guide detection. Diarization adds noticeable processing time. Once the transcription is ready, rename speakers to real names via the **Speaker Mapping** feature.
+
+## Quality selection
+
+| Tier | Speed | Notes |
+|---|---|---|
+| Draft | Fastest | Good for quick previews of long files |
+| Standard | Fast | — |
+| Good | Medium | — |
+| Better | Slow | — |
+| Best (fast) | Fast/accurate | Recommended default |
+| Best | Slowest | Maximum accuracy |
+
+**Best (fast)** is usually the right choice for most use cases.
+
+## Advanced options
+
+**Initial prompt** lets you give the model a short context sentence — useful for technical topics, proper nouns, or expected vocabulary. **Hotwords** is a comma-separated list of domain-specific terms the model should favour. Use both options sparingly; over-specifying can introduce errors.
+
+## Presets
+
+Save your current settings as a named preset to reuse them without reconfiguring every time. Create and manage presets on the **Presets** page.

--- a/frontend/src/help/en/06-subtitle-editor.md
+++ b/frontend/src/help/en/06-subtitle-editor.md
@@ -1,0 +1,17 @@
+# Subtitle Editor
+
+## Editing text
+
+Click on any utterance text to make it editable. Changes are held locally until you save — you can edit multiple utterances before committing anything. To remove an utterance, clear its text and save. Long utterances can be split at the cursor position using the split action that appears in the toolbar while editing.
+
+## Timestamps and the media player
+
+The media player at the top of the detail view stays in sync with the editor. Clicking an utterance seeks the player to that position. While playing, the current utterance is highlighted automatically. Timestamps come directly from the ASR output and are read-only — adjust them by re-running transcription with different settings if needed.
+
+## Saving your edits
+
+Edits are not saved automatically. An unsaved-changes indicator appears when you have local modifications. If you try to navigate away, a confirmation dialog will ask you to confirm or discard. Once saved, the updated text is used in all downloads — SRT, VTT, plain text, and any other export format.
+
+## Original, refined, and translated views
+
+The view switcher above the editor lets you toggle between the original transcript, a refined version, and a translated version (if those have been produced). Edits apply only to the currently active view. Editing the original does not affect the refined view, and vice versa. See **Refinement** and **Translation** for details on those views.

--- a/frontend/src/help/en/07-speaker-mapping.md
+++ b/frontend/src/help/en/07-speaker-mapping.md
@@ -1,0 +1,17 @@
+# Speaker Mapping
+
+## Opening the dialog
+
+Open the speaker mapping dialog from the **Speaker Names** button in the tab bar, or by clicking any speaker label directly in the editor. The dialog is only available when diarization has produced speaker labels for the recording.
+
+## Renaming speakers
+
+Each detected speaker — SPEAKER_00, SPEAKER_01, and so on — has an input field where you can enter a display name. Once saved, the display name replaces the generic label everywhere: in the editor, in all export formats, and in the refined and translated views. Leave a field blank to keep the original generic label for that speaker.
+
+## Re-assigning utterances
+
+If diarization misattributed an utterance to the wrong speaker, you can re-assign it from the editor without touching the rest of the transcript. Re-assignment is per-utterance. A good workflow is to rename your speakers first so labels are meaningful, then go through any misattributed utterances and reassign them to the correct speaker.
+
+## How mappings are saved
+
+Mappings are saved server-side and persist across sessions. Reloading the page or opening the transcript later will show the same display names. All download formats use the mapped names rather than the raw ASR labels.

--- a/frontend/src/help/en/08-analysis.md
+++ b/frontend/src/help/en/08-analysis.md
@@ -1,0 +1,27 @@
+# Analysis
+
+## What analysis does
+
+Analysis sends your transcript to a language model to produce a higher-level artifact — a summary, a structured protocol, chapter markers, or anything else you ask for. It does not modify the transcript. The original utterances remain unchanged regardless of what the analysis produces.
+
+## Built-in templates
+
+Three templates are available out of the box:
+
+- **General summary** — a concise overview of the recording content
+- **Meeting protocol** — structured output with participants, decisions, and action items
+- **Chapter markers** — time-coded sections with titles, useful for long recordings
+
+Pick the template that matches the nature of your content.
+
+## Custom prompts
+
+Instead of a template, write your own prompt. The model receives the full transcript text plus your prompt and returns whatever you ask for. Keep prompts direct and concrete. Avoid asking for information the transcript does not contain — the model will fill in gaps with guesses if pushed.
+
+## Chapter hints and agenda
+
+For long recordings with a known agenda, paste the agenda into the chapter hints field (one topic per line). The model uses this as context to produce more accurate chapter markers and to map discussion to the right agenda items.
+
+## Running multiple analyses
+
+You can run analysis as many times as you like, with different templates or prompts. Each result is saved separately and displayed in the analysis history. From there you can compare outputs, delete older results, or re-run any configuration.

--- a/frontend/src/help/en/09-translation.md
+++ b/frontend/src/help/en/09-translation.md
@@ -1,0 +1,13 @@
+# Translation
+
+## What translation produces
+
+Translation generates a parallel set of utterances in your chosen target language, aligned one-to-one with the source. Every source utterance maps to a translated utterance at the same position. The source transcript is not replaced — translation adds a second view accessible via the view switcher in the **Subtitle Editor**. Once produced, the translation is saved and persists across sessions.
+
+## Choosing a target language
+
+Select the target language from the dropdown before running translation. The list of supported languages depends on your configured LLM provider. For best quality, choose a well-supported language. Less common languages may produce acceptable but uneven results depending on the model.
+
+## Manual vs bundle
+
+You can trigger translation manually from the detail view at any time after transcription is complete. Alternatively, include a target language in a bundle configuration to have translation run automatically as part of the pipeline. In a bundle, translation runs after refinement and analysis, so downstream translation sees the full cleaned text. See **Refinement** for more on how pipeline steps compose.

--- a/frontend/src/help/en/10-refinement.md
+++ b/frontend/src/help/en/10-refinement.md
@@ -1,0 +1,17 @@
+# Refinement
+
+## What refinement does
+
+Refinement runs a language model cleanup pass over your transcript. It removes filler words (um, uh, you know), fixes speaker attribution errors where the wrong speaker was tagged mid-sentence, and smooths fragmented or run-on sentences into readable prose. The original transcript is fully preserved — refinement produces a separate view, not an in-place edit. It stays in the source language; it is not a translation.
+
+## When it helps
+
+Refinement is most useful for noisy sources: informal conversations, interviews, group discussions with crosstalk, or any recording where fillers and disfluencies are dense. It also helps when diarization made attribution mistakes across adjacent utterances. The refined transcript is often significantly more readable than the raw ASR output.
+
+## When to skip it
+
+For clean, single-speaker recordings — lectures, voiceovers, prepared speeches — the raw ASR output is typically already high-quality. Running refinement adds LLM cost and processing time without meaningful gain. Skip it when the original already reads well.
+
+## How it composes with other steps
+
+In a bundle pipeline, refinement always runs before analysis and translation. That means downstream steps receive the cleaned text, not the raw ASR output. If you run refinement manually after analysis has already completed, the existing analysis results are not updated — re-run analysis if you want it to reflect the refined version. See **Analysis** and **Translation** for how those steps use the transcript.

--- a/frontend/src/help/en/11-format-viewer.md
+++ b/frontend/src/help/en/11-format-viewer.md
@@ -1,0 +1,23 @@
+# Format Viewer
+
+## The four formats
+
+The detail view offers four export formats, each suited to different workflows:
+
+- **SRT** — The most widely supported subtitle format. Numbered entries with `HH:MM:SS,mmm` timestamps. Works with virtually every video player and editing tool.
+- **VTT** — The modern WebVTT standard designed for HTML5 video. Structurally similar to SRT but with cleaner syntax and native browser support.
+- **JSON** — Structured data containing everything: speaker labels, word-level timestamps, and confidence scores. The right choice when you want to process the transcript programmatically.
+- **TXT** — Plain text with speaker labels but no timestamps. Easy to read, share, or paste into a document.
+
+## Downloading
+
+Each format has its own tab. Click a tab to preview the content, then hit **Download** to save the file. Speaker names assigned in Speaker Mapping are reflected in all four formats.
+
+## Which format to pick?
+
+| Goal | Best format |
+|---|---|
+| Add subtitles to a video | SRT or VTT |
+| Post-process programmatically | JSON |
+| Read or share the transcript | TXT |
+| Embed in a web player | VTT |

--- a/frontend/src/help/en/12-presets.md
+++ b/frontend/src/help/en/12-presets.md
@@ -1,0 +1,17 @@
+# Presets
+
+## Transcription presets
+
+A transcription preset saves your preferred combination of language, quality level, diarization toggle, initial prompt, and hotwords. Select a saved preset from the Upload or Record view instead of configuring each option manually every time. Create and manage presets on the **Presets** page, accessible from the header.
+
+## Analysis presets
+
+An analysis preset stores a template or custom prompt together with the output language, chapter hints, and agenda. Useful for repeated analysis patterns — for example, "generate a meeting protocol in English using a fixed agenda". Select the preset when running analysis on any transcription.
+
+## Refinement presets
+
+A refinement preset saves a single context field: a short description that helps the LLM make better cleanup decisions — for example, "technical interview about databases". It's the simplest preset type, but it can noticeably improve refinement quality for consistent recording scenarios.
+
+## Editing and deleting
+
+Open the **Presets** page to edit any preset or remove it entirely. Deleting a preset only removes it from the dropdown — it has no effect on past transcriptions that used it. Deletion is permanent.

--- a/frontend/src/help/en/13-bundles.md
+++ b/frontend/src/help/en/13-bundles.md
@@ -1,0 +1,23 @@
+# Bundles
+
+## What a bundle is
+
+A bundle is a named composition of pipeline stages: transcription, refinement, analysis, and translation. Each stage is optional except transcription, and each stage slot holds one preset (or a target language for translation). Selecting a bundle on the Upload or Record view means all configured stages run automatically in sequence after transcription completes — no manual triggering required.
+
+## The pipeline
+
+![Bundle pipeline](./assets/bundle-pipeline.svg)
+
+Stages always execute in order: **transcription → refinement → analysis → translation**. Each stage receives the output of the previous one — refinement improves the raw transcript, analysis reads the refined text, and translation works from the analysis result or the transcript if no analysis is included.
+
+## The default bundle and auto-run
+
+You can mark one bundle as the default. It will be pre-selected for every new upload and recording. Once transcription finishes, the remaining stages start automatically and progress indicators show each stage's status. If an individual stage fails, you can dismiss the error and continue without re-running the whole pipeline.
+
+## Creating and using bundles
+
+Create bundles on the **Presets** page by picking one preset per stage and giving the bundle a name. Mark it as default if you want it applied automatically. On the Upload or Record view, switch the active bundle via the bundle dropdown at any time before submitting.
+
+## Bundle or manual steps?
+
+Use a bundle when you apply the same pipeline repeatedly — for example, "every meeting recording: refine, then summarize in English, then translate to German". Use manual steps for one-off recordings that need different treatment or where you want to inspect intermediate results before proceeding.

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -373,5 +373,28 @@
     "logout": "Abmelden",
     "loadError": "Diese Ansicht konnte nicht geladen werden. Bitte laden Sie die Seite neu.",
     "reload": "Neu laden"
+  },
+  "help": {
+    "open": "Hilfe öffnen",
+    "close": "Hilfe schließen",
+    "title": "Hilfe",
+    "emptyStateHint": "Neu hier?",
+    "emptyStateLink": "Einführung öffnen",
+    "missingContent": "Inhalt folgt in Kürze.",
+    "sections": {
+      "getting-started": "Einführung",
+      "archive": "Archiv",
+      "upload": "Hochladen",
+      "record": "Aufnehmen",
+      "transcription-settings": "Transkriptionseinstellungen",
+      "subtitle-editor": "Untertitel-Editor",
+      "speaker-mapping": "Sprecher zuordnen",
+      "analysis": "Analyse",
+      "translation": "Übersetzung",
+      "refinement": "Verfeinerung",
+      "format-viewer": "Formatansicht",
+      "presets": "Voreinstellungen",
+      "bundles": "Bundles"
+    }
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -373,5 +373,28 @@
     "logout": "Logout",
     "loadError": "Failed to load this view. Please reload the page.",
     "reload": "Reload"
+  },
+  "help": {
+    "open": "Open help",
+    "close": "Close help",
+    "title": "Help",
+    "emptyStateHint": "New here?",
+    "emptyStateLink": "Open the Getting Started guide",
+    "missingContent": "Content coming soon.",
+    "sections": {
+      "getting-started": "Getting Started",
+      "archive": "Archive",
+      "upload": "Upload",
+      "record": "Record",
+      "transcription-settings": "Transcription Settings",
+      "subtitle-editor": "Subtitle Editor",
+      "speaker-mapping": "Speaker Mapping",
+      "analysis": "Analysis",
+      "translation": "Translation",
+      "refinement": "Refinement",
+      "format-viewer": "Format Viewer",
+      "presets": "Presets",
+      "bundles": "Bundles"
+    }
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,3 +3,9 @@
 body {
   background-color: #111827;
 }
+
+@layer base {
+  button:not(:disabled) {
+    cursor: pointer;
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,8 +4,6 @@ body {
   background-color: #111827;
 }
 
-@layer base {
-  button:not(:disabled) {
-    cursor: pointer;
-  }
+button:not(:disabled) {
+  cursor: pointer;
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -61,6 +61,10 @@ interface AppState {
   setRefinementPresets: (presets: RefinementPreset[]) => void
   setBundles: (bundles: PresetBundle[]) => void
   setActiveBundleId: (id: string | null) => void
+  helpOpen: boolean
+  helpInitialSection: string | null
+  setHelpOpen: (open: boolean, initialSection?: string | null) => void
+  closeHelp: () => void
   clearRefinement: () => void
   reset: () => void
 }
@@ -146,6 +150,11 @@ export const useStore = create<AppState>((set, get) => ({
   setRefinementPresets: (presets) => set({ refinementPresets: presets }),
   setBundles: (bundles) => set({ bundles }),
   setActiveBundleId: (id) => set({ activeBundleId: id }),
+  helpOpen: false,
+  helpInitialSection: null,
+  setHelpOpen: (open, initialSection) =>
+    set({ helpOpen: open, helpInitialSection: initialSection ?? null }),
+  closeHelp: () => set({ helpOpen: false }),
   clearRefinement: () => set({ refinedUtterances: null, refinementMetadata: null, activeView: 'original' as const }),
   reset: () => set({
     currentView: 'archive' as const,


### PR DESCRIPTION
## Summary

- Adds a context-aware help drawer accessible via a `?` button in the header, covering all 13 feature areas (Getting Started, Archive, Upload, Record, Transcription Settings, Subtitle Editor, Speaker Mapping, Analysis, Translation, Refinement, Format Viewer, Presets, Bundles)
- Full bilingual content in English and German (~200 words per section), with inline SVG flow diagrams for Getting Started and Bundles
- Lazy-loaded as a separate chunk (~213 KB / 69 KB gzipped) — zero impact on main bundle
- Context-aware: opens to the section matching the current view (archive → Getting Started, upload → Upload, detail → Subtitle Editor, etc.)
- Archive empty-state hint ("New here? Open the Getting Started guide →") for first-time user discoverability
- Accessible: dialog semantics, focus trap, keyboard navigation (Escape to close, Tab cycling)
- Clickable diagram lightbox (click any SVG to view at 90% viewport width)
- Restores `cursor: pointer` on all buttons (Tailwind 4 preflight regression)

## Architecture

- Content: 26 markdown files (`frontend/src/help/{en,de}/*.md`) rendered via `react-markdown` + `remark-gfm` + `rehype-slug`
- Components: `HelpDrawer/` (drawer shell, sidebar TOC, markdown content renderer, section metadata)
- State: `helpOpen` / `helpInitialSection` in Zustand store
- Integration: lazy-imported in `App.tsx`, triggered from `Header.tsx` and `TranscriptionList.tsx`