### PR TITLE
feat: ENABLED_LANGUAGES allowlist + a11y sweep + polish (Phase 1b)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ LLM_BASE_URL=                     # for local servers (e.g., http://localhost:11
 
 # UI Configuration
 POPULAR_LANGUAGES=de,en,es,fr       # languages pinned at top of dropdowns (comma-separated codes)
+ENABLED_LANGUAGES=                  # allowlist of languages (comma-separated codes); unset = all enabled
 
 # Application
 TEMP_PATH=tmp/transcription-files

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,7 @@ class Settings:
     DATABASE_PATH: str = os.getenv("DATABASE_PATH", "")
 
     POPULAR_LANGUAGES: list[str] = os.getenv("POPULAR_LANGUAGES", "de,en,es,fr").split(",")
+    ENABLED_LANGUAGES: list[str] = [c for c in os.getenv("ENABLED_LANGUAGES", "").split(",") if c]
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "true").lower() in ("true", "1", "yes")
     DEV_MODE: bool = os.getenv("DEV_MODE", "false").lower() in ("true", "1", "yes")
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,7 +27,7 @@ class Settings:
     DATABASE_PATH: str = os.getenv("DATABASE_PATH", "")
 
     POPULAR_LANGUAGES: list[str] = os.getenv("POPULAR_LANGUAGES", "de,en,es,fr").split(",")
-    ENABLED_LANGUAGES: list[str] = [c for c in os.getenv("ENABLED_LANGUAGES", "").split(",") if c]
+    ENABLED_LANGUAGES: list[str] = [c.strip() for c in os.getenv("ENABLED_LANGUAGES", "").split(",") if c.strip()]
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "true").lower() in ("true", "1", "yes")
     DEV_MODE: bool = os.getenv("DEV_MODE", "false").lower() in ("true", "1", "yes")
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -204,6 +204,7 @@ class ConfigResponse(BaseModel):
     llm_available: bool
     logout_url: str
     popular_languages: list[str] = []
+    enabled_languages: list[str] = []
 
 
 # --- Presets ---

--- a/backend/app/routers/config_router.py
+++ b/backend/app/routers/config_router.py
@@ -20,6 +20,7 @@ async def get_config():
         llm_available=bool(settings.LLM_PROVIDER),
         logout_url=settings.LOGOUT_URL,
         popular_languages=settings.POPULAR_LANGUAGES,
