### PR TITLE
feat(metrics): expand Prometheus instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .superpowers/
 docs/superpowers/
 CLAUDE.md
+.claude/
 examples/
 .playwright-mcp/
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -151,9 +151,13 @@ The application includes comprehensive Prometheus metrics for monitoring usage a
   - `transcription_file_renames_total` — Total file renames
 
 - **Transcription Jobs**:
-  - `transcription_jobs_total` — Total jobs by language, model, and status
-  - `transcription_duration_seconds` — Processing time distribution by language and model
+  - `transcription_jobs_total` — Total jobs by backend, language, model, and status
+  - `transcription_duration_seconds` — Wall-clock processing time by backend, language, and model
+  - `transcription_audio_duration_seconds` — Input media length (seconds) by backend — pair with `transcription_duration_seconds` to derive realtime factor
+  - `transcription_realtime_factor` — Processing time divided by audio duration by backend and model (<1 = faster than realtime)
   - `transcription_active_jobs` — Number of currently processing jobs
+  - `transcription_queue_depth` — Jobs waiting in `pending` state before ASR pickup
+  - `transcription_queue_wait_seconds` — Time spent in `pending` before processing started (by backend)
   - `transcription_diarization_speakers_detected` — Speakers detected per job distribution
 
 - **Editing & Interaction**:
@@ -161,10 +165,11 @@ The application includes comprehensive Prometheus metrics for monitoring usage a
   - `transcription_speaker_renames_total` — Speaker mapping updates
   - `transcription_downloads_total` — Exports/downloads by format
 
-- **LLM (Analysis, Translation & Refinement)**:
+- **LLM (Analysis, Translation, Refinement & Titles)**:
   - `transcription_llm_requests_total` — LLM requests by provider, model, and operation
   - `transcription_llm_duration_seconds` — LLM request duration by provider, model, and operation
   - `transcription_llm_errors_total` — LLM errors by provider, model, and operation
+  - `transcription_llm_tokens_total` — Tokens consumed by provider, model, operation, and kind (`prompt`/`completion`); emitted per LLM call so chunked operations aggregate. Operations include `analysis`, `translation`, `refinement`, `title`.
 
 - **Deletions**:
   - `transcription_deletions_total` — Resource deletions by type (transcription/analysis/translation/refinement)
@@ -172,6 +177,14 @@ The application includes comprehensive Prometheus metrics for monitoring usage a
 - **WebSocket**:
   - `transcription_websocket_connections_active` — Active WebSocket connections
   - `transcription_websocket_connections_total` — Total WebSocket connections
+  - `transcription_websocket_messages_sent_total` — Messages sent to clients by type (`status`/`error`)
+  - `transcription_websocket_disconnects_total` — Disconnects by reason (`client_disconnect`, `auth_missing`, `not_found`, `completed`, `failed`, `not_found_record`, `error`)
+
+- **Storage**:
+  - `transcription_storage_bytes` — Disk usage of the media/DB volume, refreshed at startup and after each cleanup run (labelled by `path`)
+
+- **Auth**:
+  - `transcription_auth_failures_total` — Authentication failures by reason (`missing_headers`, `ws_missing_headers`)
 
 - **Cleanup**:
   - `transcription_cleanup_runs_total` — Cleanup job runs by status (success/failed)
@@ -180,6 +193,8 @@ The application includes comprehensive Prometheus metrics for monitoring usage a
 - **API & Errors**:
   - `transcription_api_request_duration_seconds` — API request latency by endpoint, method, and status
   - `transcription_errors_total` — Errors by type and component
+
+> Breaking change: `transcription_jobs_total` and `transcription_duration_seconds` now carry an additional `backend` label (`murmurai` / `whisperx`). Existing dashboards and alerts will need to include the new label or aggregate it away.
 
 ### Configuration
 
@@ -202,13 +217,15 @@ scrape_configs:
 
 The metrics are designed to work well with Grafana. Key dashboard panels might include:
 
-- Active transcription jobs and WebSocket connections over time
-- Transcription success/failure rates by model and language
-- Processing time percentiles by model
+- Active transcription jobs, queue depth, and WebSocket connections over time
+- Transcription success/failure rates by backend, model, and language
+- Realtime factor (RTF) distribution by backend/model — speed of transcription vs audio length
+- Queue wait time percentiles — backpressure signal
 - File upload volume and sizes
