### PR TITLE
feat: header unification + mobile burger + inline speaker mapping (Phase 2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -639,6 +639,8 @@ function App() {
                 />
                 <TabBar onSpeakerNamesClick={() => handleOpenSpeakerModal()} />
 
+                <SpeakerMapping isOpen={speakerModalOpen} onClose={() => { setSpeakerModalOpen(false); setFocusSpeaker(undefined) }} focusSpeaker={focusSpeaker} />
+
                 <div className={`mx-6 my-2 ${!file.has_video || playerCollapsed ? 'max-h-[calc(100vh-14rem)]' : 'max-h-[calc(100vh-22rem)]'} overflow-auto`}>
                   {activeTab === 'subtitles' && <SubtitleEditor onOpenSpeakerModal={handleOpenSpeakerModal} />}
                   {activeTab === 'analysis' && <AnalysisView />}
@@ -646,8 +648,6 @@ function App() {
                     <FormatViewer format={activeTab} />
                   )}
                 </div>
-
-                <SpeakerMapping isOpen={speakerModalOpen} onClose={() => { setSpeakerModalOpen(false); setFocusSpeaker(undefined) }} focusSpeaker={focusSpeaker} />
               </Suspense>
             </ChunkErrorBoundary>
           )}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,58 +1,153 @@
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../store'
 
 export function Header() {
   const { t, i18n } = useTranslation()
   const config = useStore((s) => s.config)
+  const [burgerOpen, setBurgerOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   const toggleLanguage = () => {
     i18n.changeLanguage(i18n.language === 'de' ? 'en' : 'de')
   }
 
+  const openHelp = () => {
+    useStore.getState().setHelpOpen(true)
+    setBurgerOpen(false)
+  }
+
+  const openPresets = () => {
+    const state = useStore.getState()
+    if (!state.confirmLeaveUpload(t('upload.confirmLeave'))) return
+    state.setCurrentView('presets')
+    setBurgerOpen(false)
+  }
+
+  const handleToggleLanguage = () => {
+    toggleLanguage()
+    setBurgerOpen(false)
+  }
+
+  const handleLogout = () => {
+    if (!useStore.getState().confirmLeaveUpload(t('upload.confirmLeave'))) return
+    if (config?.logout_url) {
+      window.location.href = config.logout_url
+    }
+  }
+
+  useEffect(() => {
+    if (!burgerOpen) return
+    const onMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setBurgerOpen(false)
+      }
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setBurgerOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [burgerOpen])
+
+  const buttonClass = 'text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500'
+  const logoutButtonClass = 'text-sm text-red-400 hover:text-red-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500'
+
   return (
-    <header className="flex flex-wrap items-center justify-between gap-2 px-6 py-3 bg-gray-900 border-b border-gray-700">
+    <header className="relative flex items-center justify-between gap-2 px-6 py-3 bg-gray-900 border-b border-gray-700">
       <div className="flex items-center gap-3 min-w-0">
         <img src={`${import.meta.env.BASE_URL}whisper-logo.svg`} alt="Transcription Service" className="h-8 w-8 shrink-0" />
         <h1 className="text-lg font-semibold text-white truncate">{t('title')}</h1>
       </div>
-      <div className="flex flex-wrap items-center gap-4">
+
+      {/* Desktop: inline button row */}
+      <div className="hidden md:flex items-center gap-4">
         <button
           type="button"
-          onClick={() => useStore.getState().setHelpOpen(true)}
+          onClick={openHelp}
           aria-label={t('help.open')}
           title={t('help.open')}
-          className="text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+          className={buttonClass}
         >
           ?
         </button>
-        <button
-          onClick={() => {
-            const state = useStore.getState()
-            if (!state.confirmLeaveUpload(t('upload.confirmLeave'))) return
-            state.setCurrentView('presets')
-          }}
-          className="text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
-        >
+        <button onClick={openPresets} className={buttonClass}>
           {t('nav.presets')}
         </button>
         <button
-          onClick={toggleLanguage}
-          className="text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+          onClick={handleToggleLanguage}
+          className={buttonClass}
           title={i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
           aria-label={i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
         >
           {(i18n.language === 'de' ? 'en' : 'de').toUpperCase()}
         </button>
         {config?.logout_url && (
-          <button
-            onClick={() => {
-              if (!useStore.getState().confirmLeaveUpload(t('upload.confirmLeave'))) return
-              window.location.href = config.logout_url
-            }}
-            className="text-sm text-red-400 hover:text-red-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
-          >
+          <button onClick={handleLogout} className={logoutButtonClass}>
             {t('common.logout')}
           </button>
+        )}
+      </div>
+
+      {/* Mobile: burger trigger + dropdown */}
+      <div className="md:hidden" ref={containerRef}>
+        <button
+          type="button"
+          onClick={() => setBurgerOpen((open) => !open)}
+          aria-label={t('nav.menu')}
+          aria-expanded={burgerOpen}
+          aria-controls="header-mobile-menu"
+          className={buttonClass}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        {burgerOpen && (
+          <div
+            id="header-mobile-menu"
+            role="menu"
+            className="absolute right-0 top-full mt-1 w-48 bg-gray-900 border border-gray-700 rounded-md shadow-lg z-40 flex flex-col py-2"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={openHelp}
+              className={`${buttonClass} text-left px-4 py-2`}
+            >
+              {t('help.open')}
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={openPresets}
+              className={`${buttonClass} text-left px-4 py-2`}
+            >
+              {t('nav.presets')}
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={handleToggleLanguage}
+              className={`${buttonClass} text-left px-4 py-2`}
+            >
+              {i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
+            </button>
+            {config?.logout_url && (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => { setBurgerOpen(false); handleLogout() }}
+                className={`${logoutButtonClass} text-left px-4 py-2`}
+              >
+                {t('common.logout')}
+              </button>
+            )}
+          </div>
         )}
       </div>
     </header>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -100,6 +100,7 @@ export function Header() {
           onClick={() => setBurgerOpen((open) => !open)}
           aria-label={t('nav.menu')}
           aria-expanded={burgerOpen}
+          aria-haspopup="menu"
           aria-controls="header-mobile-menu"
           className={buttonClass}
         >

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header() {
           onClick={() => useStore.getState().setHelpOpen(true)}
           aria-label={t('help.open')}
           title={t('help.open')}
-          className="text-sm text-gray-300 hover:text-white w-6 h-6 rounded-full border border-gray-600 flex items-center justify-center focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+          className="text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
         >
           ?
         </button>
@@ -31,13 +31,13 @@ export function Header() {
             if (!state.confirmLeaveUpload(t('upload.confirmLeave'))) return
             state.setCurrentView('presets')
           }}
-          className="text-sm text-gray-300 hover:text-white"
+          className="text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
         >
           {t('nav.presets')}
         </button>
         <button
           onClick={toggleLanguage}
-          className="text-sm text-gray-300 hover:text-white"
+          className="text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
           title={i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
           aria-label={i18n.language === 'de' ? 'Switch to English' : 'Auf Deutsch wechseln'}
         >
@@ -49,7 +49,7 @@ export function Header() {
               if (!useStore.getState().confirmLeaveUpload(t('upload.confirmLeave'))) return
               window.location.href = config.logout_url
             }}
-            className="text-sm text-red-400 hover:text-red-300"
+            className="text-sm text-red-400 hover:text-red-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
           >
             {t('common.logout')}
           </button>

--- a/frontend/src/components/SpeakerMapping/SpeakerMapping.tsx
+++ b/frontend/src/components/SpeakerMapping/SpeakerMapping.tsx
@@ -67,9 +67,8 @@ export function SpeakerMapping({ isOpen, onClose, focusSpeaker }: Props) {
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-gray-800 rounded-lg p-6 w-96 max-h-[80vh] overflow-auto">
-        <h2 className="text-lg font-medium text-white mb-4">{t('editor.speakerNames')}</h2>
+    <section className="mx-6 mb-4 bg-gray-800 rounded-lg p-6">
+      <h2 className="text-lg font-medium text-white mb-4">{t('editor.speakerNames')}</h2>
         <div className="space-y-3">
           {speakers.map((speaker) => {
             const mappedName = localMappings[speaker] || ''
@@ -108,7 +107,6 @@ export function SpeakerMapping({ isOpen, onClose, focusSpeaker }: Props) {
             {t('editor.apply')}
           </button>
         </div>
-      </div>
-    </div>
+    </section>
   )
 }

--- a/frontend/src/components/SpeakerMapping/SpeakerMapping.tsx
+++ b/frontend/src/components/SpeakerMapping/SpeakerMapping.tsx
@@ -69,44 +69,44 @@ export function SpeakerMapping({ isOpen, onClose, focusSpeaker }: Props) {
   return (
     <section className="mx-6 mb-4 bg-gray-800 rounded-lg p-6">
       <h2 className="text-lg font-medium text-white mb-4">{t('editor.speakerNames')}</h2>
-        <div className="space-y-3">
-          {speakers.map((speaker) => {
-            const mappedName = localMappings[speaker] || ''
-            const isAutoName = !mappedName || SPEAKER_PLACEHOLDER_RE.test(mappedName)
-            return (
-              <div key={speaker} className="flex items-center gap-3">
-                <span className={`text-sm w-24 shrink-0 ${isAutoName ? 'text-gray-500 italic' : 'text-gray-200 font-medium'}`}>
-                  {mappedName || speaker}
-                </span>
-                <span className="text-gray-500">{'\u2192'}</span>
-                <input
-                  ref={(el) => { inputRefs.current[speaker] = el }}
-                  value={localMappings[speaker] || ''}
-                  onChange={(e) => setLocalMappings({ ...localMappings, [speaker]: e.target.value })}
-                  placeholder={speaker}
-                  list="speaker-name-suggestions"
-                  className="flex-1 bg-gray-700 text-white text-sm rounded px-3 py-1.5"
-                />
-              </div>
-            )
-          })}
-        </div>
-        <datalist id="speaker-name-suggestions">
-          {customNames.map((name) => (
-            <option key={name} value={name} />
-          ))}
-        </datalist>
-        {speakers.length === 0 && (
-          <p className="text-gray-500 text-sm">{t('editor.noSpeakers')}</p>
-        )}
-        <div className="flex justify-end gap-3 mt-6">
-          <button onClick={onClose} className="px-4 py-1.5 text-sm text-gray-300 hover:text-white">
-            {t('common.cancel')}
-          </button>
-          <button onClick={handleApply} className="px-4 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-500">
-            {t('editor.apply')}
-          </button>
-        </div>
+      <div className="space-y-3">
+        {speakers.map((speaker) => {
+          const mappedName = localMappings[speaker] || ''
+          const isAutoName = !mappedName || SPEAKER_PLACEHOLDER_RE.test(mappedName)
+          return (
+            <div key={speaker} className="flex items-center gap-3">
+              <span className={`text-sm w-24 shrink-0 ${isAutoName ? 'text-gray-500 italic' : 'text-gray-200 font-medium'}`}>
+                {mappedName || speaker}
+              </span>
+              <span className="text-gray-500">{'\u2192'}</span>
+              <input
+                ref={(el) => { inputRefs.current[speaker] = el }}
+                value={localMappings[speaker] || ''}
+                onChange={(e) => setLocalMappings({ ...localMappings, [speaker]: e.target.value })}
+                placeholder={speaker}
+                list="speaker-name-suggestions"
+                className="flex-1 bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+              />
+            </div>
+          )
+        })}
+      </div>
+      <datalist id="speaker-name-suggestions">
+        {customNames.map((name) => (
+          <option key={name} value={name} />
+        ))}
+      </datalist>
+      {speakers.length === 0 && (
+        <p className="text-gray-500 text-sm">{t('editor.noSpeakers')}</p>
+      )}
+      <div className="flex justify-end gap-3 mt-6">
+        <button onClick={onClose} className="px-4 py-1.5 text-sm text-gray-300 hover:text-white">
+          {t('common.cancel')}
+        </button>
+        <button onClick={handleApply} className="px-4 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-500">
+          {t('editor.apply')}
+        </button>
+      </div>
     </section>
   )
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -389,7 +389,8 @@
     "backToTranscriptions": "Transkriptionen",
     "newUpload": "Hochladen",
     "newRecording": "Aufnehmen",
-    "presets": "Voreinstellungen"
+    "presets": "Voreinstellungen",
+    "menu": "Menü"
   },
   "common": {
     "loading": "Laden...",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -389,7 +389,8 @@
     "backToTranscriptions": "Transcriptions",
     "newUpload": "Upload",
     "newRecording": "Record",
-    "presets": "Presets"
+    "presets": "Presets",
+    "menu": "Menu"
   },
   "common": {
     "loading": "Loading...",


### PR DESCRIPTION
## Summary

Phase 2 of the UI polish series, bundling two of the remaining new UI issues into one PR:

- **#117** — header button styles flattened to share one class stack; mobile burger menu at `< md` (< 768px).
- **#121** — Speaker Names modal converted to an inline panel above the tab content.

## #117 — Header

**Button style.** The Help `?` button's circular bordered wrapper is removed; all four header buttons now share `text-sm text-gray-300 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500`. Logout keeps `text-red-400 hover:text-red-300` as destructive-action cue. Three of the four buttons also gained a uniform focus-ring treatment in the process — small a11y win.

**Mobile burger.** At `< md`, the four buttons collapse into a single burger-menu dropdown:
- Desktop button row: `hidden md:flex items-center gap-4`
- Burger trigger: `md:hidden`, three-line inline SVG
- Dropdown: `absolute right-0 top-full mt-1 w-48 z-40`
- Close behavior: click-outside (`mousedown` on document while open), ESC, or selecting any item
- A11y: `aria-expanded`, `aria-haspopup="menu"`, `aria-controls`, matching `role="menu"` / `role="menuitem"`

The language toggle uses the full localized label ("Switch to English" / "Auf Deutsch wechseln") inside the burger — the two-letter "EN" / "DE" reads as noise in a vertical menu.

New i18n key: `nav.menu` (en: "Menu", de: "Menü").

## #121 — Speaker Names

The modal overlay is gone. `SpeakerMapping` becomes an inline `<section>` that sits between the tab bar and the tab content. Prop contract (`isOpen` / `onClose` / `focusSpeaker`) is unchanged. The focus-speaker auto-scroll flow (click an unnamed speaker chip → corresponding input receives focus) still works since `scrollIntoView` now scrolls the document instead of the modal card.

- Removed: `fixed inset-0 bg-black/50 ... z-50` backdrop, centered `w-96 max-h-[80vh] overflow-auto` card
- Added: `<section className="mx-6 mb-4 bg-gray-800 rounded-lg p-6">` — aligns with the surrounding page's padding
- `App.tsx`: single-line JSX move so the panel renders above the tab content instead of after it

## Non-goals (explicit)

- No rethink of the Speaker Names UX (same list of inputs + datalist).
- No changes to the tab bar, subtitle table, or other detail-view components.
- Not addressing #115 (transcription-settings alignment) or #120 (mobile overflow) — those are Phase 3. A small page-level overflow issue was observed during manual testing where long transcription headings can force the page wider than narrow viewports (because the outer App container uses `overflow-x-hidden`). This is a pre-existing #120 surface, not caused by Phase 2.
- Not a broader a11y audit. Arrow-key navigation inside the burger dropdown is intentionally not implemented — four items don't warrant it.

## Closes

- Closes #117
- Closes #121