+        enabled_languages=settings.ENABLED_LANGUAGES,
     )
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -127,6 +127,7 @@ export interface ConfigResponse {
   llm_available: boolean
   logout_url: string
   popular_languages: string[]
+  enabled_languages: string[]
 }
 
 export interface AnalysisTemplate {

--- a/frontend/src/components/AnalysisView/AnalysisView.tsx
+++ b/frontend/src/components/AnalysisView/AnalysisView.tsx
@@ -731,8 +731,8 @@ export function AnalysisView() {
           {/* Language selector + Generate button */}
           <div className="flex items-center justify-center gap-3">
             <div>
-              <label className="block text-xs text-gray-400 mb-1">{t('editor.outputLanguage')}</label>
-              <LanguageSelect value={language} onChange={setLanguage} className="bg-gray-700 text-white text-sm rounded px-3 py-1.5" />
+              <label htmlFor="analysis-output-language-field" className="block text-xs text-gray-400 mb-1">{t('editor.outputLanguage')}</label>
+              <LanguageSelect id="analysis-output-language-field" value={language} onChange={setLanguage} className="bg-gray-700 text-white text-sm rounded px-3 py-1.5" />
             </div>
             <button
               onClick={handleGenerate}

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -124,20 +124,21 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
           />
         </div>
         <div className="min-w-0">
-          <label className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
+          <label htmlFor="upload-model-field" className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
           {(() => {
             const models = config?.whisper_models || []
             if (models.length === 1) {
               const m = models[0]
               const label = t(`settings.modelLabels.${m}`, '')
               return (
-                <div className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
+                <output id="upload-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
                   {label ? `${label} (${m})` : m}
-                </div>
+                </output>
               )
             }
             return (
               <select
+                id="upload-model-field"
                 value={values.model}
                 onChange={(e) => onChange({ model: e.target.value })}
                 className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -115,8 +115,9 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
       )}
       <div className="flex flex-wrap gap-4 items-end">
         <div className="min-w-0">
-          <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
+          <label htmlFor="upload-language-field" className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
           <LanguageSelect
+            id="upload-language-field"
             value={values.language}
             onChange={(v) => onChange({ language: v })}
             includeAuto

--- a/frontend/src/components/LanguageSelect.tsx
+++ b/frontend/src/components/LanguageSelect.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useEffect, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../store'
 import { LANGUAGES, LANGUAGES_WITH_AUTO, filterEnabledLanguages } from '../utils/languages'
@@ -24,12 +24,18 @@ export function LanguageSelect({ value, onChange, includeAuto, className, disabl
   const popular = popularLanguages.filter((code) => allCodes.includes(code))
   const rest = allCodes.filter((code) => code !== 'auto' && !popular.includes(code))
   const userVisibleCount = allCodes.filter((code) => code !== 'auto').length
+  const collapsedOnly = userVisibleCount === 1 && !includeAuto ? allCodes[0] : null
 
-  if (userVisibleCount === 1 && !includeAuto) {
-    const only = allCodes[0]
+  useEffect(() => {
+    if (collapsedOnly && value !== collapsedOnly) {
+      onChange(collapsedOnly)
+    }
+  }, [collapsedOnly, value, onChange])
+
+  if (collapsedOnly) {
     return (
-      <output id={effectiveId} className={className}>
-        {t(`languages.${only}`, only)}
+      <output id={effectiveId} className={className ? `block ${className}` : 'block'}>
+        {t(`languages.${collapsedOnly}`, collapsedOnly)}
       </output>
     )
   }

--- a/frontend/src/components/LanguageSelect.tsx
+++ b/frontend/src/components/LanguageSelect.tsx
@@ -1,6 +1,7 @@
+import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../store'
-import { LANGUAGES, LANGUAGES_WITH_AUTO } from '../utils/languages'
+import { LANGUAGES, LANGUAGES_WITH_AUTO, filterEnabledLanguages } from '../utils/languages'
 
 interface Props {
   value: string
@@ -8,18 +9,34 @@ interface Props {
   includeAuto?: boolean
   className?: string
   disabled?: boolean
+  id?: string
 }
 
-export function LanguageSelect({ value, onChange, includeAuto, className, disabled }: Props) {
+export function LanguageSelect({ value, onChange, includeAuto, className, disabled, id }: Props) {
   const { t } = useTranslation()
   const popularLanguages = useStore((s) => s.config?.popular_languages) || []
+  const enabledLanguages = useStore((s) => s.config?.enabled_languages) || []
+  const autoId = useId()
+  const effectiveId = id ?? autoId
 
-  const allCodes: readonly string[] = includeAuto ? LANGUAGES_WITH_AUTO : LANGUAGES
+  const baseList: readonly string[] = includeAuto ? LANGUAGES_WITH_AUTO : LANGUAGES
+  const allCodes = filterEnabledLanguages(baseList, enabledLanguages)
   const popular = popularLanguages.filter((code) => allCodes.includes(code))
   const rest = allCodes.filter((code) => code !== 'auto' && !popular.includes(code))
+  const userVisibleCount = allCodes.filter((code) => code !== 'auto').length
+
+  if (userVisibleCount === 1 && !includeAuto) {
+    const only = allCodes[0]
+    return (
+      <output id={effectiveId} className={className}>
+        {t(`languages.${only}`, only)}
+      </output>
+    )
+  }
 
   return (
     <select
+      id={effectiveId}
       value={value}
       onChange={(e) => onChange(e.target.value)}
       className={className}
@@ -31,7 +48,7 @@ export function LanguageSelect({ value, onChange, includeAuto, className, disabl
           {popular.map((code) => (
             <option key={code} value={code}>{t(`languages.${code}`, code)}</option>
           ))}
-          <option disabled>{'───────────'}</option>
+          {rest.length > 0 && <option disabled>{'───────────'}</option>}
         </>
       )}
       {rest.map((code) => (

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -520,6 +520,7 @@ function BundlesList() {
   const transcriptionPresets = useStore((s) => s.transcriptionPresets)
   const analysisPresets = useStore((s) => s.analysisPresets)
   const refinementPresets = useStore((s) => s.refinementPresets)
+  const enabledLanguages = useStore((s) => s.config?.enabled_languages) || []
 
   const emptyForm: PresetBundleCreate = { name: '', transcription_preset_id: null, analysis_preset_id: null, refinement_preset_id: null }
   const [showForm, setShowForm] = useState(false)
@@ -535,12 +536,15 @@ function BundlesList() {
 
   const openEdit = (b: PresetBundle) => {
     setEditingId(b.id)
+    const translateLanguage = b.translate_language && !isLanguageEnabled(b.translate_language, enabledLanguages)
+      ? null
+      : b.translate_language
     setForm({
       name: b.name,
       transcription_preset_id: b.transcription_preset_id,
       analysis_preset_id: b.analysis_preset_id,
       refinement_preset_id: b.refinement_preset_id,
-      translate_language: b.translate_language,
+      translate_language: translateLanguage,
     })
     setShowForm(true)
   }
@@ -721,14 +725,15 @@ function BundlesList() {
             </select>
           </div>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">{t('presets.bundle.translateLanguage')}</label>
+            <label htmlFor="bundle-translate-language-field" className="block text-xs text-gray-400 mb-1">{t('presets.bundle.translateLanguage')}</label>
             <select
+              id="bundle-translate-language-field"
               value={form.translate_language ?? ''}
               onChange={(e) => setForm({ ...form, translate_language: e.target.value || null })}
               className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
             >
               <option value="">{t('presets.bundle.none')}</option>
-              {LANGUAGES.map((code) => (
+              {filterEnabledLanguages(LANGUAGES, enabledLanguages).map((code) => (
                 <option key={code} value={code}>{t(`languages.${code}`)}</option>
               ))}
             </select>

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../../store'
 import { api } from '../../api/client'
-import { LANGUAGES } from '../../utils/languages'
+import { LANGUAGES, filterEnabledLanguages, isLanguageEnabled } from '../../utils/languages'
 import type {
   TranscriptionPreset,
   TranscriptionPresetCreate,
@@ -32,6 +32,7 @@ function TranscriptionPresetsList() {
 
   const models = config?.whisper_models ?? []
   const defaultModel = config?.default_model ?? ''
+  const enabledLanguages = config?.enabled_languages ?? []
 
   const openNew = () => {
     setEditingId(null)
@@ -42,7 +43,8 @@ function TranscriptionPresetsList() {
   const openEdit = (p: TranscriptionPreset) => {
     setEditingId(p.id)
     const model = models.length === 1 ? models[0] : p.model
-    setForm({ name: p.name, language: p.language, model, initial_prompt: p.initial_prompt, hotwords: p.hotwords })
+    const language = p.language && !isLanguageEnabled(p.language, enabledLanguages) ? null : p.language
+    setForm({ name: p.name, language, model, initial_prompt: p.initial_prompt, hotwords: p.hotwords })
     setShowForm(true)
   }
 
@@ -119,14 +121,15 @@ function TranscriptionPresetsList() {
             />
           </div>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
+            <label htmlFor="transcription-preset-language-field" className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
             <select
+              id="transcription-preset-language-field"
               value={form.language ?? ''}
               onChange={(e) => setForm({ ...form, language: e.target.value || null })}
               className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
             >
               <option value="">{t('languages.auto')}</option>
-              {LANGUAGES.map((code) => (
+              {filterEnabledLanguages(LANGUAGES, enabledLanguages).map((code) => (
                 <option key={code} value={code}>{t(`languages.${code}`)}</option>
               ))}
             </select>

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -214,6 +214,7 @@ function AnalysisPresetsList() {
   const { t } = useTranslation()
   const presets = useStore((s) => s.analysisPresets)
   const setPresets = useStore((s) => s.setAnalysisPresets)
+  const enabledLanguages = useStore((s) => s.config?.enabled_languages) || []
 
   const emptyForm: AnalysisPresetCreate = { name: '', template: 'summary', custom_prompt: null, language: null }
   const [showForm, setShowForm] = useState(false)
@@ -229,7 +230,8 @@ function AnalysisPresetsList() {
 
   const openEdit = (p: AnalysisPreset) => {
     setEditingId(p.id)
-    setForm({ name: p.name, template: p.template, custom_prompt: p.custom_prompt, language: p.language })
+    const language = p.language && !isLanguageEnabled(p.language, enabledLanguages) ? null : p.language
+    setForm({ name: p.name, template: p.template, custom_prompt: p.custom_prompt, language })
     setShowForm(true)
   }
 
@@ -326,14 +328,15 @@ function AnalysisPresetsList() {
             </select>
           </div>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
+            <label htmlFor="analysis-preset-language-field" className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
             <select
+              id="analysis-preset-language-field"
               value={form.language ?? ''}
               onChange={(e) => setForm({ ...form, language: e.target.value || null })}
               className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
             >
               <option value="">{t('languages.auto')}</option>
-              {LANGUAGES.map((code) => (
+              {filterEnabledLanguages(LANGUAGES, enabledLanguages).map((code) => (
                 <option key={code} value={code}>{t(`languages.${code}`)}</option>
               ))}
             </select>

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -132,17 +132,18 @@ function TranscriptionPresetsList() {
             </select>
           </div>
           <div>
-            <label className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
+            <label htmlFor="transcription-preset-model-field" className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
             {models.length === 1 ? (() => {
               const m = models[0]
               const label = t(`settings.modelLabels.${m}`, '')
               return (
-                <div className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
+                <output id="transcription-preset-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
                   {label ? `${label} (${m})` : m}
-                </div>
+                </output>
               )
             })() : (
               <select
+                id="transcription-preset-model-field"
                 value={form.model ?? defaultModel}
                 onChange={(e) => setForm({ ...form, model: e.target.value })}
                 className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -329,7 +329,7 @@ function AnalysisPresetsList() {
             </select>
           </div>
           <div>
-            <label htmlFor="analysis-preset-language-field" className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
+            <label htmlFor="analysis-preset-language-field" className="block text-xs text-gray-400 mb-1">{t('editor.outputLanguage')}</label>
             <select
               id="analysis-preset-language-field"
               value={form.language ?? ''}

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -151,9 +151,10 @@ function TranscriptionPresetsList() {
                 onChange={(e) => setForm({ ...form, model: e.target.value })}
                 className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500"
               >
-                {models.map((m) => (
-                  <option key={m} value={m}>{t(`settings.modelLabels.${m}`, { defaultValue: m })}</option>
-                ))}
+                {models.map((m) => {
+                  const label = t(`settings.modelLabels.${m}`, '')
+                  return <option key={m} value={m}>{label ? `${label} (${m})` : m}</option>
+                })}
               </select>
             )}
           </div>

--- a/frontend/src/components/SubtitleEditor/SubtitleEditor.tsx
+++ b/frontend/src/components/SubtitleEditor/SubtitleEditor.tsx
@@ -760,8 +760,9 @@ export function SubtitleEditor({ onOpenSpeakerModal }: SubtitleEditorProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
           <div className="bg-gray-800 border border-gray-700 rounded-lg shadow-xl w-full max-w-sm mx-4 p-5">
             <h3 className="text-sm font-medium text-gray-200 mb-3">{t('editor.translateTo')}</h3>
-            <label className="block text-xs text-gray-400 mb-1">{t('editor.translationLanguage')}</label>
+            <label htmlFor="translation-language-field" className="block text-xs text-gray-400 mb-1">{t('editor.translationLanguage')}</label>
             <LanguageSelect
+              id="translation-language-field"
               value={translateLanguage}
               onChange={setTranslateLanguage}
               disabled={translating}

--- a/frontend/src/utils/languages.ts
+++ b/frontend/src/utils/languages.ts
@@ -25,3 +25,25 @@ export const LANGUAGES = [
 ] as const
 
 export const LANGUAGES_WITH_AUTO = ['auto', ...LANGUAGES] as const
+
+/**
+ * Filter a list of language codes through an allowlist.
+ * Empty allowlist (length 0) is the "no restriction" sentinel → return the full list.
+ * The special 'auto' code is always kept when present in the input list, regardless of allowlist.
+ */
+export function filterEnabledLanguages<T extends string>(
+  list: readonly T[],
+  enabled: readonly string[],
+): T[] {
+  if (enabled.length === 0) return [...list]
+  return list.filter((code) => code === 'auto' || enabled.includes(code))
+}
+
+/**
+ * Check whether a single language code is enabled by the allowlist.
+ * Empty allowlist means all codes are enabled.
+ */
+export function isLanguageEnabled(code: string, enabled: readonly string[]): boolean {
+  if (enabled.length === 0) return true
+  return enabled.includes(code)
+}


### PR DESCRIPTION
## Summary

Follow-up to #123 (Phase 1a), tackling the two pieces we deferred:

1. **Configurable language list** — admins can now restrict the ~100-language list via a new `ENABLED_LANGUAGES` env var, with the same single-option handling Phase 1a added for `WHISPER_MODELS`.
2. **A11y sweep** — every model + language static-label site (and the adjacent `<select>` branches) now has proper `<label htmlFor>` ↔ `id` wiring, replacing dangling labels with labeled `<output>` fields.

Plus two polish commits picked up during live testing.

## `ENABLED_LANGUAGES`

```env
ENABLED_LANGUAGES=de,en,es,fr
```

Comma-separated ISO codes. Unset → empty list → all ~100 languages available (current behavior preserved). Exposed via `/api/config` alongside `whisper_models` and `popular_languages`.

Filter logic lives in a shared helper and applies to:
- Transcription language (upload settings, transcription preset form)
- Translation target (subtitle editor, bundle preset `translate_language`)
- Analysis output language (analysis view, analysis preset form)

Per-feature env vars (`TRANSCRIPTION_LANGUAGES` / `TRANSLATION_LANGUAGES` / …) were considered and rejected as YAGNI. Can be split later if needed.

## Single-option `<output>` in `LanguageSelect`

When the allowlist narrows the list to a single user-visible language (`includeAuto` false), `LanguageSelect` renders a read-only `<output>` instead of a `<select>` — same behavior Phase 1a introduced for the model dropdown.

Two subtle gotchas surfaced in review and were fixed:
- **Value reconciliation:** if the parent's `value` prop doesn't match the collapsed language, the UI would display "German" while the form submitted a stale value. `useEffect` now fires `onChange(collapsedOnly)` to reconcile.
- **Display mode:** `<output>` is `display: inline` by default; caller classNames were written for a `<select>`. `LanguageSelect` now prefixes `block ` to the output's className.

Transcription selectors (`includeAuto=true`) always keep the dropdown because "auto + German" is two meaningful choices.

## Stale-preset reconcile

Mirrors Phase 1a's `form.model` reconcile. On `openEdit` for each of the three preset types:
- **Transcription preset** — disabled stored language → `null` (auto-detect)
- **Analysis preset** — disabled stored language → `null` (auto; `AnalysisView` defaults null to `'en'` at use-time)
- **Bundle preset** — disabled `translate_language` → `null` (= no translation)

## A11y sweep

Every static-label site (model + language) was migrated from `<div>` under a dangling `<label>` to `<output htmlFor=...>` + `<label htmlFor=...>`. The adjacent `<select>` branches got the same `id` for consistency. Sites touched:
- `SettingsPanel` — model + language
- `PresetsPage` TranscriptionPresetsList — model + language
- `PresetsPage` AnalysisPresetsList — language
- `PresetsPage` BundlesList — translate_language
- `AnalysisView` — output language (via `LanguageSelect` `id` prop)
- `SubtitleEditor` — translation language (via `LanguageSelect` `id` prop)

## Polish picked up during live testing

- **Model dropdown option format alignment** — PresetsPage's transcription-preset model dropdown was showing `"Standard"` while SettingsPanel showed `"Standard (base)"`. Both now use the `label (key)` format. Leftover inconsistency the Phase 1a review flagged but we deferred.
- **Analysis preset label fix** — the analysis preset form had its language field labeled "Transcription language" (the generic i18n key) when it's actually the **output** language for the generated summary/protocol. Relabeled to match `AnalysisView`'s "Output language".

## Non-goals (explicit)

- Backend request validation — matches `WHISPER_MODELS` precedent; the UI is the gate, stale values are reconciled on edit.
- Broader a11y audit beyond static-label sites.