-- LLM request duration and error rates by provider
+- LLM request duration, error rates, and token consumption (prompt vs completion) by provider/operation
 - Export/download format distribution
-- Cleanup job effectiveness
+- Disk usage trend and cleanup job effectiveness
+- WebSocket disconnect reasons (client vs error vs auth)
 
 ## Authors
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,5 +1,6 @@
 from fastapi import HTTPException, Request
 from app.config import settings
+from app.metrics import inc, auth_failures_total
 from app.models import UserInfo
 
 
@@ -14,4 +15,5 @@ async def get_current_user(request: Request) -> UserInfo:
     elif settings.DEV_MODE:
         return UserInfo(id="dev-user", email="dev@localhost")
     else:
+        inc(auth_failures_total, "missing_headers")
         raise HTTPException(status_code=401, detail="Missing authentication headers")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,8 +8,26 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db, get_db
 from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets
-from app.metrics import inc, cleanup_runs_total, cleanup_items_deleted_total
+from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes
 from app.services.audio import has_video_stream
+
+
+def _dir_size_bytes(path: str) -> int:
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                pass
+    return total
+
+
+def _refresh_storage_gauge():
+    try:
+        gauge_set(storage_bytes, _dir_size_bytes(settings.TEMP_PATH), settings.TEMP_PATH)
+    except Exception:
+        pass
 
 
 async def cleanup_old_files():
@@ -74,6 +92,7 @@ async def cleanup_old_files():
             inc(cleanup_items_deleted_total, "transcription", amount=transcriptions_deleted)
             inc(cleanup_items_deleted_total, "analysis", amount=analyses_deleted)
             inc(cleanup_items_deleted_total, "speaker_mapping", amount=mappings_deleted)
+            _refresh_storage_gauge()
         except Exception as e:
             inc(cleanup_runs_total, "failed")
             print(f"Cleanup error: {e}")
@@ -100,6 +119,7 @@ async def lifespan(app: FastAPI):
             )
         if rows:
             await db.commit()
