### PR TITLE
fix: device permission UX (#109)

### DIFF
--- a/frontend/src/components/Recorder/RecordingSources.tsx
+++ b/frontend/src/components/Recorder/RecordingSources.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getSystemAudioSupport } from '../../utils/platformDetect'
+import { useDevicePermission } from '../../utils/devicePermissions'
 import { SourceCard } from './SourceCard'
 
 const systemAudioSupport = getSystemAudioSupport()
@@ -44,25 +45,29 @@ export function RecordingSources(props: RecordingSourcesProps) {
   const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[]>([])
   const [videoDevices, setVideoDevices] = useState<MediaDeviceInfo[]>([])
 
+  const micPermission = useDevicePermission('mic')
+  const cameraPermission = useDevicePermission('camera')
+
   const cameraDisabled = captureSystemAudio
-  const effectiveCamera = useCamera && !cameraDisabled
-  const valid = useMicrophone || captureSystemAudio || effectiveCamera
+  const validMic = useMicrophone && micPermission.state !== 'denied'
+  const validCamera = useCamera && !cameraDisabled && cameraPermission.state !== 'denied'
+  const valid = validMic || captureSystemAudio || validCamera
 
   useEffect(() => {
     onValidityChange?.(valid)
   }, [valid, onValidityChange])
 
-  async function enumerateWithPermission(requestVideo: boolean) {
+  async function enumerateWithPermission(kind: 'audio' | 'video') {
     try {
-      const constraints: MediaStreamConstraints = { audio: true }
-      if (requestVideo) constraints.video = true
+      const constraints: MediaStreamConstraints =
+        kind === 'audio' ? { audio: true } : { video: true }
       const stream = await navigator.mediaDevices.getUserMedia(constraints)
       stream.getTracks().forEach((tr) => tr.stop())
       const devices = await navigator.mediaDevices.enumerateDevices()
       setAudioDevices(devices.filter((d) => d.kind === 'audioinput'))
       setVideoDevices(devices.filter((d) => d.kind === 'videoinput'))
     } catch {
-      // Permission denied
+      // Permission denied — the permission hook picks this up via onchange or the next refresh.
     }
   }
 
@@ -72,7 +77,7 @@ export function RecordingSources(props: RecordingSourcesProps) {
         const devices = await navigator.mediaDevices.enumerateDevices()
         const hasAudioLabels = devices.some((d) => d.kind === 'audioinput' && d.label)
         if (!hasAudioLabels) {
-          await enumerateWithPermission(false)
+          await enumerateWithPermission('audio')
         } else {
           setAudioDevices(devices.filter((d) => d.kind === 'audioinput'))
           setVideoDevices(devices.filter((d) => d.kind === 'videoinput'))
@@ -90,7 +95,7 @@ export function RecordingSources(props: RecordingSourcesProps) {
     if (!useCamera || cameraDisabled) return
     const hasVideoLabels = videoDevices.some((d) => d.label)
     if (!hasVideoLabels) {
-      enumerateWithPermission(true)
+      enumerateWithPermission('video')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- runs once per camera toggle, not on every device list change
   }, [useCamera, cameraDisabled])
@@ -105,6 +110,22 @@ export function RecordingSources(props: RecordingSourcesProps) {
     }
   }, [captureSystemAudio, audioDevices, audioDeviceId, secondAudioDeviceId, onSecondAudioDeviceChange])
 
+  const makeDeniedBanner = (sourceLabel: string, onRetry: () => void) => (
+    <div className="bg-red-900/30 border border-red-700 rounded px-3 py-2 text-xs flex items-start gap-3">
+      <span className="text-red-400 text-sm" aria-hidden="true">!</span>
+      <div className="flex-1 min-w-0">
+        <p className="text-red-200">{t('recorder.permissionDenied', { source: sourceLabel })}</p>
+        <p className="text-red-400/80 mt-1">{t('recorder.permissionRecovery')}</p>
+      </div>
+      <button
+        onClick={onRetry}
+        className="shrink-0 px-2 py-1 bg-red-700 hover:bg-red-600 text-white rounded text-xs"
+      >
+        {t('recorder.permissionRetry')}
+      </button>
+    </div>
+  )
+
   return (
     <div className="flex flex-col gap-3">
       <SourceCard
@@ -113,6 +134,8 @@ export function RecordingSources(props: RecordingSourcesProps) {
         enabled={useMicrophone}
         onToggle={onUseMicrophoneChange}
         recording={recording}
+        permission={micPermission.state}
+        deniedBanner={makeDeniedBanner(t('recorder.sourceMicrophone'), micPermission.refresh)}
       >
         <div className="flex flex-col gap-1 min-w-0 sm:flex-row sm:items-center sm:gap-3">
           <label className="text-xs text-gray-400 sm:min-w-24 sm:shrink-0">{t('recorder.selectMic')}</label>
@@ -176,6 +199,8 @@ export function RecordingSources(props: RecordingSourcesProps) {
         disabled={cameraDisabled}
         disabledReason={t('recorder.sourcesCameraDisabledBySystemAudio')}
         recording={recording}
+        permission={cameraPermission.state}
+        deniedBanner={makeDeniedBanner(t('recorder.sourceCamera'), cameraPermission.refresh)}
       >
         <div className="flex flex-col gap-1 min-w-0 sm:flex-row sm:items-center sm:gap-3">
           <label className="text-xs text-gray-400 sm:min-w-24 sm:shrink-0">{t('recorder.selectCamera')}</label>

--- a/frontend/src/components/Recorder/RecordingSources.tsx
+++ b/frontend/src/components/Recorder/RecordingSources.tsx
@@ -111,7 +111,7 @@ export function RecordingSources(props: RecordingSourcesProps) {
   }, [captureSystemAudio, audioDevices, audioDeviceId, secondAudioDeviceId, onSecondAudioDeviceChange])
 
   const makeDeniedBanner = (sourceLabel: string, onRetry: () => void) => (
-    <div className="bg-red-900/30 border border-red-700 rounded px-3 py-2 text-xs flex items-start gap-3">
+    <div role="alert" className="bg-red-900/30 border border-red-700 rounded px-3 py-2 text-xs flex items-start gap-3">
       <span className="text-red-400 text-sm" aria-hidden="true">!</span>
       <div className="flex-1 min-w-0">
         <p className="text-red-200">{t('recorder.permissionDenied', { source: sourceLabel })}</p>

--- a/frontend/src/components/Recorder/SourceCard.tsx
+++ b/frontend/src/components/Recorder/SourceCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import type { DevicePermission } from '../../utils/devicePermissions'
 
 interface SourceCardProps {
   icon: ReactNode
@@ -9,6 +10,8 @@ interface SourceCardProps {
   disabledReason?: string
   recording?: boolean
   children?: ReactNode
+  permission?: DevicePermission
+  deniedBanner?: ReactNode
 }
 
 export function SourceCard({
@@ -20,9 +23,12 @@ export function SourceCard({
   disabledReason,
   recording = false,
   children,
+  permission,
+  deniedBanner,
 }: SourceCardProps) {
   const interactive = !disabled && !recording
   const effectiveOn = !disabled && enabled
+  const showDenied = permission === 'denied' && !disabled && enabled
 
   return (
     <div
@@ -60,7 +66,10 @@ export function SourceCard({
       {disabled && disabledReason && (
         <p className="mt-2 text-xs text-gray-500">{disabledReason}</p>
       )}
-      {!disabled && enabled && children && (
+      {showDenied && deniedBanner && (
+        <div className="mt-3">{deniedBanner}</div>
+      )}
+      {!showDenied && !disabled && enabled && children && (
         <div className="mt-3">{children}</div>
       )}
     </div>

--- a/frontend/src/components/Recorder/useMediaRecorder.ts
+++ b/frontend/src/components/Recorder/useMediaRecorder.ts
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
+import { inferFromError } from '../../utils/devicePermissions'
 
 export type RecorderState = 'idle' | 'recording' | 'paused' | 'stopped'
 
@@ -195,22 +196,32 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
           recordingStream = displayStream
         }
       } else {
-        // Standard path: microphone (with optional system audio mixing)
-        const constraints: MediaStreamConstraints = {
-          audio: options.audioDeviceId
-            ? { deviceId: { exact: options.audioDeviceId } }
-            : true,
-        }
-        if (options.useCamera && !options.captureSystemAudio) {
-          constraints.video = options.videoDeviceId
-            ? { deviceId: { exact: options.videoDeviceId } }
-            : true
-        }
+        // Standard path: microphone (with optional system audio mixing and/or camera)
+        const audioConstraint: MediaTrackConstraints | boolean = options.audioDeviceId
+          ? { deviceId: { exact: options.audioDeviceId } }
+          : true
 
-        const micStream = await navigator.mediaDevices.getUserMedia(constraints)
+        const micStream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraint })
         streamRef.current = micStream
 
-        recordingStream = micStream
+        let cameraStream: MediaStream | null = null
+        if (options.useCamera && !options.captureSystemAudio) {
+          const videoConstraint: MediaTrackConstraints | boolean = options.videoDeviceId
+            ? { deviceId: { exact: options.videoDeviceId } }
+            : true
+          try {
+            cameraStream = await navigator.mediaDevices.getUserMedia({ video: videoConstraint })
+          } catch (err) {
+            micStream.getTracks().forEach((t) => t.stop())
+            streamRef.current = null
+            setError(inferFromError(err) === 'denied' ? 'cameraDenied' : 'cameraFailed')
+            return
+          }
+        }
+
+        recordingStream = cameraStream
+          ? new MediaStream([...micStream.getTracks(), ...cameraStream.getVideoTracks()])
+          : micStream
 
         if (options.captureSystemAudio) {
           if (options.secondAudioDeviceId) {
@@ -332,8 +343,8 @@ export function useMediaRecorder(options: UseMediaRecorderOptions = {}): UseMedi
     } catch (err) {
       if (options.captureSystemAudio && options.useMicrophone === false) {
         setError('systemAudioFailed')
-      } else if (options.useCamera && err instanceof DOMException && err.name === 'NotAllowedError') {
-        setError('cameraFailed')
+      } else if (inferFromError(err) === 'denied') {
+        setError('micDenied')
       } else {
         setError('micRequired')
       }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -372,7 +372,7 @@
     "sourceCamera": "Kamera",
     "sourceSystemAudio": "Systemaudio",
     "permissionDenied": "{{source}}-Zugriff ist blockiert.",
-    "permissionRecovery": "Erlauben Sie den Zugriff in den Website-Einstellungen Ihres Browsers und klicken Sie dann auf \"Erneut versuchen\".",
+    "permissionRecovery": "Erlauben Sie den Zugriff in den Website-Einstellungen Ihres Browsers und klicken Sie dann auf „Erneut versuchen“.",
     "permissionRetry": "Erneut versuchen",
     "micDenied": "Mikrofonzugriff wurde verweigert. Erlauben Sie den Zugriff in den Website-Einstellungen Ihres Browsers und versuchen Sie es erneut.",
     "cameraDenied": "Kamerazugriff wurde verweigert. Erlauben Sie den Zugriff in den Website-Einstellungen Ihres Browsers und versuchen Sie es erneut."

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -370,7 +370,12 @@
     "sourcesCameraDisabledBySystemAudio": "Nicht verfügbar, solange Systemaudio aktiv ist",
     "sourceMicrophone": "Mikrofon",
     "sourceCamera": "Kamera",
-    "sourceSystemAudio": "Systemaudio"
+    "sourceSystemAudio": "Systemaudio",
+    "permissionDenied": "{{source}}-Zugriff ist blockiert.",
+    "permissionRecovery": "Erlauben Sie den Zugriff in den Website-Einstellungen Ihres Browsers und klicken Sie dann auf \"Erneut versuchen\".",
+    "permissionRetry": "Erneut versuchen",
+    "micDenied": "Mikrofonzugriff wurde verweigert. Erlauben Sie den Zugriff in den Website-Einstellungen Ihres Browsers und versuchen Sie es erneut.",
+    "cameraDenied": "Kamerazugriff wurde verweigert. Erlauben Sie den Zugriff in den Website-Einstellungen Ihres Browsers und versuchen Sie es erneut."
   },
   "player": {
     "subtitles": "Untertitel",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -370,7 +370,12 @@
     "sourcesCameraDisabledBySystemAudio": "Not available while System audio is on",
     "sourceMicrophone": "Microphone",
     "sourceCamera": "Camera",
-    "sourceSystemAudio": "System audio"
+    "sourceSystemAudio": "System audio",
+    "permissionDenied": "{{source}} access is blocked.",
+    "permissionRecovery": "Allow it in your browser's site settings, then click Retry.",
+    "permissionRetry": "Retry",
+    "micDenied": "Microphone access was denied. Allow it in your browser's site settings and try again.",
+    "cameraDenied": "Camera access was denied. Allow it in your browser's site settings and try again."
   },
   "player": {
     "subtitles": "Subtitles",

--- a/frontend/src/utils/devicePermissions.ts
+++ b/frontend/src/utils/devicePermissions.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState, useCallback } from 'react'
+
+export type DevicePermission = 'prompt' | 'granted' | 'denied'
+export type DeviceKind = 'mic' | 'camera'
+
+const permissionName: Record<DeviceKind, PermissionName> = {
+  mic: 'microphone' as PermissionName,
+  camera: 'camera' as PermissionName,
+}
+
+export async function queryDevicePermission(kind: DeviceKind): Promise<DevicePermission> {
+  if (!navigator.permissions?.query) return 'prompt'
+  try {
+    const status = await navigator.permissions.query({ name: permissionName[kind] })
+    return status.state as DevicePermission
+  } catch {
+    // Older Safari throws TypeError for microphone/camera names
+    return 'prompt'
+  }
+}
+
+export function inferFromError(err: unknown): DevicePermission | null {
+  if (err instanceof DOMException && err.name === 'NotAllowedError') return 'denied'
+  return null
+}
+
+export function useDevicePermission(kind: DeviceKind): {
+  state: DevicePermission
+  refresh: () => void
+} {
+  const [state, setState] = useState<DevicePermission>('prompt')
+
+  const refresh = useCallback(() => {
+    queryDevicePermission(kind).then(setState)
+  }, [kind])
+
+  useEffect(() => {
+    let cancelled = false
+    let statusRef: PermissionStatus | null = null
+    const handler = () => {
+      if (!cancelled && statusRef) setState(statusRef.state as DevicePermission)
+    }
+
+    async function init() {
+      if (!navigator.permissions?.query) {
+        setState('prompt')
+        return
+      }
+      try {
+        const status = await navigator.permissions.query({ name: permissionName[kind] })
+        if (cancelled) return
+        setState(status.state as DevicePermission)
+        statusRef = status
+        status.addEventListener('change', handler)
+      } catch {
+        if (!cancelled) setState('prompt')
+      }
+    }
+
+    init()
+    return () => {
+      cancelled = true
+      if (statusRef) statusRef.removeEventListener('change', handler)
+    }
+  }, [kind])
+
+  return { state, refresh }
+}

--- a/frontend/src/utils/devicePermissions.ts
+++ b/frontend/src/utils/devicePermissions.ts
@@ -4,8 +4,8 @@ export type DevicePermission = 'prompt' | 'granted' | 'denied'
 export type DeviceKind = 'mic' | 'camera'
 
 const permissionName: Record<DeviceKind, PermissionName> = {
-  mic: 'microphone' as PermissionName,
-  camera: 'camera' as PermissionName,
+  mic: 'microphone',
+  camera: 'camera',
 }
 
 export async function queryDevicePermission(kind: DeviceKind): Promise<DevicePermission> {


### PR DESCRIPTION
Closes #109

Resolves the three bugs reported in the issue:

1. **Empty dropdowns with no feedback when permission is blocked** → each source card now shows a clear denied-state banner (red outline, explanation, recovery text, and a **Retry** button) when its permission is `denied`. `role=\"alert\"` ensures screen readers announce it.
2. **Wrong \"microphone missing\" error when only camera was denied** → `useMediaRecorder` now requests mic and camera separately when both are enabled, so `NotAllowedError` is attributed to the correct track. Two new error codes (`micDenied`, `cameraDenied`) distinguish permission denial from other failures.
3. **Microphone re-requested during camera enumeration** → `enumerateWithPermission('video')` now uses `{video: true}` only, not `{audio: true, video: true}`.

Plus: validity gating now excludes denied sources — if mic is the only source and permission is denied, the \"Enable at least one source\" hint appears and Start Recording is disabled.

## Components

**New:** `frontend/src/utils/devicePermissions.ts` — `useDevicePermission(kind)` hook that subscribes to `PermissionStatus.onchange` so site-settings changes in another tab auto-update the UI.

**Modified:**
- `SourceCard` — two new optional props (`permission`, `deniedBanner`) with a truth-table-driven body render.
- `RecordingSources` — consumes one permission hook per source, builds and passes the banner JSX; extends the validity check.
- `useMediaRecorder` — split `getUserMedia`; centralized `NotAllowedError` detection via `inferFromError` helper.
- `i18n/en.json` + `i18n/de.json` — 5 new keys per language (permissionDenied, permissionRecovery, permissionRetry, micDenied, cameraDenied).

## Verification

- `npx tsc --noEmit`, `npm run lint`, `npm run build` all pass.
- Manual browser smoke test: granted path renders the usual picker; simulated denied state (via `navigator.permissions.query` monkey-patch) shows the banner with Retry, the validity hint, and disables Start Recording.