### PR TITLE
style(settings): container-based layout for transcription settings (Phase 3a)

### DIFF
--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -113,6 +113,7 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
             selectedId={null}
             onSelect={() => {}}
             onSave={handleSavePreset}
+            hideDropdown
           />
         </div>
       </div>

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -73,38 +73,41 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
 
   return (
     <div className="px-6 py-3 bg-gray-800 border-b border-gray-700 space-y-3">
-      {(transcriptionPresets.length > 0 || bundles.length > 0) && (
-        <div className="flex flex-wrap gap-4 items-center mb-2">
-          {bundles.length > 0 && (
-            <div className="min-w-0">
-              <label className="block text-xs text-gray-400 mb-1">{t('presets.bundles')}</label>
-              <select
-                value={activeBundleId || ''}
-                onChange={(e) => handleLoadBundle(e.target.value || null)}
-                className="bg-gray-700 text-white text-sm rounded px-3 py-1.5"
-              >
-                <option value="">{t('presets.selectBundle')}</option>
-                {bundles.map((b) => (
-                  <option key={b.id} value={b.id}>
-                    {b.name}{b.is_default ? ` (${t('presets.bundle.isDefault')})` : ''}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
+      {/* Row 1 — Preset/bundle row (always renders; dropdowns left, save-as right) */}
+      <div className="flex flex-wrap items-end gap-4 mb-2">
+        {bundles.length > 0 && (
+          <div className="min-w-0">
+            <label className="block text-xs text-gray-400 mb-1">{t('presets.bundles')}</label>
+            <select
+              value={activeBundleId || ''}
+              onChange={(e) => handleLoadBundle(e.target.value || null)}
+              className="bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+            >
+              <option value="">{t('presets.selectBundle')}</option>
+              {bundles.map((b) => (
+                <option key={b.id} value={b.id}>
+                  {b.name}{b.is_default ? ` (${t('presets.bundle.isDefault')})` : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        {transcriptionPresets.length > 0 && (
           <div className="min-w-0">
             <label className="block text-xs text-gray-400 mb-1">{t('presets.transcription')}</label>
-            <PresetSelect
-              presets={transcriptionPresets}
-              selectedId={values.selectedPresetId}
-              onSelect={handleLoadPreset}
-              onSave={handleSavePreset}
-            />
+            <select
+              value={values.selectedPresetId || ''}
+              onChange={(e) => handleLoadPreset(e.target.value || null)}
+              className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 min-w-[140px]"
+            >
+              <option value="">{t('presets.selectPreset')}</option>
+              {transcriptionPresets.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
           </div>
-        </div>
-      )}
-      {transcriptionPresets.length === 0 && bundles.length === 0 && (
-        <div className="flex justify-end mb-1">
+        )}
+        <div className="ml-auto">
           <PresetSelect
             presets={[]}
             selectedId={null}
@@ -112,8 +115,10 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
             onSave={handleSavePreset}
           />
         </div>
-      )}
-      <div className="flex flex-wrap gap-4 items-end">
+      </div>
+
+      {/* Row 2 — Core settings (Language + Model) */}
+      <div className="flex flex-wrap items-end gap-4">
         <div className="min-w-0">
           <label htmlFor="upload-language-field" className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
           <LanguageSelect
@@ -152,15 +157,19 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
             )
           })()}
         </div>
-        <div className="flex items-center gap-2 py-1.5 min-w-0">
+      </div>
+
+      {/* Row 3 — Speaker detection (checkbox + optional min/max as one wrap unit) */}
+      <div className="flex flex-wrap items-end gap-4">
+        <label className="flex items-center gap-2 py-1.5">
           <input
             type="checkbox"
             checked={values.detectSpeakers}
             onChange={(e) => onChange({ detectSpeakers: e.target.checked })}
             className="rounded shrink-0"
           />
-          <label className="text-sm text-gray-300">{t('settings.detectSpeakers')}</label>
-        </div>
+          <span className="text-sm text-gray-300">{t('settings.detectSpeakers')}</span>
+        </label>
         {values.detectSpeakers && (
           <>
             <div className="min-w-0">
@@ -199,13 +208,18 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
             </div>
           </>
         )}
+      </div>
+
+      {/* Row 4 — Advanced options toggle (own line, right-aligned) */}
+      <div className="flex justify-end">
         <button
           onClick={() => onChange({ showAdvanced: !values.showAdvanced })}
-          className="text-sm text-blue-400 hover:text-blue-300 shrink-0"
+          className="text-sm text-blue-400 hover:text-blue-300"
         >
           {t('settings.advancedOptions')} {values.showAdvanced ? '▲' : '▼'}
         </button>
       </div>
+
       {saveError && (
         <div className="p-4 bg-red-900/30 rounded-lg border border-red-700">
           <div className="flex items-center gap-3">
@@ -214,6 +228,8 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
           </div>
         </div>
       )}
+
+      {/* Row 5 — Advanced options panel (unchanged) */}
       {values.showAdvanced && (
         <div className="flex flex-wrap gap-4">
           <div className="flex-1 min-w-[200px]">

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -71,151 +71,157 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
     }
   }
 
+  const groupClass = 'flex flex-wrap items-end gap-3 border border-gray-700 rounded-md px-3 pt-1 pb-3'
+  const legendClass = 'text-[10px] uppercase tracking-wider text-gray-500 px-1'
+
   return (
     <div className="px-6 py-3 bg-gray-800 border-b border-gray-700 space-y-3">
-      {/* Row 1 — Preset/bundle row (always renders; dropdowns left, save-as right) */}
-      <div className="flex flex-wrap items-end gap-4 mb-2">
-        {bundles.length > 0 && (
-          <div className="min-w-0">
-            <label className="block text-xs text-gray-400 mb-1">{t('presets.bundles')}</label>
-            <select
-              value={activeBundleId || ''}
-              onChange={(e) => handleLoadBundle(e.target.value || null)}
-              className="bg-gray-700 text-white text-sm rounded px-3 py-1.5"
-            >
-              <option value="">{t('presets.selectBundle')}</option>
-              {bundles.map((b) => (
-                <option key={b.id} value={b.id}>
-                  {b.name}{b.is_default ? ` (${t('presets.bundle.isDefault')})` : ''}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
-        {transcriptionPresets.length > 0 && (
-          <div className="min-w-0">
-            <label className="block text-xs text-gray-400 mb-1">{t('presets.transcription')}</label>
-            <select
-              value={values.selectedPresetId || ''}
-              onChange={(e) => handleLoadPreset(e.target.value || null)}
-              className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 min-w-[140px]"
-            >
-              <option value="">{t('presets.selectPreset')}</option>
-              {transcriptionPresets.map((p) => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-            </select>
-          </div>
-        )}
-        <div className="ml-auto">
-          <PresetSelect
-            presets={[]}
-            selectedId={null}
-            onSelect={() => {}}
-            onSave={handleSavePreset}
-            hideDropdown
-          />
-        </div>
-      </div>
-
-      {/* Row 2 — Core settings (Language + Model) */}
-      <div className="flex flex-wrap items-end gap-4">
-        <div className="min-w-0">
-          <label htmlFor="upload-language-field" className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
-          <LanguageSelect
-            id="upload-language-field"
-            value={values.language}
-            onChange={(v) => onChange({ language: v })}
-            includeAuto
-            className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
-          />
-        </div>
-        <div className="min-w-0">
-          <label htmlFor="upload-model-field" className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
-          {(() => {
-            const models = config?.whisper_models || []
-            if (models.length === 1) {
-              const m = models[0]
-              const label = t(`settings.modelLabels.${m}`, '')
-              return (
-                <output id="upload-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
-                  {label ? `${label} (${m})` : m}
-                </output>
-              )
-            }
-            return (
+      {/* Container row — semantic groups laid out side-by-side, wrap freely */}
+      <div className="flex flex-wrap gap-3 items-stretch">
+        {/* Presets group */}
+        <fieldset className={groupClass}>
+          <legend className={legendClass}>{t('settings.groups.presets')}</legend>
+          {bundles.length > 0 && (
+            <div className="min-w-0">
+              <label className="block text-xs text-gray-400 mb-1">{t('presets.bundles')}</label>
               <select
-                id="upload-model-field"
-                value={values.model}
-                onChange={(e) => onChange({ model: e.target.value })}
-                className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+                value={activeBundleId || ''}
+                onChange={(e) => handleLoadBundle(e.target.value || null)}
+                className="bg-gray-700 text-white text-sm rounded px-3 py-1.5"
               >
-                {models.map((m) => {
-                  const label = t(`settings.modelLabels.${m}`, '')
-                  return <option key={m} value={m}>{label ? `${label} (${m})` : m}</option>
-                })}
+                <option value="">{t('presets.selectBundle')}</option>
+                {bundles.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.name}{b.is_default ? ` (${t('presets.bundle.isDefault')})` : ''}
+                  </option>
+                ))}
               </select>
-            )
-          })()}
-        </div>
-      </div>
-
-      {/* Row 3 — Speaker detection (checkbox + optional min/max as one wrap unit) */}
-      <div className="flex flex-wrap items-end gap-4">
-        <label className="flex items-center gap-2 py-1.5">
-          <input
-            type="checkbox"
-            checked={values.detectSpeakers}
-            onChange={(e) => onChange({ detectSpeakers: e.target.checked })}
-            className="rounded shrink-0"
-          />
-          <span className="text-sm text-gray-300">{t('settings.detectSpeakers')}</span>
-        </label>
-        {values.detectSpeakers && (
-          <>
-            <div className="min-w-0">
-              <label className="block text-xs text-gray-400 mb-1">{t('settings.minSpeakers')}</label>
-              <input
-                type="number"
-                min={1}
-                max={20}
-                value={values.minSpeakers}
-                onChange={(e) => {
-                  const val = Math.max(1, Math.min(20, Number(e.target.value)))
-                  onChange({
-                    minSpeakers: val,
-                    maxSpeakers: val > values.maxSpeakers ? val : values.maxSpeakers,
-                  })
-                }}
-                className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 w-16"
-              />
             </div>
+          )}
+          {transcriptionPresets.length > 0 && (
             <div className="min-w-0">
-              <label className="block text-xs text-gray-400 mb-1">{t('settings.maxSpeakers')}</label>
-              <input
-                type="number"
-                min={1}
-                max={20}
-                value={values.maxSpeakers}
-                onChange={(e) => {
-                  const val = Math.max(1, Math.min(20, Number(e.target.value)))
-                  onChange({
-                    maxSpeakers: val,
-                    minSpeakers: val < values.minSpeakers ? val : values.minSpeakers,
-                  })
-                }}
-                className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 w-16"
-              />
+              <label className="block text-xs text-gray-400 mb-1">{t('presets.transcription')}</label>
+              <select
+                value={values.selectedPresetId || ''}
+                onChange={(e) => handleLoadPreset(e.target.value || null)}
+                className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 min-w-[140px]"
+              >
+                <option value="">{t('presets.selectPreset')}</option>
+                {transcriptionPresets.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
             </div>
-          </>
-        )}
-      </div>
+          )}
+          <div className="self-end">
+            <PresetSelect
+              presets={[]}
+              selectedId={null}
+              onSelect={() => {}}
+              onSave={handleSavePreset}
+              hideDropdown
+            />
+          </div>
+        </fieldset>
 
-      {/* Row 4 — Advanced options toggle (own line, right-aligned) */}
-      <div className="flex justify-end">
+        {/* Transcription group (Language + Quality) */}
+        <fieldset className={groupClass}>
+          <legend className={legendClass}>{t('settings.groups.transcription')}</legend>
+          <div className="min-w-0">
+            <label htmlFor="upload-language-field" className="block text-xs text-gray-400 mb-1">{t('settings.language')}</label>
+            <LanguageSelect
+              id="upload-language-field"
+              value={values.language}
+              onChange={(v) => onChange({ language: v })}
+              includeAuto
+              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+            />
+          </div>
+          <div className="min-w-0">
+            <label htmlFor="upload-model-field" className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
+            {(() => {
+              const models = config?.whisper_models || []
+              if (models.length === 1) {
+                const m = models[0]
+                const label = t(`settings.modelLabels.${m}`, '')
+                return (
+                  <output id="upload-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
+                    {label ? `${label} (${m})` : m}
+                  </output>
+                )
+              }
+              return (
+                <select
+                  id="upload-model-field"
+                  value={values.model}
+                  onChange={(e) => onChange({ model: e.target.value })}
+                  className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+                >
+                  {models.map((m) => {
+                    const label = t(`settings.modelLabels.${m}`, '')
+                    return <option key={m} value={m}>{label ? `${label} (${m})` : m}</option>
+                  })}
+                </select>
+              )
+            })()}
+          </div>
+        </fieldset>
+
+        {/* Speakers group (checkbox + optional min/max — never split across wraps) */}
+        <fieldset className={groupClass}>
+          <legend className={legendClass}>{t('settings.groups.speakers')}</legend>
+          <label className="flex items-center gap-2 py-1.5">
+            <input
+              type="checkbox"
+              checked={values.detectSpeakers}
+              onChange={(e) => onChange({ detectSpeakers: e.target.checked })}
+              className="rounded shrink-0"
+            />
+            <span className="text-sm text-gray-300">{t('settings.detectSpeakers')}</span>
+          </label>
+          {values.detectSpeakers && (
+            <>
+              <div className="min-w-0">
+                <label className="block text-xs text-gray-400 mb-1">{t('settings.minSpeakers')}</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={values.minSpeakers}
+                  onChange={(e) => {
+                    const val = Math.max(1, Math.min(20, Number(e.target.value)))
+                    onChange({
+                      minSpeakers: val,
+                      maxSpeakers: val > values.maxSpeakers ? val : values.maxSpeakers,
+                    })
+                  }}
+                  className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 w-16"
+                />
+              </div>
+              <div className="min-w-0">
+                <label className="block text-xs text-gray-400 mb-1">{t('settings.maxSpeakers')}</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={values.maxSpeakers}
+                  onChange={(e) => {
+                    const val = Math.max(1, Math.min(20, Number(e.target.value)))
+                    onChange({
+                      maxSpeakers: val,
+                      minSpeakers: val < values.minSpeakers ? val : values.minSpeakers,
+                    })
+                  }}
+                  className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 w-16"
+                />
+              </div>
+            </>
+          )}
+        </fieldset>
+
         <button
           onClick={() => onChange({ showAdvanced: !values.showAdvanced })}
-          className="text-sm text-blue-400 hover:text-blue-300"
+          className="ml-auto self-end text-sm text-blue-400 hover:text-blue-300 py-1.5 shrink-0"
         >
           {t('settings.advancedOptions')} {values.showAdvanced ? '▲' : '▼'}
         </button>
@@ -230,28 +236,31 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
         </div>
       )}
 
-      {/* Row 5 — Advanced options panel (unchanged) */}
+      {/* Advanced options panel — wrapped in a labeled container to match other groups */}
       {values.showAdvanced && (
-        <div className="flex flex-wrap gap-4">
-          <div className="flex-1 min-w-[200px]">
-            <label className="block text-xs text-gray-400 mb-1">{t('settings.initialPrompt')}</label>
-            <textarea
-              value={values.initialPrompt}
-              onChange={(e) => onChange({ initialPrompt: e.target.value })}
-              placeholder={t('settings.initialPromptHelp')}
-              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 h-16 resize-none"
-            />
+        <fieldset className={`${groupClass} w-full`}>
+          <legend className={legendClass}>{t('settings.advancedOptions')}</legend>
+          <div className="flex flex-wrap gap-3 w-full">
+            <div className="flex-1 min-w-[200px]">
+              <label className="block text-xs text-gray-400 mb-1">{t('settings.initialPrompt')}</label>
+              <textarea
+                value={values.initialPrompt}
+                onChange={(e) => onChange({ initialPrompt: e.target.value })}
+                placeholder={t('settings.initialPromptHelp')}
+                className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5 h-16 resize-none"
+              />
+            </div>
+            <div className="flex-1 min-w-[200px]">
+              <label className="block text-xs text-gray-400 mb-1">{t('settings.hotwords')}</label>
+              <input
+                value={values.hotwords}
+                onChange={(e) => onChange({ hotwords: e.target.value })}
+                placeholder={t('settings.hotwordsHelp')}
+                className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+              />
+            </div>
           </div>
-          <div className="flex-1 min-w-[200px]">
-            <label className="block text-xs text-gray-400 mb-1">{t('settings.hotwords')}</label>
-            <input
-              value={values.hotwords}
-              onChange={(e) => onChange({ hotwords: e.target.value })}
-              placeholder={t('settings.hotwordsHelp')}
-              className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
-            />
-          </div>
-        </div>
+        </fieldset>
       )}
     </div>
   )

--- a/frontend/src/components/PresetSelect/PresetSelect.tsx
+++ b/frontend/src/components/PresetSelect/PresetSelect.tsx
@@ -12,9 +12,10 @@ interface PresetSelectProps {
   onSelect: (id: string | null) => void
   onSave: (name: string) => void
   placeholder?: string
+  hideDropdown?: boolean
 }
 
-export function PresetSelect({ presets, selectedId, onSelect, onSave, placeholder }: PresetSelectProps) {
+export function PresetSelect({ presets, selectedId, onSelect, onSave, placeholder, hideDropdown }: PresetSelectProps) {
   const { t } = useTranslation()
   const [showSave, setShowSave] = useState(false)
   const [saveName, setSaveName] = useState('')
@@ -29,16 +30,18 @@ export function PresetSelect({ presets, selectedId, onSelect, onSave, placeholde
 
   return (
     <div className="flex items-center gap-2">
-      <select
-        value={selectedId || ''}
-        onChange={(e) => onSelect(e.target.value || null)}
-        className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 min-w-[140px]"
-      >
-        <option value="">{placeholder || t('presets.selectPreset')}</option>
-        {presets.map((p) => (
-          <option key={p.id} value={p.id}>{p.name}</option>
-        ))}
-      </select>
+      {!hideDropdown && (
+        <select
+          value={selectedId || ''}
+          onChange={(e) => onSelect(e.target.value || null)}
+          className="bg-gray-700 text-white text-sm rounded px-3 py-1.5 min-w-[140px]"
+        >
+          <option value="">{placeholder || t('presets.selectPreset')}</option>
+          {presets.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      )}
 
       {showSave ? (
         <div className="flex items-center gap-1">

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -20,6 +20,11 @@
     "initialPromptHelp": "Optionaler Kontext für die Transkription",
     "hotwords": "Schlüsselwörter",
     "hotwordsHelp": "Kommagetrennte Fachbegriffe",
+    "groups": {
+      "presets": "Voreinstellungen",
+      "transcription": "Transkription",
+      "speakers": "Sprecher"
+    },
     "modelLabels": {
       "tiny": "Entwurf",
       "base": "Standard",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -20,6 +20,11 @@
     "initialPromptHelp": "Optional context for the transcription",
     "hotwords": "Hotwords",
     "hotwordsHelp": "Comma-separated technical terms",
+    "groups": {
+      "presets": "Presets",
+      "transcription": "Transcription",
+      "speakers": "Speakers"
+    },
     "modelLabels": {
       "tiny": "Draft",
       "base": "Standard",


### PR DESCRIPTION
## Summary

Phase 3a of the UI polish series — closes #115 (transcription settings alignment).

The first attempt (commits 254e130 + 76e86e9) split controls into separate stacked rows for consistent alignment + grouping. That fixed the original alignment complaint but introduced large empty horizontal gaps on wide viewports — controls clustered to the left while action buttons hugged the right (cluttered/sparse look).

This PR replaces the row-based layout with **labeled `<fieldset>` containers** — one per semantic group:

- **PRESETS** — bundles dropdown, transcription preset dropdown, save-as button
- **TRANSCRIPTION** — language, quality
- **SPEAKERS** — detect checkbox, min/max (kept as one wrap unit so they never orphan)
- **ADVANCED OPTIONS** — initial prompt, hotwords (revealed by the toggle, also wrapped in a matching fieldset so the expanded panel doesn't float loose)

The standalone **Advanced options ▼** toggle floats outside the group containers as a non-grouped action.

### Why containers over rows

- Containers fill horizontal space when wide and wrap as units when narrow — no empty middle gaps at any width
- Group purpose is communicated by the legend label, not by row position or `ml-auto` push-right tricks
- Group-scoped actions (Save as preset → Presets group) live with their group
- `<fieldset>` / `<legend>` are the proper a11y semantics for grouped form controls

Verified at 1600 / 1400 / 900 / 600 / 375 px (mobile). On mobile each container stacks vertically, the speakers checkbox + min/max stay together, and Advanced Options sits as its own labeled box.

### i18n

New keys: `settings.groups.{presets,transcription,speakers}` (en + de).

## Closes

- Closes #115