### PR TITLE
fix: make help drawer usable on mobile

### DIFF
--- a/frontend/src/components/HelpDrawer/HelpDrawer.tsx
+++ b/frontend/src/components/HelpDrawer/HelpDrawer.tsx
@@ -106,6 +106,20 @@ export function HelpDrawer() {
             ✕
           </button>
         </div>
+        <div className="md:hidden px-4 py-2 border-b border-gray-700">
+          <select
+            value={activeId}
+            onChange={(e) => setActiveId(e.target.value as HelpSectionId)}
+            aria-label={t('help.title')}
+            className="w-full bg-gray-700 text-white text-sm rounded px-3 py-2"
+          >
+            {sections.map((section) => (
+              <option key={section.id} value={section.id}>
+                {t(`help.sections.${section.id}`)}
+              </option>
+            ))}
+          </select>
+        </div>
         <div className="flex flex-1 min-h-0">
           <HelpSidebar activeId={activeId} onSelect={setActiveId} />
           <HelpContent sectionId={activeId} />

--- a/frontend/src/components/HelpDrawer/HelpSidebar.tsx
+++ b/frontend/src/components/HelpDrawer/HelpSidebar.tsx
@@ -13,7 +13,7 @@ export function HelpSidebar({ activeId, onSelect }: HelpSidebarProps) {
   return (
     <nav
       aria-label={t('help.title')}
-      className="w-[200px] shrink-0 border-r border-gray-700 overflow-y-auto py-4"
+      className="hidden md:block w-[200px] shrink-0 border-r border-gray-700 overflow-y-auto py-4"
     >
       <ul className="space-y-1">
         {sections.map((section) => {


### PR DESCRIPTION
Closes #111

The help drawer was unusable on mobile because the sidebar (`w-[200px] shrink-0`) consumed most of the viewport width on small screens, leaving the content cramped to ~150px.

## Fix

- Hide the sidebar (`hidden md:block`) on viewports below the `md` breakpoint (768px).
- Render a section `<select>` at the top of the drawer on mobile only (`md:hidden`).

The same `activeId` state drives both selectors, so behavior is identical — only the section-picker UI changes by viewport.

Desktop is unchanged (sidebar visible, no dropdown shown).