+    _refresh_storage_gauge()
     cleanup_task = asyncio.create_task(cleanup_old_files())
     yield
     cleanup_task.cancel()

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -46,12 +46,28 @@ file_renames_total = _counter("transcription_file_renames_total", "Total file re
 # --- Transcription jobs ---
 transcriptions_total = _counter(
     "transcription_jobs_total", "Total transcription jobs",
-    ["language", "model", "status"],
+    ["backend", "language", "model", "status"],
 )
 transcription_duration_seconds = _histogram(
-    "transcription_duration_seconds", "Transcription duration",
-    labels=["language", "model"],
+    "transcription_duration_seconds", "Transcription wall-clock duration",
+    labels=["backend", "language", "model"],
     buckets=[1, 5, 10, 30, 60, 120, 300, 600, 1200, 1800, 3600],
+)
+transcription_audio_duration_seconds = _histogram(
+    "transcription_audio_duration_seconds", "Input media duration (length of the audio being transcribed)",
+    labels=["backend"],
+    buckets=[10, 30, 60, 180, 300, 600, 1200, 1800, 3600, 7200, 14400],
+)
+transcription_realtime_factor = _histogram(
+    "transcription_realtime_factor", "Processing time divided by audio duration (lower is faster; <1 means faster than realtime)",
+    labels=["backend", "model"],
+    buckets=[0.05, 0.1, 0.25, 0.5, 1, 2, 4, 8, 16],
+)
+transcription_queue_depth = _gauge("transcription_queue_depth", "Transcriptions in 'pending' state waiting to start")
+transcription_queue_wait_seconds = _histogram(
+    "transcription_queue_wait_seconds", "Time a job spent pending before processing started",
+    labels=["backend"],
+    buckets=[0.1, 0.5, 1, 5, 15, 30, 60, 300, 900],
 )
 active_transcriptions = _gauge("transcription_active_jobs", "Active transcription jobs")
 diarization_speakers_detected = _histogram(
@@ -83,6 +99,10 @@ llm_errors_total = _counter(
     "transcription_llm_errors_total", "LLM errors",
     ["provider", "model", "operation"],
 )
+llm_tokens_total = _counter(
+    "transcription_llm_tokens_total", "LLM tokens consumed",
+    ["provider", "model", "operation", "kind"],  # kind: prompt | completion
+)
 
 # --- Errors ---
 errors_total = _counter("transcription_errors_total", "Errors", ["error_type", "component"])
@@ -97,10 +117,29 @@ api_request_duration_seconds = _histogram(
 # --- WebSocket ---
 websocket_connections_active = _gauge("transcription_websocket_connections_active", "Active WebSocket connections")
 websocket_connections_total = _counter("transcription_websocket_connections_total", "Total WebSocket connections")
+websocket_messages_sent_total = _counter(
+    "transcription_websocket_messages_sent_total", "WebSocket messages sent to clients",
+    ["type"],  # type: status | error
+)
+websocket_disconnects_total = _counter(
+    "transcription_websocket_disconnects_total", "WebSocket disconnects",
+    ["reason"],  # reason: client_disconnect | auth_missing | not_found | completed | failed | not_found_record | error
+)
 
 # --- Cleanup ---
 cleanup_runs_total = _counter("transcription_cleanup_runs_total", "Cleanup job runs", ["status"])
 cleanup_items_deleted_total = _counter("transcription_cleanup_items_deleted_total", "Items deleted by cleanup", ["resource_type"])
+
+# --- Storage ---
+storage_bytes = (
+    Gauge("transcription_storage_bytes", "Disk usage in bytes", ["path"]) if _enabled else None
+)
+
+# --- Auth ---
+auth_failures_total = _counter(
+    "transcription_auth_failures_total", "Authentication failures",
+    ["reason"],  # reason: missing_headers | ws_missing_headers
+)
 
 
 # --- Helper for safe instrumentation ---
@@ -134,6 +173,35 @@ def gauge_dec(gauge, amount=1):
     """Safely decrement a gauge (no-op if metrics disabled)."""
     if gauge is not None:
         gauge.dec(amount)
+
+
+def gauge_set(gauge, value, *args):
+    """Safely set a gauge value (no-op if metrics disabled)."""
+    if gauge is None:
+        return
+    if args:
+        gauge.labels(*args).set(value)
+    else:
+        gauge.set(value)
+
+
+def track_llm_tokens(provider: str, model: str, operation: str, usage) -> None:
+    """Record LLM token counts from a provider response.
+
+    `usage` accepts OpenAI-style objects (prompt_tokens/completion_tokens) and
+    Ollama-style dicts (prompt_eval_count/eval_count).
+    """
+    if llm_tokens_total is None or usage is None:
+        return
+    prompt = getattr(usage, "prompt_tokens", None)
+    completion = getattr(usage, "completion_tokens", None)
+    if prompt is None and isinstance(usage, dict):
+        prompt = usage.get("prompt_tokens") or usage.get("prompt_eval_count")
+        completion = usage.get("completion_tokens") or usage.get("eval_count")
+    if prompt:
+        inc(llm_tokens_total, provider, model, operation, "prompt", amount=int(prompt))
+    if completion:
+        inc(llm_tokens_total, provider, model, operation, "completion", amount=int(completion))
 
 
 def metrics_response() -> Response:

--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -14,7 +14,7 @@ from app.services.llm.prompt import (
     chunk_transcript,
     build_consolidation_prompt,
 )
-from app.metrics import inc, observe, llm_requests_total, llm_duration_seconds, llm_errors_total, deletions_total, errors_total
+from app.metrics import inc, observe, track_llm_tokens, llm_requests_total, llm_duration_seconds, llm_errors_total, deletions_total, errors_total
 
 router = APIRouter()
 
@@ -178,6 +178,7 @@ async def _call_llm(provider, user_content: str, system_prompt: str) -> dict:
             temperature=0.3,
             response_format={"type": "json_object"},
         )
+        track_llm_tokens(settings.LLM_PROVIDER, provider._model, "analysis", getattr(response, "usage", None))
         content = response.choices[0].message.content or "{}"
         return json.loads(content)
     elif hasattr(provider, "_base_url"):
@@ -198,6 +199,7 @@ async def _call_llm(provider, user_content: str, system_prompt: str) -> dict:
             )
             resp.raise_for_status()
             data = resp.json()
+            track_llm_tokens(settings.LLM_PROVIDER, provider._model, "analysis", data)
             return json.loads(data["message"]["content"])
     else:
         raise HTTPException(status_code=503, detail="Unsupported LLM provider for analysis")

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -16,13 +16,17 @@ from app.models import (
 from app.database import get_db
 from app.services.asr import get_asr_backend
 from app.services.asr.base import TranscriptionSettings
+from app.services.audio import get_media_duration
 from app.services.formats import generate_srt, generate_vtt, generate_txt
 from app.metrics import (
     inc, observe, gauge_inc, gauge_dec,
     transcriptions_total, transcription_duration_seconds, active_transcriptions,
+    transcription_audio_duration_seconds, transcription_realtime_factor,
+    transcription_queue_depth, transcription_queue_wait_seconds,
     diarization_speakers_detected, edits_saved_total, speaker_renames_total,
     downloads_total, deletions_total, errors_total,
     websocket_connections_active, websocket_connections_total,
+    websocket_messages_sent_total, websocket_disconnects_total,
 )
 
 router = APIRouter()
@@ -57,20 +61,32 @@ async def start_transcription(
         )
         await db.commit()
 
-    asyncio.create_task(_run_transcription(transcription_id, mp3_path, req))
+    gauge_inc(transcription_queue_depth)
+    submitted_at = time.monotonic()
+    asyncio.create_task(_run_transcription(transcription_id, mp3_path, req, submitted_at))
     return {"id": transcription_id, "status": "pending"}
 
 
-async def _run_transcription(transcription_id: str, file_path: str, req: TranscriptionSettingsModel):
+async def _run_transcription(transcription_id: str, file_path: str, req: TranscriptionSettingsModel, submitted_at: float):
     backend = get_asr_backend()
+    backend_name = settings.ASR_BACKEND
     ts = TranscriptionSettings(
         language=req.language, model=req.model,
         min_speakers=req.min_speakers, max_speakers=req.max_speakers,
         initial_prompt=req.initial_prompt, hotwords=req.hotwords,
     )
 
+    gauge_dec(transcription_queue_depth)
+    observe(transcription_queue_wait_seconds, time.monotonic() - submitted_at, backend_name)
     gauge_inc(active_transcriptions)
     start_time = time.monotonic()
+
+    try:
+        audio_duration = await asyncio.wait_for(get_media_duration(file_path), timeout=5)
+    except (asyncio.TimeoutError, Exception):
+        audio_duration = None
+    if audio_duration is not None:
+        observe(transcription_audio_duration_seconds, audio_duration, backend_name)
 
     try:
         async with get_db() as db:
@@ -94,8 +110,12 @@ async def _run_transcription(transcription_id: str, file_path: str, req: Transcr
         result = await backend.get_result(asr_job_id)
 
         duration = time.monotonic() - start_time
-        observe(transcription_duration_seconds, duration, req.language or "auto", req.model or "default")
-        inc(transcriptions_total, req.language or "auto", req.model or "default", "completed")
+        lang_label = req.language or "auto"
+        model_label = req.model or "default"
+        observe(transcription_duration_seconds, duration, backend_name, lang_label, model_label)
+        inc(transcriptions_total, backend_name, lang_label, model_label, "completed")
+        if audio_duration and audio_duration > 0:
+            observe(transcription_realtime_factor, duration / audio_duration, backend_name, model_label)
 
         # Track number of unique speakers detected
         speakers = {u.speaker for u in result.utterances if u.speaker}
@@ -130,7 +150,7 @@ async def _run_transcription(transcription_id: str, file_path: str, req: Transcr
     except Exception as e:
         logging.error("Transcription %s failed: %s: %s", transcription_id, type(e).__name__, e)
         logging.error("Traceback: %s", traceback.format_exc())
-        inc(transcriptions_total, req.language or "auto", req.model or "default", "failed")
+        inc(transcriptions_total, backend_name, req.language or "auto", req.model or "default", "failed")
         inc(errors_total, "transcription_failed", "asr")
 
         async with get_db() as db:
@@ -388,13 +408,17 @@ async def update_title(transcription_id: str, body: TitleRequest, user: UserInfo
 
 @router.websocket("/api/ws/status/{transcription_id}")
 async def websocket_status(websocket: WebSocket, transcription_id: str):
+    from app.metrics import auth_failures_total
     await websocket.accept()
     inc(websocket_connections_total)
     gauge_inc(websocket_connections_active)
+    close_reason = "client_disconnect"
     try:
         # Extract user from headers (same as get_current_user dependency)
         user_id = websocket.headers.get("x-auth-request-user")
         if not user_id:
+            inc(auth_failures_total, "ws_missing_headers")
+            close_reason = "auth_missing"
             await websocket.close(code=4001, reason="Missing authentication")
             return
 
@@ -405,6 +429,7 @@ async def websocket_status(websocket: WebSocket, transcription_id: str):
                 (transcription_id, user_id),
             )
             if not await cursor.fetchone():
+                close_reason = "not_found"
                 await websocket.close(code=4003, reason="Not found")
                 return
 
@@ -418,6 +443,8 @@ async def websocket_status(websocket: WebSocket, transcription_id: str):
 
             if not row:
                 await websocket.send_json({"type": "error", "detail": "Transcription not found"})
+                inc(websocket_messages_sent_total, "error")
+                close_reason = "not_found_record"
                 break
 
             status = row["status"]
@@ -425,15 +452,21 @@ async def websocket_status(websocket: WebSocket, transcription_id: str):
             if status == "failed" and row["error_message"]:
                 msg["error"] = row["error_message"]
             await websocket.send_json(msg)
+            inc(websocket_messages_sent_total, "status")
 
             if status in ("completed", "failed"):
+                close_reason = status
                 break
 
             await asyncio.sleep(5)
     except WebSocketDisconnect:
-        pass
+        close_reason = "client_disconnect"
+    except Exception:
+        close_reason = "error"
+        raise
     finally:
         gauge_dec(websocket_connections_active)
+        inc(websocket_disconnects_total, close_reason)
         try:
             await websocket.close()
         except Exception:

--- a/backend/app/routers/translation.py
+++ b/backend/app/routers/translation.py
@@ -11,7 +11,7 @@ from app.services.llm.prompt import (
     build_translation_user_prompt,
     chunk_utterances_for_refinement,
 )
-from app.metrics import inc, observe, llm_requests_total, llm_duration_seconds, llm_errors_total, deletions_total, errors_total
+from app.metrics import inc, observe, track_llm_tokens, llm_requests_total, llm_duration_seconds, llm_errors_total, deletions_total, errors_total
 
 router = APIRouter()
 
@@ -36,9 +36,10 @@ async def _call_llm_translation(provider, utterances: list[dict], target_languag
                 temperature=0.3,
                 response_format={"type": "json_object"},
             )
+            track_llm_tokens(settings.LLM_PROVIDER, provider._model, "translation", getattr(resp, "usage", None))
             data = json.loads(resp.choices[0].message.content or "{}")
         elif isinstance(provider, OllamaProvider):
-            content = await provider._chat(system, user)
+            content = await provider._chat(system, user, operation="translation")
             data = json.loads(content)
         else:
             raise HTTPException(status_code=503, detail="Unsupported LLM provider for translation")

--- a/backend/app/services/audio.py
+++ b/backend/app/services/audio.py
@@ -27,8 +27,33 @@ async def convert_to_mp3(input_path: str) -> str:
     return output_path
 
 
+async def get_media_duration(file_path: str) -> float | None:
+    """Return the duration of a media file in seconds, or None on failure."""
+    process = None
+    try:
+        process = await asyncio.create_subprocess_exec(
+            settings.FFPROBE_PATH, "-v", "error", "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1", file_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await process.communicate()
+        return float(stdout.decode().strip())
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    except asyncio.CancelledError:
+        if process and process.returncode is None:
+            process.kill()
+            try:
+                await process.wait()
+            except Exception:
+                pass
+        raise
+
+
 async def has_video_stream(file_path: str) -> bool:
     """Check if a media file contains a video stream using ffprobe."""
+    process = None
     try:
         process = await asyncio.create_subprocess_exec(
             settings.FFPROBE_PATH, "-v", "error", "-select_streams", "v",
@@ -40,3 +65,11 @@ async def has_video_stream(file_path: str) -> bool:
         return b"video" in stdout
     except (FileNotFoundError, OSError):
         return False
+    except asyncio.CancelledError:
+        if process and process.returncode is None:
+            process.kill()
+            try:
+                await process.wait()
+            except Exception:
+                pass
+        raise

--- a/backend/app/services/llm/ollama.py
+++ b/backend/app/services/llm/ollama.py
@@ -1,6 +1,7 @@
 import json
 import httpx
 from app.config import settings
+from app.metrics import track_llm_tokens
 from app.services.llm.base import LLMProvider
 from app.services.llm.prompt import (
     build_system_prompt, build_user_prompt, chunk_transcript, build_consolidation_prompt,
@@ -48,7 +49,7 @@ class OllamaProvider(LLMProvider):
             chapters=[SummaryChapter(**ch) for ch in data.get("chapters", [])],
         )
 
-    async def _chat(self, system: str, user: str) -> str:
+    async def _chat(self, system: str, user: str, operation: str = "analysis") -> str:
         async with httpx.AsyncClient(timeout=300) as client:
             response = await client.post(
                 f"{self._base_url}/api/chat",
@@ -63,7 +64,9 @@ class OllamaProvider(LLMProvider):
                 },
             )
             response.raise_for_status()
-            return response.json()["message"]["content"]
+            payload = response.json()
+            track_llm_tokens("ollama", self._model, operation, payload)
+            return payload["message"]["content"]
 
     async def generate_protocol(self, transcript: str, summary_context: str | None = None, language: str | None = None) -> ProtocolResult:
         chunks = chunk_transcript(transcript)
@@ -117,7 +120,7 @@ class OllamaProvider(LLMProvider):
         for chunk in chunks:
             system = build_refinement_system_prompt(context)
             user = build_refinement_user_prompt(chunk)
-            content = await self._chat(system, user)
+            content = await self._chat(system, user, operation="refinement")
             data = json.loads(content)
             all_refined.extend(data.get("utterances", []))
             summaries.append(data.get("changes_summary", ""))
@@ -128,6 +131,7 @@ class OllamaProvider(LLMProvider):
                 REFINEMENT_CONSOLIDATION_PROMPT.format(
                     summaries="\n".join(f"- {s}" for s in summaries)
                 ),
+                operation="refinement",
             )
         else:
             combined_summary = summaries[0] if summaries else "No changes needed"
@@ -141,6 +145,7 @@ class OllamaProvider(LLMProvider):
         result = await self._chat(
             "Generate a short descriptive title (max 8 words) for the following transcript. Return ONLY the title text, nothing else. No quotes, no punctuation at the end.",
             transcript[:2000],
+            operation="title",
         )
         try:
             data = json.loads(result)

--- a/backend/app/services/llm/openai.py
+++ b/backend/app/services/llm/openai.py
@@ -1,6 +1,7 @@
 import json
 from openai import AsyncOpenAI
 from app.config import settings
+from app.metrics import track_llm_tokens
 from app.services.llm.base import LLMProvider
 from app.services.llm.prompt import (
     build_system_prompt, build_user_prompt, chunk_transcript, build_consolidation_prompt,
@@ -19,6 +20,11 @@ class OpenAIProvider(LLMProvider):
         )
         self._model = settings.LLM_MODEL or "gpt-4o"
 
+    async def _chat_complete(self, operation: str, **kwargs):
+        response = await self._client.chat.completions.create(model=self._model, **kwargs)
+        track_llm_tokens("openai", self._model, operation, getattr(response, "usage", None))
+        return response
+
     async def generate_summary(self, transcript: str, chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
         chunks = chunk_transcript(transcript)
 
@@ -34,8 +40,8 @@ class OpenAIProvider(LLMProvider):
         return await self._consolidate(chunk_summaries, chapter_hints, language)
 
     async def _summarize_single(self, transcript: str, chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        response = await self._client.chat.completions.create(
-            model=self._model,
+        response = await self._chat_complete(
+            "analysis",
             messages=[
                 {"role": "system", "content": build_system_prompt(chapter_hints, language)},
                 {"role": "user", "content": build_user_prompt(transcript)},
@@ -56,8 +62,8 @@ class OpenAIProvider(LLMProvider):
         prompt = build_consolidation_prompt(
             "\n\n---\n\n".join(chunk_summaries), chapter_hints, language
         )
-        response = await self._client.chat.completions.create(
-            model=self._model,
+        response = await self._chat_complete(
+            "analysis",
             messages=[
                 {"role": "system", "content": build_system_prompt(chapter_hints, language)},
                 {"role": "user", "content": prompt},
@@ -88,8 +94,8 @@ class OpenAIProvider(LLMProvider):
         return await self._consolidate_protocol(chunk_protocols, language)
 
     async def _protocol_single(self, transcript: str, summary_context: str | None = None, language: str | None = None) -> ProtocolResult:
-        response = await self._client.chat.completions.create(
-            model=self._model,
+        response = await self._chat_complete(
+            "analysis",
             messages=[
                 {"role": "system", "content": build_protocol_system_prompt(language)},
                 {"role": "user", "content": build_protocol_user_prompt(transcript, summary_context)},
@@ -117,8 +123,8 @@ class OpenAIProvider(LLMProvider):
             schema=json.dumps(PROTOCOL_SCHEMA, indent=2),
             language_instruction=language_instruction,
         )
-        response = await self._client.chat.completions.create(
-            model=self._model,
+        response = await self._chat_complete(
+            "analysis",
             messages=[
                 {"role": "system", "content": build_protocol_system_prompt(language)},
                 {"role": "user", "content": prompt},
@@ -148,8 +154,8 @@ class OpenAIProvider(LLMProvider):
         for chunk in chunks:
             system = build_refinement_system_prompt(context)
             user = build_refinement_user_prompt(chunk)
-            resp = await self._client.chat.completions.create(
-                model=self._model,
+            resp = await self._chat_complete(
+                "refinement",
                 messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
                 temperature=0.3,
                 response_format={"type": "json_object"},
@@ -159,8 +165,8 @@ class OpenAIProvider(LLMProvider):
             summaries.append(data.get("changes_summary", ""))
 
         if len(summaries) > 1:
-            consolidation_resp = await self._client.chat.completions.create(
-                model=self._model,
+            consolidation_resp = await self._chat_complete(
+                "refinement",
                 messages=[{"role": "user", "content": REFINEMENT_CONSOLIDATION_PROMPT.format(
                     summaries="\n".join(f"- {s}" for s in summaries)
                 )}],
@@ -176,8 +182,8 @@ class OpenAIProvider(LLMProvider):
         )
 
     async def generate_title(self, transcript: str) -> str:
-        response = await self._client.chat.completions.create(
-            model=self._model,
+        response = await self._chat_complete(
+            "title",
             messages=[
                 {"role": "system", "content": "Generate a short descriptive title (max 8 words) for the following transcript. Return ONLY the title text, nothing else. No quotes, no punctuation at the end."},
                 {"role": "user", "content": transcript[:2000]},


### PR DESCRIPTION
## Summary

Expands Prometheus coverage to fill gaps in the golden signals and enable key dashboards (realtime factor, queue backpressure, LLM cost).

### New metrics
- **Transcription**: `transcription_audio_duration_seconds`, `transcription_realtime_factor`, `transcription_queue_depth`, `transcription_queue_wait_seconds`
- **LLM**: `transcription_llm_tokens_total` (provider, model, operation, kind=prompt|completion) — emitted per call inside each provider's chat helper, so chunked operations aggregate correctly. Operations: `analysis`, `translation`, `refinement`, `title`.
- **WebSocket**: `transcription_websocket_messages_sent_total` (type), `transcription_websocket_disconnects_total` (reason)
- **Storage**: `transcription_storage_bytes` (labelled by path) — refreshed at startup and after each cleanup run, no extra task
- **Auth**: `transcription_auth_failures_total` (reason)

### Breaking change
`transcription_jobs_total` and `transcription_duration_seconds` now carry an additional `backend` label (`murmurai` / `whisperx`). Dashboards/alerts need to aggregate away or include the new label.

### Safety
`get_media_duration` (new ffprobe helper in `services/audio.py`) is wrapped in `asyncio.wait_for(timeout=5)` inside the detached transcription task, and both ffprobe helpers kill+reap the subprocess on `CancelledError` to avoid orphaned processes.

### Docs
- README metrics section rewritten with the new entries and the breaking-change note
- CLAUDE.md gains an Observability section documenting the helpers and labelling conventions
- `.claude/` added to `.gitignore`