### PR TITLE
fix(ui): mobile overflow — phase 3b

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 - Copy, download, and delete generated analysis results.
 - LLM provider and model attribution display on generated content.
 - Transcription history as default landing page with persistent storage.
+- Auto-generated transcription titles via LLM (overridable through inline rename).
+- In-app help drawer with a bilingual (English/German) user manual covering every feature.
 - Per-item expiration with configurable retention — files expire after a default period (3 days), with an "archive" action to extend retention (180 days).
 - Real-time progress updates via WebSocket.
 - Responsive layout — mobile-friendly UI with no horizontal overflow on small screens.
@@ -73,6 +75,7 @@ LLM_BASE_URL=                     # for custom endpoints (e.g., vLLM, Ollama: ht
 
 # UI Configuration
 POPULAR_LANGUAGES=de,en,es,fr       # languages pinned at top of dropdowns (comma-separated codes)
+ENABLED_LANGUAGES=                  # allowlist of languages (comma-separated codes); unset = all enabled
 
 # Application
 TEMP_PATH=tmp/transcription-files

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -785,12 +785,12 @@ export function PresetsPage() {
       <h2 className="text-xl font-semibold text-white mb-4">{t('presets.title')}</h2>
 
       {/* Tab bar */}
-      <div className="flex gap-1 border-b border-gray-700 mb-5">
+      <div className="flex gap-1 border-b border-gray-700 mb-5 overflow-x-auto [mask-image:linear-gradient(to_right,transparent,black_1rem,black_calc(100%-1rem),transparent)] sm:[mask-image:none]">
         {tabs.map(({ key, label }) => (
           <button
             key={key}
             onClick={() => setActiveTab(key)}
-            className={`px-4 py-2 text-sm font-medium transition-colors ${
+            className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${
               activeTab === key
                 ? 'text-white border-b-2 border-blue-400 -mb-px'
                 : 'text-gray-400 hover:text-gray-200'

--- a/frontend/src/components/SubtitleEditor/SubtitleEditor.tsx
+++ b/frontend/src/components/SubtitleEditor/SubtitleEditor.tsx
@@ -527,7 +527,7 @@ export function SubtitleEditor({ onOpenSpeakerModal }: SubtitleEditorProps) {
         )}
       </div>
       {(llmAvailable || refinementMetadata || translatedUtterances) && (
-      <div className="flex items-center gap-2 px-3 py-2 bg-gray-800 border-b border-gray-700">
+      <div className="flex flex-wrap items-center gap-2 px-3 py-2 bg-gray-800 border-b border-gray-700">
         {llmAvailable && !refinementMetadata && (
           <button
             onClick={() => setShowRefineModal(true)}

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -21,7 +21,7 @@ export function TabBar({ onSpeakerNamesClick }: Props) {
   ]
 
   return (
-    <div className="flex items-center gap-1 px-6 py-2 bg-gray-800 border-b border-gray-700 overflow-x-auto">
+    <div className="flex items-center gap-1 px-6 py-2 bg-gray-800 border-b border-gray-700 overflow-x-auto [mask-image:linear-gradient(to_right,transparent,black_1rem,black_calc(100%-1rem),transparent)] sm:[mask-image:none]">
       {tabs.map((tab) => (
         <button
           key={tab.id}


### PR DESCRIPTION
## Summary

Targeted mobile-overflow fixes raised in #120, plus a small README catch-up:

- **PresetsPage tab bar** is now horizontally scrollable. The fourth tab (`Bundles` / German `Verfeinerung` for the third) was clipping on narrow viewports.
- **SubtitleEditor refinement/translation toolbar** now wraps with `flex-wrap`, so the `Delete translation` / `Delete refinement` buttons drop to a second row instead of being pushed off-screen by `ml-auto`.
- Both tab bars (editor + presets) get a subtle CSS-mask edge-fade affordance on `overflow-x-auto` containers at mobile breakpoints, signalling more content lives off-screen. Disabled at `sm:` and up.
- README catches up on three prior PRs that didn't update it: `ENABLED_LANGUAGES` env var (#124), in-app help drawer (#107), and LLM-generated transcription titles (#82).

Three className-only edits across three frontend files plus one README addition. No prop, behavior, or i18n changes.