### PR TITLE
fix: UI polish pass — model labels, single-option dropdown, recorder button padding

### DIFF
--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -131,7 +131,7 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
               const m = models[0]
               const label = t(`settings.modelLabels.${m}`, '')
               return (
-                <div className="text-sm text-white px-3 py-1.5">
+                <div className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
                   {label ? `${label} (${m})` : m}
                 </div>
               )

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -125,16 +125,30 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
         </div>
         <div className="min-w-0">
           <label className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
-          <select
-            value={values.model}
-            onChange={(e) => onChange({ model: e.target.value })}
-            className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
-          >
-            {(config?.whisper_models || []).map((m) => {
+          {(() => {
+            const models = config?.whisper_models || []
+            if (models.length === 1) {
+              const m = models[0]
               const label = t(`settings.modelLabels.${m}`, '')
-              return <option key={m} value={m}>{label ? `${label} (${m})` : m}</option>
-            })}
-          </select>
+              return (
+                <div className="text-sm text-white px-3 py-1.5">
+                  {label ? `${label} (${m})` : m}
+                </div>
+              )
+            }
+            return (
+              <select
+                value={values.model}
+                onChange={(e) => onChange({ model: e.target.value })}
+                className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+              >
+                {models.map((m) => {
+                  const label = t(`settings.modelLabels.${m}`, '')
+                  return <option key={m} value={m}>{label ? `${label} (${m})` : m}</option>
+                })}
+              </select>
+            )
+          })()}
         </div>
         <div className="flex items-center gap-2 py-1.5 min-w-0">
           <input

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -133,11 +133,15 @@ function TranscriptionPresetsList() {
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
-            {models.length === 1 ? (
-              <div className="text-sm text-white px-3 py-1.5">
-                {t(`settings.modelLabels.${models[0]}`, { defaultValue: models[0] })}
-              </div>
-            ) : (
+            {models.length === 1 ? (() => {
+              const m = models[0]
+              const label = t(`settings.modelLabels.${m}`, '')
+              return (
+                <div className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
+                  {label ? `${label} (${m})` : m}
+                </div>
+              )
+            })() : (
               <select
                 value={form.model ?? defaultModel}
                 onChange={(e) => setForm({ ...form, model: e.target.value })}

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -132,15 +132,21 @@ function TranscriptionPresetsList() {
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
-            <select
-              value={form.model ?? defaultModel}
-              onChange={(e) => setForm({ ...form, model: e.target.value })}
-              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
-            >
-              {models.map((m) => (
-                <option key={m} value={m}>{t(`settings.modelLabels.${m}`, { defaultValue: m })}</option>
-              ))}
-            </select>
+            {models.length === 1 ? (
+              <div className="text-sm text-white px-3 py-1.5">
+                {t(`settings.modelLabels.${models[0]}`, { defaultValue: models[0] })}
+              </div>
+            ) : (
+              <select
+                value={form.model ?? defaultModel}
+                onChange={(e) => setForm({ ...form, model: e.target.value })}
+                className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                {models.map((m) => (
+                  <option key={m} value={m}>{t(`settings.modelLabels.${m}`, { defaultValue: m })}</option>
+                ))}
+              </select>
+            )}
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">{t('settings.hotwords')}</label>

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -41,7 +41,8 @@ function TranscriptionPresetsList() {
 
   const openEdit = (p: TranscriptionPreset) => {
     setEditingId(p.id)
-    setForm({ name: p.name, language: p.language, model: p.model, initial_prompt: p.initial_prompt, hotwords: p.hotwords })
+    const model = models.length === 1 ? models[0] : p.model
+    setForm({ name: p.name, language: p.language, model, initial_prompt: p.initial_prompt, hotwords: p.hotwords })
     setShowForm(true)
   }
 

--- a/frontend/src/components/Recorder/RecorderControls.tsx
+++ b/frontend/src/components/Recorder/RecorderControls.tsx
@@ -122,7 +122,7 @@ export function RecorderControls({
             <button
               onClick={onDiscard}
               disabled={uploading}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-red-400 rounded-lg text-sm transition-colors"
+              className="px-6 py-3 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-red-400 rounded-lg font-medium transition-colors"
             >
               {t('recorder.discard')}
             </button>

--- a/frontend/src/help/de/05-transcription-settings.md
+++ b/frontend/src/help/de/05-transcription-settings.md
@@ -8,14 +8,14 @@ Die Sprechererkennung (Diarization) erkennt, wer wann gesprochen hat, und versie
 
 | Stufe | Geschwindigkeit | Hinweis |
 |---|---|---|
-| Draft | Schnellste | Gut für schnelle Vorschauen langer Dateien |
+| Entwurf | Schnellste | Gut für schnelle Vorschauen langer Dateien |
 | Standard | Schnell | — |
-| Good | Mittel | — |
-| Better | Langsam | — |
-| Best (fast) | Schnell/genau | Empfohlene Standardwahl |
-| Best | Langsamste | Maximale Genauigkeit |
+| Gut | Mittel | — |
+| Besser | Langsam | — |
+| Ausgewogen | Schnell/genau | Empfohlene Standardwahl |
+| Beste Qualität | Langsamste | Maximale Genauigkeit |
 
-**Best (fast)** ist für die meisten Anwendungsfälle die richtige Wahl.
+**Ausgewogen** ist für die meisten Anwendungsfälle die richtige Wahl.
 
 ## Erweiterte Optionen
 

--- a/frontend/src/help/en/05-transcription-settings.md
+++ b/frontend/src/help/en/05-transcription-settings.md
@@ -12,10 +12,10 @@ Diarization detects who spoke when and tags each utterance with a label like SPE
 | Standard | Fast | — |
 | Good | Medium | — |
 | Better | Slow | — |
-| Best (fast) | Fast/accurate | Recommended default |
-| Best | Slowest | Maximum accuracy |
+| Balanced | Fast/accurate | Recommended default |
+| Best quality | Slowest | Maximum accuracy |
 
-**Best (fast)** is usually the right choice for most use cases.
+**Balanced** is usually the right choice for most use cases.
 
 ## Advanced options
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -25,9 +25,9 @@
       "base": "Standard",
       "small": "Gut",
       "medium": "Besser",
-      "large-v3-turbo": "Beste (schnell)",
-      "large-v3": "Beste",
-      "large-v2": "Beste"
+      "large-v3-turbo": "Ausgewogen",
+      "large-v3": "Beste Qualität",
+      "large-v2": "Beste Qualität"
     }
   },
   "transcription": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -25,9 +25,9 @@
       "base": "Standard",
       "small": "Good",
       "medium": "Better",
-      "large-v3-turbo": "Best (fast)",
-      "large-v3": "Best",
-      "large-v2": "Best"
+      "large-v3-turbo": "Balanced",
+      "large-v3": "Best quality",
+      "large-v2": "Best quality"
     }
   },
   "transcription": {


### PR DESCRIPTION
## Summary

Bundles three small UI fixes from the recent issue set.

### #119 — Model label renaming
The dropdown had two "Best" entries for `large-v3` and `large-v3-turbo`, which was nonsensical. Renamed just those two tiers so the progression stays coherent:

| Model | Before | After (en) | After (de) |
|---|---|---|---|
| `large-v3-turbo` | Best (fast) | Balanced | Ausgewogen |
| `large-v3` / `large-v2` | Best | Best quality | Beste Qualität |

Lower tiers (`tiny`/`base`/`small`/`medium`) unchanged. Also updated the transcription-settings help doc — including fixing a pre-existing inconsistency where the German help table used English tier labels.

### #118 (model part) — Hide single-option dropdowns
When `WHISPER_MODELS` contains exactly one model, the dropdown is replaced by a static read-only label on both the upload settings panel and the preset form. Multi-option behavior is unchanged.

**Edge case handled:** editing an existing preset whose stored model is no longer in `WHISPER_MODELS` previously left the stale value in form state with no way to fix it (since the control was now a static div) — `form.model` is now reconciled to the only available model on edit, so saving no longer silently persists bad data.

**Not in scope here:** the four `LanguageSelect` usages always render a hardcoded ISO list, so there's no single-option case today. Making the language list backend-configurable (and applying the same treatment) is a separate follow-up.

### #116 — Recorder button padding
In the recorder's stopped state, Transcribe and Discard sat next to each other with mismatched padding and text size. Upgraded Discard to `px-6 py-3 font-medium` so the pair reads as a balanced primary/secondary decision. Color still communicates destructive intent.

### Follow-up tweak during review
A styling unification commit (`8a68dbe`) was added at the end after manual testing: both single-option static labels now share the same \`\"label (key)\"\` content format and a matching \`bg-gray-700\` disabled-field background, so they read as filled-in fields rather than floating captions.

## Closes

- Closes #116
- Closes #118
- Closes #119