### PR TITLE
feat(api): personal API tokens for external access

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,48 @@ For subpath deployments behind a reverse proxy (e.g., serving at `/transcription
 docker build --build-arg VITE_BASE_PATH=/transcription -t transcription-app .
 ```
 
+## API access
+
+The REST API is available for scripting and third-party integrations when
+`ENABLE_API_TOKENS=true` is set in the environment.
+
+### Enabling tokens
+
+Add to `.env` before `docker run` or the local uvicorn process:
+
+```
+ENABLE_API_TOKENS=true
+API_TOKEN_MAX_PER_USER=10        # optional, default 10
+API_TOKEN_DEFAULT_EXPIRY_DAYS=90 # optional, default 90
+```
+
+### Issuing a token
+
+With `ENABLE_API_TOKENS=true`, logged-in users see a **Settings → API tokens**
+page in the UI. Click **Create token**, choose an expiry, and copy the
+displayed `tw_…` string. The raw token is shown only once.
+
+### Using a token
+
+Pass the token as an HTTP bearer header:
+
+```bash
+curl -H "Authorization: Bearer tw_..." https://your-host/api/tokens
+```
+
+For the status WebSocket, pass the token as a query parameter (browsers cannot
+send custom headers on WebSocket requests):
+
+```
+wss://your-host/api/ws/status/{transcription_id}?token=tw_...
+```
+
+Tokens inherit the issuing user's access — they can read and write the user's
+own files, transcriptions, and presets, but cannot see another user's data.
+Tokens never carry LLM capabilities beyond what the deployment has configured:
+if `LLM_PROVIDER` is unset, analysis/translation/refinement endpoints return
+503 regardless of authentication method.
+
 ## Development
 
 ### Backend

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,6 +30,9 @@ class Settings:
     ENABLED_LANGUAGES: list[str] = [c.strip() for c in os.getenv("ENABLED_LANGUAGES", "").split(",") if c.strip()]
     ENABLE_METRICS: bool = os.getenv("ENABLE_METRICS", "true").lower() in ("true", "1", "yes")
     DEV_MODE: bool = os.getenv("DEV_MODE", "false").lower() in ("true", "1", "yes")
+    ENABLE_API_TOKENS: bool = os.getenv("ENABLE_API_TOKENS", "false").lower() in ("true", "1", "yes")
+    API_TOKEN_MAX_PER_USER: int = int(os.getenv("API_TOKEN_MAX_PER_USER", "10"))
+    API_TOKEN_DEFAULT_EXPIRY_DAYS: int = int(os.getenv("API_TOKEN_DEFAULT_EXPIRY_DAYS", "90"))
 
     @property
     def db_path(self) -> str:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -113,6 +113,20 @@ CREATE TABLE IF NOT EXISTS preset_bundles (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    name TEXT NOT NULL,
+    prefix TEXT NOT NULL,
+    token_hash TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP,
+    last_used_at TIMESTAMP,
+    revoked_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
 """
 
 _db_path: str = ""

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,19 +1,53 @@
+import asyncio
+import logging
+
 from fastapi import HTTPException, Request
+
 from app.config import settings
-from app.metrics import inc, auth_failures_total
+from app.database import get_db
+from app.metrics import inc, auth_failures_total, api_token_auth_total
 from app.models import UserInfo
+from app.services.api_tokens import resolve_token, touch_last_used
+
+logger = logging.getLogger(__name__)
+
+
+async def _touch_best_effort(token_id: str) -> None:
+    try:
+        async with get_db() as db:
+            await touch_last_used(db, token_id=token_id)
+    except Exception as e:
+        logger.warning("touch_last_used failed for %s: %s", token_id, e)
 
 
 async def get_current_user(request: Request) -> UserInfo:
+    if settings.ENABLE_API_TOKENS:
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer tw_"):
+            raw = auth.removeprefix("Bearer ").strip()
+            async with get_db() as db:
+                result = await resolve_token(db, raw_token=raw)
+            if result is not None:
+                user, token_id = result
+                inc(api_token_auth_total, "success")
+                asyncio.create_task(_touch_best_effort(token_id))
+                return user
+            inc(api_token_auth_total, "failure")
+            inc(auth_failures_total, "invalid_token")
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid or expired API token",
+                headers={"WWW-Authenticate": 'Bearer realm="transcription-whisper"'},
+            )
+
     user_id = request.headers.get("X-Auth-Request-User")
     email = request.headers.get("X-Auth-Request-Email")
-
     if user_id:
         return UserInfo(id=user_id, email=email)
-    elif email:
+    if email:
         return UserInfo(id=email, email=email)
-    elif settings.DEV_MODE:
+    if settings.DEV_MODE:
         return UserInfo(id="dev-user", email="dev@localhost")
-    else:
-        inc(auth_failures_total, "missing_headers")
-        raise HTTPException(status_code=401, detail="Missing authentication headers")
+
+    inc(auth_failures_total, "missing_headers")
+    raise HTTPException(status_code=401, detail="Missing authentication headers")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db, get_db
-from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets
+from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets, tokens
 from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes
 from app.services.audio import has_video_stream
 
@@ -142,6 +142,7 @@ app.include_router(refinement.router)
 app.include_router(analysis.router)
 app.include_router(translation.router)
 app.include_router(presets.router)
+app.include_router(tokens.router)
 
 # Serve frontend static files (only when built files exist, i.e., in Docker)
 from fastapi.staticfiles import StaticFiles

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -149,7 +149,8 @@ app.include_router(refinement.router)
 app.include_router(analysis.router)
 app.include_router(translation.router)
 app.include_router(presets.router)
-app.include_router(tokens.router)
+if settings.ENABLE_API_TOKENS:
+    app.include_router(tokens.router)
 
 # Serve frontend static files (only when built files exist, i.e., in Docker)
 from fastapi.staticfiles import StaticFiles

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,8 +8,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db, get_db
 from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets, tokens
-from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes
+from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes, api_tokens_active
 from app.services.audio import has_video_stream
+from app.services.api_tokens import cleanup_stale_tokens, count_active_tokens
 
 
 def _dir_size_bytes(path: str) -> int:
@@ -86,12 +87,16 @@ async def cleanup_old_files():
                 )
                 db_files_deleted = cursor.rowcount
                 await db.commit()
+                tokens_deleted = await cleanup_stale_tokens(db)
+                active_tokens = await count_active_tokens(db)
 
             inc(cleanup_runs_total, "success")
             inc(cleanup_items_deleted_total, "file", amount=files_deleted + db_files_deleted)
             inc(cleanup_items_deleted_total, "transcription", amount=transcriptions_deleted)
             inc(cleanup_items_deleted_total, "analysis", amount=analyses_deleted)
             inc(cleanup_items_deleted_total, "speaker_mapping", amount=mappings_deleted)
+            inc(cleanup_items_deleted_total, "api_token", amount=tokens_deleted)
+            gauge_set(api_tokens_active, active_tokens)
             _refresh_storage_gauge()
         except Exception as e:
             inc(cleanup_runs_total, "failed")
@@ -120,6 +125,8 @@ async def lifespan(app: FastAPI):
         if rows:
             await db.commit()
     _refresh_storage_gauge()
+    async with get_db() as db:
+        gauge_set(api_tokens_active, await count_active_tokens(db))
     cleanup_task = asyncio.create_task(cleanup_old_files())
     yield
     cleanup_task.cancel()

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -138,8 +138,17 @@ storage_bytes = (
 # --- Auth ---
 auth_failures_total = _counter(
     "transcription_auth_failures_total", "Authentication failures",
-    ["reason"],  # reason: missing_headers | ws_missing_headers
+    ["reason"],  # reason: missing_headers | ws_missing_headers | invalid_token | expired_token | revoked_token
 )
+
+# --- API tokens ---
+api_tokens_created_total = _counter("transcription_api_tokens_created_total", "API tokens created")
+api_tokens_revoked_total = _counter("transcription_api_tokens_revoked_total", "API tokens revoked")
+api_token_auth_total = _counter(
+    "transcription_api_token_auth_total", "API token authentication attempts",
+    ["result"],  # result: success | failure
+)
+api_tokens_active = _gauge("transcription_api_tokens_active", "Active (non-revoked, non-expired) API tokens")
 
 
 # --- Helper for safe instrumentation ---

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -138,7 +138,7 @@ storage_bytes = (
 # --- Auth ---
 auth_failures_total = _counter(
     "transcription_auth_failures_total", "Authentication failures",
-    ["reason"],  # reason: missing_headers | ws_missing_headers | invalid_token | expired_token | revoked_token
+    ["reason"],  # reason: missing_headers | ws_missing_headers | invalid_token
 )
 
 # --- API tokens ---

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -205,6 +205,7 @@ class ConfigResponse(BaseModel):
     logout_url: str
     popular_languages: list[str] = []
     enabled_languages: list[str] = []
+    api_tokens_enabled: bool = False
 
 
 # --- Presets ---
@@ -270,3 +271,44 @@ class BundleExpandedResponse(BundleResponse):
     transcription_preset: TranscriptionPresetResponse | None = None
     analysis_preset: AnalysisPresetResponse | None = None
     refinement_preset: RefinementPresetResponse | None = None
+
+
+# --- API Tokens ---
+
+class TokenCreateRequest(BaseModel):
+    name: str
+    expires_in_days: int | None = None
+
+    @field_validator("name")
+    @classmethod
+    def name_length(cls, v: str) -> str:
+        stripped = v.strip()
+        if not (1 <= len(stripped) <= 64):
+            raise ValueError("Name must be 1–64 characters")
+        return stripped
+
+    @field_validator("expires_in_days")
+    @classmethod
+    def positive_days(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("expires_in_days must be positive or null")
+        return v
+
+
+class TokenCreateResponse(BaseModel):
+    id: str
+    name: str
+    prefix: str
+    created_at: str
+    expires_at: str | None = None
+    token: str  # raw token — only present in creation response
+
+
+class TokenListItem(BaseModel):
+    id: str
+    name: str
+    prefix: str
+    created_at: str
+    expires_at: str | None = None
+    last_used_at: str | None = None
+    revoked_at: str | None = None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -206,6 +206,7 @@ class ConfigResponse(BaseModel):
     popular_languages: list[str] = []
     enabled_languages: list[str] = []
     api_tokens_enabled: bool = False
+    api_token_default_expiry_days: int = 90
 
 
 # --- Presets ---

--- a/backend/app/routers/config_router.py
+++ b/backend/app/routers/config_router.py
@@ -21,6 +21,7 @@ async def get_config():
         logout_url=settings.LOGOUT_URL,
         popular_languages=settings.POPULAR_LANGUAGES,
         enabled_languages=settings.ENABLED_LANGUAGES,
+        api_tokens_enabled=settings.ENABLE_API_TOKENS,
     )
 
 

--- a/backend/app/routers/config_router.py
+++ b/backend/app/routers/config_router.py
@@ -22,6 +22,7 @@ async def get_config():
         popular_languages=settings.POPULAR_LANGUAGES,
         enabled_languages=settings.ENABLED_LANGUAGES,
         api_tokens_enabled=settings.ENABLE_API_TOKENS,
+        api_token_default_expiry_days=settings.API_TOKEN_DEFAULT_EXPIRY_DAYS,
     )
 
 

--- a/backend/app/routers/tokens.py
+++ b/backend/app/routers/tokens.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+
+from app.config import settings
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.metrics import inc, api_tokens_created_total, api_tokens_revoked_total
+from app.models import (
+    TokenCreateRequest, TokenCreateResponse, TokenListItem, UserInfo,
+)
+from app.services.api_tokens import (
+    create_token, list_tokens, revoke_token,
+    DuplicateTokenNameError, TokenLimitError,
+)
+
+
+async def _require_tokens_enabled() -> None:
+    if not settings.ENABLE_API_TOKENS:
+        raise HTTPException(status_code=404)
+
+
+router = APIRouter(dependencies=[Depends(_require_tokens_enabled)])
+
+
+@router.post("/api/tokens", response_model=TokenCreateResponse)
+async def create_api_token(
+    req: TokenCreateRequest,
+    user: UserInfo = Depends(get_current_user),
+):
+    async with get_db() as db:
+        # Ensure user row exists (mirrors upload.py pattern)
+        await db.execute(
+            "INSERT OR IGNORE INTO users (id, email) VALUES (?, ?)",
+            (user.id, user.email),
+        )
+        try:
+            created = await create_token(
+                db, user_id=user.id, name=req.name, expires_in_days=req.expires_in_days,
+            )
+        except DuplicateTokenNameError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except TokenLimitError as e:
+            raise HTTPException(status_code=429, detail=str(e))
+    inc(api_tokens_created_total)
+    return TokenCreateResponse(**created)
+
+
+@router.get("/api/tokens", response_model=list[TokenListItem])
+async def list_api_tokens(user: UserInfo = Depends(get_current_user)):
+    async with get_db() as db:
+        items = await list_tokens(db, user_id=user.id)
+    return [TokenListItem(**row) for row in items]
+
+
+@router.delete("/api/tokens/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_api_token(
+    token_id: str,
+    user: UserInfo = Depends(get_current_user),
+):
+    async with get_db() as db:
+        ok = await revoke_token(db, user_id=user.id, token_id=token_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Token not found")
+    inc(api_tokens_revoked_total)
+    return Response(status_code=204)

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -15,6 +15,7 @@ from app.models import (
 )
 from app.database import get_db
 from app.services.asr import get_asr_backend
+from app.services.api_tokens import resolve_token
 from app.services.asr.base import TranscriptionSettings
 from app.services.audio import get_media_duration
 from app.services.formats import generate_srt, generate_vtt, generate_txt
@@ -414,8 +415,23 @@ async def websocket_status(websocket: WebSocket, transcription_id: str):
     gauge_inc(websocket_connections_active)
     close_reason = "client_disconnect"
     try:
-        # Extract user from headers (same as get_current_user dependency)
-        user_id = websocket.headers.get("x-auth-request-user")
+        # Prefer API token from query param when feature is enabled
+        user_id: str | None = None
+        if settings.ENABLE_API_TOKENS:
+            raw = websocket.query_params.get("token")
+            if raw and raw.startswith("tw_"):
+                async with get_db() as db:
+                    result = await resolve_token(db, raw_token=raw)
+                if result is None:
+                    inc(auth_failures_total, "invalid_token")
+                    close_reason = "auth_missing"
+                    await websocket.close(code=4001, reason="Invalid token")
+                    return
+                user_id = result[0].id
+
+        if user_id is None:
+            user_id = websocket.headers.get("x-auth-request-user")
+
         if not user_id:
             inc(auth_failures_total, "ws_missing_headers")
             close_reason = "auth_missing"

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -28,6 +28,7 @@ from app.metrics import (
     downloads_total, deletions_total, errors_total,
     websocket_connections_active, websocket_connections_total,
     websocket_messages_sent_total, websocket_disconnects_total,
+    auth_failures_total, api_token_auth_total,
 )
 
 router = APIRouter()
@@ -409,7 +410,6 @@ async def update_title(transcription_id: str, body: TitleRequest, user: UserInfo
 
 @router.websocket("/api/ws/status/{transcription_id}")
 async def websocket_status(websocket: WebSocket, transcription_id: str):
-    from app.metrics import auth_failures_total
     await websocket.accept()
     inc(websocket_connections_total)
     gauge_inc(websocket_connections_active)
@@ -423,11 +423,13 @@ async def websocket_status(websocket: WebSocket, transcription_id: str):
                 async with get_db() as db:
                     result = await resolve_token(db, raw_token=raw)
                 if result is None:
+                    inc(api_token_auth_total, "failure")
                     inc(auth_failures_total, "invalid_token")
                     close_reason = "auth_missing"
                     await websocket.close(code=4001, reason="Invalid token")
                     return
                 user_id = result[0].id
+                inc(api_token_auth_total, "success")
 
         if user_id is None:
             user_id = websocket.headers.get("x-auth-request-user")

--- a/backend/app/services/api_tokens.py
+++ b/backend/app/services/api_tokens.py
@@ -38,8 +38,16 @@ async def create_token(
     Raises TokenLimitError if the user is at the cap.
     Raises DuplicateTokenNameError if an active token with this name already exists.
     """
+    # Capture current time once for all queries and the INSERT
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.strftime("%Y-%m-%d %H:%M:%S")
+    expires_at: str | None = None
+    if expires_in_days is not None:
+        expires_at = (now_dt + timedelta(days=expires_in_days)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
     # Check per-user cap (count truly active tokens: non-revoked and non-expired)
-    now = _now_str()
     cursor = await db.execute(
         "SELECT COUNT(*) FROM api_tokens WHERE user_id = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
         (user_id, now),
@@ -51,13 +59,13 @@ async def create_token(
             f"User {user_id} has reached the maximum of {settings.API_TOKEN_MAX_PER_USER} active tokens"
         )
 
-    # Check for duplicate name among active tokens
+    # Check for duplicate name among active (non-revoked, non-expired) tokens
     cursor = await db.execute(
-        "SELECT COUNT(*) FROM api_tokens WHERE user_id = ? AND name = ? AND revoked_at IS NULL",
-        (user_id, name),
+        "SELECT id FROM api_tokens WHERE user_id = ? AND name = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+        (user_id, name, now),
     )
     row = await cursor.fetchone()
-    if row[0] > 0:
+    if row is not None:
         raise DuplicateTokenNameError(
             f"An active token named '{name}' already exists for this user"
         )
@@ -67,20 +75,13 @@ async def create_token(
     prefix = raw_token[:12]
     token_hash = _hash_token(raw_token)
     token_id = str(uuid.uuid4())
-    created_at = _now_str()
-
-    expires_at: str | None = None
-    if expires_in_days is not None:
-        expires_at = (
-            datetime.now(timezone.utc) + timedelta(days=expires_in_days)
-        ).strftime("%Y-%m-%d %H:%M:%S")
 
     await db.execute(
         """
         INSERT INTO api_tokens (id, user_id, name, prefix, token_hash, created_at, expires_at)
         VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (token_id, user_id, name, prefix, token_hash, created_at, expires_at),
+        (token_id, user_id, name, prefix, token_hash, now, expires_at),
     )
     await db.commit()
 
@@ -88,7 +89,7 @@ async def create_token(
         "id": token_id,
         "name": name,
         "prefix": prefix,
-        "created_at": created_at,
+        "created_at": now,
         "expires_at": expires_at,
         "token": raw_token,
     }

--- a/backend/app/services/api_tokens.py
+++ b/backend/app/services/api_tokens.py
@@ -1,0 +1,216 @@
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from aiosqlite import Connection
+
+from app.config import settings
+from app.models import UserInfo
+
+
+class TokenLimitError(Exception):
+    """Raised when a user has reached the per-user token cap."""
+
+
+class DuplicateTokenNameError(Exception):
+    """Raised when a user already has an active token with the given name."""
+
+
+def _now_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+async def create_token(
+    db: Connection,
+    *,
+    user_id: str,
+    name: str,
+    expires_in_days: int | None,
+) -> dict:
+    """Create a new API token for the given user.
+
+    Returns a dict with keys: id, name, prefix, created_at, expires_at, token.
+    Raises TokenLimitError if the user is at the cap.
+    Raises DuplicateTokenNameError if an active token with this name already exists.
+    """
+    # Check per-user cap (count non-revoked tokens)
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM api_tokens WHERE user_id = ? AND revoked_at IS NULL",
+        (user_id,),
+    )
+    row = await cursor.fetchone()
+    active_count = row[0]
+    if active_count >= settings.API_TOKEN_MAX_PER_USER:
+        raise TokenLimitError(
+            f"User {user_id} has reached the maximum of {settings.API_TOKEN_MAX_PER_USER} active tokens"
+        )
+
+    # Check for duplicate name among active tokens
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM api_tokens WHERE user_id = ? AND name = ? AND revoked_at IS NULL",
+        (user_id, name),
+    )
+    row = await cursor.fetchone()
+    if row[0] > 0:
+        raise DuplicateTokenNameError(
+            f"An active token named '{name}' already exists for this user"
+        )
+
+    # Generate token
+    raw_token = "tw_" + secrets.token_urlsafe(32)
+    prefix = raw_token[:12]
+    token_hash = _hash_token(raw_token)
+    token_id = str(uuid.uuid4())
+    created_at = _now_str()
+
+    expires_at: str | None = None
+    if expires_in_days is not None:
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(days=expires_in_days)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+
+    await db.execute(
+        """
+        INSERT INTO api_tokens (id, user_id, name, prefix, token_hash, created_at, expires_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (token_id, user_id, name, prefix, token_hash, created_at, expires_at),
+    )
+    await db.commit()
+
+    return {
+        "id": token_id,
+        "name": name,
+        "prefix": prefix,
+        "created_at": created_at,
+        "expires_at": expires_at,
+        "token": raw_token,
+    }
+
+
+async def list_tokens(db: Connection, *, user_id: str) -> list[dict]:
+    """Return all tokens for the user. Never includes 'token' or 'token_hash' fields."""
+    cursor = await db.execute(
+        """
+        SELECT id, name, prefix, created_at, expires_at, last_used_at, revoked_at
+        FROM api_tokens
+        WHERE user_id = ?
+        ORDER BY created_at DESC
+        """,
+        (user_id,),
+    )
+    rows = await cursor.fetchall()
+    return [
+        {
+            "id": row["id"],
+            "name": row["name"],
+            "prefix": row["prefix"],
+            "created_at": row["created_at"],
+            "expires_at": row["expires_at"],
+            "last_used_at": row["last_used_at"],
+            "revoked_at": row["revoked_at"],
+        }
+        for row in rows
+    ]
+
+
+async def revoke_token(db: Connection, *, user_id: str, token_id: str) -> bool:
+    """Revoke a token. Returns True only if the row was updated (ownership match and not already revoked)."""
+    now = _now_str()
+    cursor = await db.execute(
+        """
+        UPDATE api_tokens
+        SET revoked_at = ?
+        WHERE id = ? AND user_id = ? AND revoked_at IS NULL
+        """,
+        (now, token_id, user_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def resolve_token(
+    db: Connection, *, raw_token: str
+) -> tuple[UserInfo, str] | None:
+    """Resolve a raw token string to a (UserInfo, token_id) tuple.
+
+    Returns None if the token is invalid, expired, revoked, or unknown.
+    """
+    token_hash = _hash_token(raw_token)
+    now = _now_str()
+
+    cursor = await db.execute(
+        """
+        SELECT t.id, t.user_id, t.expires_at, t.revoked_at, u.email
+        FROM api_tokens t
+        JOIN users u ON u.id = t.user_id
+        WHERE t.token_hash = ?
+        """,
+        (token_hash,),
+    )
+    row = await cursor.fetchone()
+
+    if row is None:
+        return None
+
+    # Check revoked
+    if row["revoked_at"] is not None:
+        return None
+
+    # Check expiry
+    if row["expires_at"] is not None and row["expires_at"] <= now:
+        return None
+
+    user = UserInfo(id=row["user_id"], email=row["email"])
+    return user, row["id"]
+
+
+async def touch_last_used(db: Connection, *, token_id: str) -> None:
+    """Update last_used_at to now for the given token."""
+    now = _now_str()
+    await db.execute(
+        "UPDATE api_tokens SET last_used_at = ? WHERE id = ?",
+        (now, token_id),
+    )
+    await db.commit()
+
+
+async def cleanup_stale_tokens(db: Connection) -> int:
+    """Hard-delete tokens revoked >30 days ago OR expired >90 days ago.
+
+    Returns the number of tokens deleted.
+    """
+    now = datetime.now(timezone.utc)
+    revoked_cutoff = (now - timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S")
+    expired_cutoff = (now - timedelta(days=90)).strftime("%Y-%m-%d %H:%M:%S")
+
+    cursor = await db.execute(
+        """
+        DELETE FROM api_tokens
+        WHERE (revoked_at IS NOT NULL AND revoked_at < ?)
+           OR (expires_at IS NOT NULL AND expires_at < ?)
+        """,
+        (revoked_cutoff, expired_cutoff),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def count_active_tokens(db: Connection) -> int:
+    """Return count of rows where revoked_at IS NULL and (expires_at IS NULL OR expires_at > now)."""
+    now = _now_str()
+    cursor = await db.execute(
+        """
+        SELECT COUNT(*) FROM api_tokens
+        WHERE revoked_at IS NULL
+          AND (expires_at IS NULL OR expires_at > ?)
+        """,
+        (now,),
+    )
+    row = await cursor.fetchone()
+    return row[0]

--- a/backend/app/services/api_tokens.py
+++ b/backend/app/services/api_tokens.py
@@ -38,10 +38,11 @@ async def create_token(
     Raises TokenLimitError if the user is at the cap.
     Raises DuplicateTokenNameError if an active token with this name already exists.
     """
-    # Check per-user cap (count non-revoked tokens)
+    # Check per-user cap (count truly active tokens: non-revoked and non-expired)
+    now = _now_str()
     cursor = await db.execute(
-        "SELECT COUNT(*) FROM api_tokens WHERE user_id = ? AND revoked_at IS NULL",
-        (user_id,),
+        "SELECT COUNT(*) FROM api_tokens WHERE user_id = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+        (user_id, now),
     )
     row = await cursor.fetchone()
     active_count = row[0]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,8 @@
-import asyncio
 import os
+os.environ.setdefault("ENABLE_API_TOKENS", "true")
+os.environ.setdefault("DEV_MODE", "true")
+
+import asyncio
 import tempfile
 import pytest
 import pytest_asyncio

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -167,11 +167,12 @@ async def test_cleanup_stale_tokens_removes_old_revoked_and_expired():
         await db.commit()
 
         deleted = await cleanup_stale_tokens(db)
-        assert deleted == 2
 
-        cursor = await db.execute("SELECT COUNT(*) as cnt FROM api_tokens")
-        row = await cursor.fetchone()
-        assert row["cnt"] == 1
+        cursor = await db.execute("SELECT name FROM api_tokens")
+        rows = await cursor.fetchall()
+        remaining_names = {r["name"] for r in rows}
+    assert deleted == 2
+    assert remaining_names == {"still-active"}
 
 
 @pytest.mark.asyncio
@@ -191,3 +192,22 @@ async def test_create_token_cap_ignores_expired_tokens(monkeypatch):
         # Should now be allowed — only one "active" token
         result = await create_token(db, user_id="u1", name="c", expires_in_days=None)
     assert result["id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_touch_last_used_updates_timestamp():
+    from app.database import get_db
+    async with get_db() as db:
+        await _seed_user(db)
+        t = await create_token(db, user_id="u1", name="touch-test", expires_in_days=None)
+
+        # Fetch initial last_used_at — should be NULL
+        cursor = await db.execute("SELECT last_used_at FROM api_tokens WHERE id = ?", (t["id"],))
+        row = await cursor.fetchone()
+        assert row["last_used_at"] is None
+
+        await touch_last_used(db, token_id=t["id"])
+
+        cursor = await db.execute("SELECT last_used_at FROM api_tokens WHERE id = ?", (t["id"],))
+        row = await cursor.fetchone()
+    assert row["last_used_at"] is not None

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -1,0 +1,174 @@
+import pytest
+import app.config as config_module
+from app.database import get_db
+from app.models import UserInfo
+from app.services.api_tokens import (
+    create_token,
+    list_tokens,
+    revoke_token,
+    resolve_token,
+    touch_last_used,
+    cleanup_stale_tokens,
+    count_active_tokens,
+    TokenLimitError,
+    DuplicateTokenNameError,
+)
+
+
+async def _seed_user(db, user_id="u1", email="u1@example.com"):
+    await db.execute("INSERT INTO users (id, email) VALUES (?, ?)", (user_id, email))
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_create_token_returns_raw_and_persists_hash():
+    async with get_db() as db:
+        await _seed_user(db)
+        result = await create_token(db, user_id="u1", name="my-token", expires_in_days=30)
+
+    assert result["token"].startswith("tw_")
+    assert result["prefix"] == result["token"][:12]
+    assert "token_hash" not in result
+
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT token_hash FROM api_tokens WHERE id = ?", (result["id"],)
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row["token_hash"] != result["token"]
+
+
+@pytest.mark.asyncio
+async def test_create_token_rejects_duplicate_name():
+    async with get_db() as db:
+        await _seed_user(db)
+        await create_token(db, user_id="u1", name="dup-name", expires_in_days=30)
+        with pytest.raises(DuplicateTokenNameError):
+            await create_token(db, user_id="u1", name="dup-name", expires_in_days=30)
+
+
+@pytest.mark.asyncio
+async def test_create_token_enforces_per_user_cap(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "API_TOKEN_MAX_PER_USER", 2)
+    async with get_db() as db:
+        await _seed_user(db)
+        await create_token(db, user_id="u1", name="token-1", expires_in_days=30)
+        await create_token(db, user_id="u1", name="token-2", expires_in_days=30)
+        with pytest.raises(TokenLimitError):
+            await create_token(db, user_id="u1", name="token-3", expires_in_days=30)
+
+
+@pytest.mark.asyncio
+async def test_list_tokens_returns_user_tokens_only():
+    async with get_db() as db:
+        await _seed_user(db, "u1", "u1@example.com")
+        await _seed_user(db, "u2", "u2@example.com")
+        await create_token(db, user_id="u1", name="u1-token", expires_in_days=30)
+        await create_token(db, user_id="u2", name="u2-token", expires_in_days=30)
+
+        tokens = await list_tokens(db, user_id="u1")
+
+    assert len(tokens) == 1
+    assert tokens[0]["name"] == "u1-token"
+    assert "token" not in tokens[0]
+    assert "token_hash" not in tokens[0]
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_sets_revoked_at_and_blocks_reuse():
+    async with get_db() as db:
+        await _seed_user(db)
+        t = await create_token(db, user_id="u1", name="to-revoke", expires_in_days=30)
+        revoked = await revoke_token(db, user_id="u1", token_id=t["id"])
+        assert revoked is True
+
+        result = await resolve_token(db, raw_token=t["token"])
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_returns_false_for_other_user():
+    async with get_db() as db:
+        await _seed_user(db, "u1", "u1@example.com")
+        await _seed_user(db, "u2", "u2@example.com")
+        t = await create_token(db, user_id="u1", name="u1-token", expires_in_days=30)
+        revoked = await revoke_token(db, user_id="u2", token_id=t["id"])
+        assert revoked is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_returns_user_for_valid_token():
+    async with get_db() as db:
+        await _seed_user(db, "u1", "u1@example.com")
+        t = await create_token(db, user_id="u1", name="valid-token", expires_in_days=30)
+
+        result = await resolve_token(db, raw_token=t["token"])
+        assert result is not None
+        user, token_id = result
+        assert isinstance(user, UserInfo)
+        assert user.id == "u1"
+        assert user.email == "u1@example.com"
+        assert token_id == t["id"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_rejects_expired():
+    async with get_db() as db:
+        await _seed_user(db)
+        t = await create_token(db, user_id="u1", name="will-expire", expires_in_days=30)
+        await db.execute(
+            "UPDATE api_tokens SET expires_at = ? WHERE id = ?",
+            ("2000-01-01 00:00:00", t["id"]),
+        )
+        await db.commit()
+
+        result = await resolve_token(db, raw_token=t["token"])
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_rejects_unknown_token():
+    async with get_db() as db:
+        result = await resolve_token(db, raw_token="tw_totallyfake")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_tokens_removes_old_revoked_and_expired():
+    from datetime import datetime, timedelta, timezone
+
+    async with get_db() as db:
+        await _seed_user(db)
+
+        # Token 1: revoked 40 days ago
+        t1 = await create_token(db, user_id="u1", name="old-revoked", expires_in_days=None)
+        revoked_40_days_ago = (
+            datetime.now(timezone.utc) - timedelta(days=40)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        await db.execute(
+            "UPDATE api_tokens SET revoked_at = ? WHERE id = ?",
+            (revoked_40_days_ago, t1["id"]),
+        )
+
+        # Token 2: expired 100 days ago
+        t2 = await create_token(db, user_id="u1", name="old-expired", expires_in_days=None)
+        expired_100_days_ago = (
+            datetime.now(timezone.utc) - timedelta(days=100)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        await db.execute(
+            "UPDATE api_tokens SET expires_at = ? WHERE id = ?",
+            (expired_100_days_ago, t2["id"]),
+        )
+
+        # Token 3: active
+        await create_token(db, user_id="u1", name="still-active", expires_in_days=30)
+
+        await db.commit()
+
+        deleted = await cleanup_stale_tokens(db)
+        assert deleted == 2
+
+        cursor = await db.execute("SELECT COUNT(*) as cnt FROM api_tokens")
+        row = await cursor.fetchone()
+        assert row["cnt"] == 1

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -1,5 +1,7 @@
 import pytest
 import app.config as config_module
+from httpx import AsyncClient, ASGITransport
+from app.main import app
 from app.database import get_db
 from app.models import UserInfo
 from app.services.api_tokens import (
@@ -211,3 +213,95 @@ async def test_touch_last_used_updates_timestamp():
         cursor = await db.execute("SELECT last_used_at FROM api_tokens WHERE id = ?", (t["id"],))
         row = await cursor.fetchone()
     assert row["last_used_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_token_endpoint_returns_raw_token_once(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/api/tokens", json={"name": "my-cli", "expires_in_days": 30})
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["token"].startswith("tw_")
+        assert data["prefix"] == data["token"][:12]
+
+        r2 = await c.get("/api/tokens")
+        assert r2.status_code == 200
+        items = r2.json()
+        assert len(items) == 1
+        assert "token" not in items[0]
+
+
+@pytest.mark.asyncio
+async def test_create_token_rejects_empty_name(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post("/api/tokens", json={"name": "   ", "expires_in_days": None})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_token_duplicate_name_returns_409(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post("/api/tokens", json={"name": "dup", "expires_in_days": None})
+        r = await c.post("/api/tokens", json={"name": "dup", "expires_in_days": None})
+    assert r.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_token_over_cap_returns_429(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", True)
+    monkeypatch.setattr(config_module.settings, "API_TOKEN_MAX_PER_USER", 1)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post("/api/tokens", json={"name": "a", "expires_in_days": None})
+        r = await c.post("/api/tokens", json={"name": "b", "expires_in_days": None})
+    assert r.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_returns_204_and_blocks_reuse(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        created = (await c.post("/api/tokens", json={"name": "r", "expires_in_days": None})).json()
+        r = await c.delete(f"/api/tokens/{created['id']}")
+        assert r.status_code == 204
+        r2 = await c.get("/api/tokens", headers={"Authorization": f"Bearer {created['token']}"})
+    assert r2.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_routes_absent_when_flag_off(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", False)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/api/tokens")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_tokens_user_isolated(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post("/api/tokens", json={"name": "dev-t", "expires_in_days": None})
+        await c.post(
+            "/api/tokens",
+            headers={"X-Auth-Request-User": "alice"},
+            json={"name": "alice-t", "expires_in_days": None},
+        )
+        items = (await c.get("/api/tokens")).json()
+    names = {i["name"] for i in items}
+    assert names == {"dev-t"}

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -172,3 +172,22 @@ async def test_cleanup_stale_tokens_removes_old_revoked_and_expired():
         cursor = await db.execute("SELECT COUNT(*) as cnt FROM api_tokens")
         row = await cursor.fetchone()
         assert row["cnt"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_token_cap_ignores_expired_tokens(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "API_TOKEN_MAX_PER_USER", 2)
+    async with get_db() as db:
+        await _seed_user(db)
+        # Two active tokens → at cap
+        await create_token(db, user_id="u1", name="a", expires_in_days=None)
+        b = await create_token(db, user_id="u1", name="b", expires_in_days=None)
+        # Force one to be expired → no longer "active"
+        await db.execute(
+            "UPDATE api_tokens SET expires_at = '2000-01-01 00:00:00' WHERE id = ?",
+            (b["id"],),
+        )
+        await db.commit()
+        # Should now be allowed — only one "active" token
+        result = await create_token(db, user_id="u1", name="c", expires_in_days=None)
+    assert result["id"] is not None

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -1,0 +1,94 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI, Depends
+
+from app.dependencies import get_current_user
+from app.models import UserInfo
+from app.database import get_db
+from app.services.api_tokens import create_token
+from app import config as config_module
+
+
+def _mini_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(user: UserInfo = Depends(get_current_user)):
+        return {"id": user.id, "email": user.email}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_token_wins_over_headers(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    async with get_db() as db:
+        await db.execute("INSERT INTO users (id, email) VALUES ('u1', 'u1@x')")
+        await db.commit()
+        t = await create_token(db, user_id="u1", name="k", expires_in_days=None)
+
+    transport = ASGITransport(app=_mini_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get(
+            "/whoami",
+            headers={
+                "Authorization": f"Bearer {t['token']}",
+                "X-Auth-Request-User": "someone-else",
+            },
+        )
+    assert r.status_code == 200
+    assert r.json()["id"] == "u1"
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_returns_401_no_fallback(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    transport = ASGITransport(app=_mini_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get(
+            "/whoami",
+            headers={
+                "Authorization": "Bearer tw_notvalid",
+                "X-Auth-Request-User": "headers-user",
+            },
+        )
+    assert r.status_code == 401
+    assert r.headers.get("www-authenticate", "").startswith("Bearer")
+
+
+@pytest.mark.asyncio
+async def test_headers_used_when_no_authorization(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    transport = ASGITransport(app=_mini_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get(
+            "/whoami",
+            headers={"X-Auth-Request-User": "u1", "X-Auth-Request-Email": "u1@x"},
+        )
+    assert r.status_code == 200
+    assert r.json()["id"] == "u1"
+
+
+@pytest.mark.asyncio
+async def test_token_ignored_when_flag_off(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", False)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", False)
+    transport = ASGITransport(app=_mini_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/whoami", headers={"Authorization": "Bearer tw_anything"})
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_non_tw_bearer_falls_through(monkeypatch):
+    """Future-compat: `Bearer jwt…` should not be swallowed as an invalid tw token."""
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    transport = ASGITransport(app=_mini_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get(
+            "/whoami",
+            headers={"Authorization": "Bearer eyJ.jwt.token",
+                     "X-Auth-Request-User": "u1"},
+        )
+    assert r.status_code == 200
+    assert r.json()["id"] == "u1"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -21,3 +21,28 @@ async def test_metrics_endpoint():
         response = await client.get("/metrics")
     assert response.status_code == 200
     assert "transcription_app_info" in response.text
+
+
+import importlib
+import os
+
+
+def test_api_token_settings_defaults(monkeypatch):
+    for var in ("ENABLE_API_TOKENS", "API_TOKEN_MAX_PER_USER", "API_TOKEN_DEFAULT_EXPIRY_DAYS"):
+        monkeypatch.delenv(var, raising=False)
+    from app import config as config_module
+    importlib.reload(config_module)
+    assert config_module.settings.ENABLE_API_TOKENS is False
+    assert config_module.settings.API_TOKEN_MAX_PER_USER == 10
+    assert config_module.settings.API_TOKEN_DEFAULT_EXPIRY_DAYS == 90
+
+
+def test_api_token_settings_from_env(monkeypatch):
+    monkeypatch.setenv("ENABLE_API_TOKENS", "true")
+    monkeypatch.setenv("API_TOKEN_MAX_PER_USER", "5")
+    monkeypatch.setenv("API_TOKEN_DEFAULT_EXPIRY_DAYS", "30")
+    from app import config as config_module
+    importlib.reload(config_module)
+    assert config_module.settings.ENABLE_API_TOKENS is True
+    assert config_module.settings.API_TOKEN_MAX_PER_USER == 5
+    assert config_module.settings.API_TOKEN_DEFAULT_EXPIRY_DAYS == 30

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -31,3 +31,27 @@ async def test_has_video_column_exists(tmp_path):
         cursor = await db.execute("PRAGMA table_info(files)")
         columns = {row[1] for row in await cursor.fetchall()}
     assert "has_video" in columns
+
+
+@pytest.mark.asyncio
+async def test_api_tokens_table_created(tmp_path):
+    db_path = str(tmp_path / "api_tokens.db")
+    await init_db(db_path)
+    async with get_db(db_path) as db:
+        cursor = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='api_tokens'"
+        )
+        row = await cursor.fetchone()
+    assert row is not None
+
+
+@pytest.mark.asyncio
+async def test_api_tokens_hash_index_created(tmp_path):
+    db_path = str(tmp_path / "api_tokens_idx.db")
+    await init_db(db_path)
+    async with get_db(db_path) as db:
+        cursor = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_api_tokens_hash'"
+        )
+        row = await cursor.fetchone()
+    assert row is not None

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -10,3 +10,20 @@ async def test_health_endpoint():
         response = await client.get("/api/health")
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_config_reports_api_tokens_enabled(monkeypatch):
+    from app import config as config_module
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    # Also patch the reference held by the config router module to survive any
+    # `importlib.reload(config_module)` in test_config.py.
+    from app.routers import config_router as cr
+    monkeypatch.setattr(cr.settings, "ENABLE_API_TOKENS", True)
+    from httpx import AsyncClient, ASGITransport
+    from app.main import app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/api/config")
+    assert r.status_code == 200
+    assert r.json()["api_tokens_enabled"] is True

--- a/backend/tests/test_token_e2e.py
+++ b/backend/tests/test_token_e2e.py
@@ -1,0 +1,39 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from app.main import app
+from app.database import get_db
+from app.services.api_tokens import create_token
+from app import config as config_module
+
+
+@pytest.mark.asyncio
+async def test_upload_works_with_bearer_token(monkeypatch):
+    # Patch both the config module's settings and the dependencies module's
+    # captured reference, to survive importlib.reload side-effects from other
+    # tests.
+    from app import dependencies as dep
+    from app.routers import upload as upload_router
+    monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(dep.settings, "ENABLE_API_TOKENS", True)
+    monkeypatch.setattr(config_module.settings, "DEV_MODE", False)  # force token path
+    monkeypatch.setattr(dep.settings, "DEV_MODE", False)
+
+    async with get_db() as db:
+        await db.execute("INSERT OR IGNORE INTO users (id, email) VALUES ('alice', 'a@x')")
+        await db.commit()
+        t = await create_token(db, user_id="alice", name="cli", expires_in_days=None)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.post(
+            "/api/upload",
+            headers={"Authorization": f"Bearer {t['token']}"},
+            files={"file": ("t.mp3", b"fake", "audio/mpeg")},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    async with get_db() as db:
+        cursor = await db.execute("SELECT user_id FROM files WHERE id = ?", (body["id"],))
+        row = await cursor.fetchone()
+    assert row["user_id"] == "alice"

--- a/backend/tests/test_ws_auth.py
+++ b/backend/tests/test_ws_auth.py
@@ -1,0 +1,56 @@
+import asyncio
+import uuid
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+from app.main import app
+from app.database import get_db
+from app.services.api_tokens import create_token
+import app.routers.transcription as transcription_module
+
+
+async def _seed_ws_test_data(user_id: str, transcription_id: str) -> str:
+    """Seed user, token, and transcription row; return the raw token string."""
+    async with get_db() as db:
+        await db.execute(
+            "INSERT INTO users (id, email) VALUES (?, ?)",
+            (user_id, f"{user_id}@x"),
+        )
+        await db.commit()
+        t = await create_token(db, user_id=user_id, name="ws", expires_in_days=None)
+        await db.execute(
+            "INSERT INTO transcriptions (id, user_id, status) VALUES (?, ?, 'pending')",
+            (transcription_id, user_id),
+        )
+        await db.commit()
+    return t["token"]
+
+
+def test_ws_accepts_query_param_token(monkeypatch):
+    """The WS endpoint should authenticate via ?token=tw_… when flag is on."""
+    # Patch the settings object that the transcription router actually holds — not
+    # config_module.settings, which may have been replaced by importlib.reload in
+    # test_config.py tests that run before this one.
+    monkeypatch.setattr(transcription_module.settings, "ENABLE_API_TOKENS", True)
+    user_id = str(uuid.uuid4())
+    transcription_id = str(uuid.uuid4())
+
+    with TestClient(app) as client:
+        # Seed data after lifespan has initialised _db_path
+        raw_token = asyncio.run(_seed_ws_test_data(user_id, transcription_id))
+        with client.websocket_connect(
+            f"/api/ws/status/{transcription_id}?token={raw_token}"
+        ) as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "status"
+
+
+def test_ws_rejects_invalid_query_token(monkeypatch):
+    monkeypatch.setattr(transcription_module.settings, "ENABLE_API_TOKENS", True)
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(
+                "/api/ws/status/anything?token=tw_bad"
+            ) as ws:
+                ws.receive_json()
+    assert exc.value.code == 4001

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,9 @@ const AnalysisView = lazy(() =>
 const PresetsPage = lazy(() =>
   import('./components/PresetsPage/PresetsPage').then((m) => ({ default: m.PresetsPage }))
 )
+const SettingsPage = lazy(() =>
+  import('./components/SettingsPage').then((m) => ({ default: m.SettingsPage }))
+)
 const HelpDrawer = lazy(() =>
   import('./components/HelpDrawer').then((m) => ({ default: m.HelpDrawer }))
 )
@@ -506,6 +509,17 @@ function App() {
           <ChunkErrorBoundary errorMessage={t('common.loadError')} reloadLabel={t('common.reload')}>
             <Suspense fallback={<LoadingFallback />}>
               <PresetsPage />
+            </Suspense>
+          </ChunkErrorBoundary>
+        </>
+      )}
+
+      {currentView === 'settings' && (
+        <>
+          <BackButton />
+          <ChunkErrorBoundary errorMessage={t('common.loadError')} reloadLabel={t('common.reload')}>
+            <Suspense fallback={<LoadingFallback />}>
+              <SettingsPage />
             </Suspense>
           </ChunkErrorBoundary>
         </>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -219,7 +219,7 @@ export const api = {
 
   revokeApiToken: async (id: string): Promise<void> => {
     const response = await fetch(`${BASE}/api/tokens/${id}`, { method: 'DELETE' })
-    if (!response.ok && response.status !== 204) {
+    if (!response.ok) {
       throw new Error(response.statusText)
     }
   },

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   AnalysisPreset, AnalysisPresetCreate,
   RefinementPreset, RefinementPresetCreate,
   PresetBundle, PresetBundleCreate, PresetBundleExpanded,
+  ApiToken, ApiTokenCreated,
 } from './types'
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '')
@@ -205,4 +206,21 @@ export const api = {
   clearDefaultBundle: () =>
     request<{ status: string }>('/api/presets/default', { method: 'DELETE' }),
   getDefaultBundle: () => request<PresetBundleExpanded | null>('/api/presets/default'),
+
+  // --- API Tokens ---
+
+  listApiTokens: () => request<ApiToken[]>('/api/tokens'),
+
+  createApiToken: (name: string, expiresInDays: number | null) =>
+    request<ApiTokenCreated>('/api/tokens', {
+      method: 'POST',
+      body: JSON.stringify({ name, expires_in_days: expiresInDays }),
+    }),
+
+  revokeApiToken: async (id: string): Promise<void> => {
+    const response = await fetch(`${BASE}/api/tokens/${id}`, { method: 'DELETE' })
+    if (!response.ok && response.status !== 204) {
+      throw new Error(response.statusText)
+    }
+  },
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -128,6 +128,7 @@ export interface ConfigResponse {
   logout_url: string
   popular_languages: string[]
   enabled_languages: string[]
+  api_tokens_enabled?: boolean
 }
 
 export interface AnalysisTemplate {
@@ -242,4 +243,23 @@ export interface PresetBundleExpanded extends PresetBundle {
   transcription_preset: TranscriptionPreset | null
   analysis_preset: AnalysisPreset | null
   refinement_preset: RefinementPreset | null
+}
+
+export interface ApiToken {
+  id: string
+  name: string
+  prefix: string
+  created_at: string
+  expires_at: string | null
+  last_used_at: string | null
+  revoked_at: string | null
+}
+
+export interface ApiTokenCreateRequest {
+  name: string
+  expires_in_days: number | null
+}
+
+export interface ApiTokenCreated extends ApiToken {
+  token: string
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -129,6 +129,7 @@ export interface ConfigResponse {
   popular_languages: string[]
   enabled_languages: string[]
   api_tokens_enabled?: boolean
+  api_token_default_expiry_days?: number
 }
 
 export interface AnalysisTemplate {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -24,6 +24,13 @@ export function Header() {
     setBurgerOpen(false)
   }
 
+  const openSettings = () => {
+    const state = useStore.getState()
+    if (!state.confirmLeaveUpload(t('upload.confirmLeave'))) return
+    state.setCurrentView('settings')
+    setBurgerOpen(false)
+  }
+
   const handleToggleLanguage = () => {
     toggleLanguage()
     setBurgerOpen(false)
@@ -78,6 +85,11 @@ export function Header() {
         <button onClick={openPresets} className={buttonClass}>
           {t('nav.presets')}
         </button>
+        {config?.api_tokens_enabled && (
+          <button onClick={openSettings} className={buttonClass}>
+            {t('nav.settings')}
+          </button>
+        )}
         <button
           onClick={handleToggleLanguage}
           className={buttonClass}
@@ -130,6 +142,16 @@ export function Header() {
             >
               {t('nav.presets')}
             </button>
+            {config?.api_tokens_enabled && (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={openSettings}
+                className={`${buttonClass} text-left px-4 py-2`}
+              >
+                {t('nav.settings')}
+              </button>
+            )}
             <button
               type="button"
               role="menuitem"

--- a/frontend/src/components/HelpDrawer/helpSections.ts
+++ b/frontend/src/components/HelpDrawer/helpSections.ts
@@ -21,6 +21,7 @@ export type HelpSectionId =
   | 'format-viewer'
   | 'presets'
   | 'bundles'
+  | 'api-access'
 
 export interface HelpSection {
   id: HelpSectionId
@@ -41,9 +42,10 @@ export const sections: readonly HelpSection[] = [
   { id: 'format-viewer', filename: '11-format-viewer.md' },
   { id: 'presets', filename: '12-presets.md' },
   { id: 'bundles', filename: '13-bundles.md' },
+  { id: 'api-access', filename: '14-api-access.md' },
 ] as const
 
-type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets'
+type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets' | 'settings'
 
 export const viewToSection: Record<AppView, HelpSectionId> = {
   archive: 'getting-started',
@@ -51,6 +53,7 @@ export const viewToSection: Record<AppView, HelpSectionId> = {
   record: 'record',
   detail: 'subtitle-editor',
   presets: 'presets',
+  settings: 'api-access',
 }
 
 // Vite glob: load every en/*.md and de/*.md as a raw string at build time.

--- a/frontend/src/components/SettingsPage/ApiTokensSection.tsx
+++ b/frontend/src/components/SettingsPage/ApiTokensSection.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '../../api/client'
+import type { ApiToken } from '../../api/types'
+import { CreateTokenModal } from './CreateTokenModal'
+
+type TokenStatus = 'active' | 'expired' | 'revoked'
+
+function getTokenStatus(token: ApiToken): TokenStatus {
+  if (token.revoked_at) return 'revoked'
+  if (token.expires_at) {
+    const expiry = new Date(token.expires_at.replace(' ', 'T') + 'Z')
+    if (expiry < new Date()) return 'expired'
+  }
+  return 'active'
+}
+
+export function ApiTokensSection() {
+  const [tokens, setTokens] = useState<ApiToken[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [revoking, setRevoking] = useState<string | null>(null)
+
+  const fetchTokens = useCallback(async () => {
+    setError(null)
+    try {
+      const result = await api.listApiTokens()
+      setTokens(result)
+    } catch (e) {
+      setError((e as Error).message)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchTokens()
+  }, [fetchTokens])
+
+  async function handleRevoke(id: string) {
+    setRevoking(id)
+    setError(null)
+    try {
+      await api.revokeApiToken(id)
+      await fetchTokens()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setRevoking(null)
+    }
+  }
+
+  function handleCreated() {
+    setShowModal(false)
+    fetchTokens()
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-white">API tokens</h2>
+        <button
+          type="button"
+          onClick={() => setShowModal(true)}
+          className="text-sm bg-blue-600 hover:bg-blue-500 text-white rounded px-4 py-1.5"
+        >
+          Create token
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-400">{error}</p>
+      )}
+
+      {tokens.length === 0 && !error && (
+        <p className="text-sm text-gray-500">No API tokens yet.</p>
+      )}
+
+      {tokens.length > 0 && (
+        <div className="space-y-2">
+          {tokens.map((token) => {
+            const status = getTokenStatus(token)
+            const isInactive = status !== 'active'
+            return (
+              <div
+                key={token.id}
+                className={`bg-gray-800 border border-gray-700 rounded-lg p-4 flex items-start justify-between gap-3 ${isInactive ? 'opacity-60' : ''}`}
+              >
+                <div className="min-w-0 space-y-0.5">
+                  <p className="font-medium text-white truncate">{token.name}</p>
+                  <p className="text-xs text-gray-400 font-mono">{token.prefix}…</p>
+                  <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-gray-500">
+                    <span className={
+                      status === 'active' ? 'text-green-400' :
+                      status === 'expired' ? 'text-yellow-500' :
+                      'text-red-400'
+                    }>
+                      {status}
+                    </span>
+                    {token.expires_at && (
+                      <span>expires {token.expires_at}</span>
+                    )}
+                    {token.last_used_at && (
+                      <span>last used {token.last_used_at}</span>
+                    )}
+                  </div>
+                </div>
+                {status === 'active' && (
+                  <button
+                    type="button"
+                    onClick={() => handleRevoke(token.id)}
+                    disabled={revoking === token.id}
+                    className="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 shrink-0"
+                  >
+                    {revoking === token.id ? '…' : 'Revoke'}
+                  </button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {showModal && (
+        <CreateTokenModal
+          onClose={() => setShowModal(false)}
+          onCreated={handleCreated}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/SettingsPage/ApiTokensSection.tsx
+++ b/frontend/src/components/SettingsPage/ApiTokensSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
 import type { ApiToken } from '../../api/types'
 import { CreateTokenModal } from './CreateTokenModal'
@@ -15,6 +16,7 @@ function getTokenStatus(token: ApiToken): TokenStatus {
 }
 
 export function ApiTokensSection() {
+  const { t } = useTranslation()
   const [tokens, setTokens] = useState<ApiToken[]>([])
   const [error, setError] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
@@ -55,13 +57,13 @@ export function ApiTokensSection() {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="text-lg font-semibold text-white">API tokens</h2>
+        <h2 className="text-lg font-semibold text-white">{t('settings.apiTokens.title')}</h2>
         <button
           type="button"
           onClick={() => setShowModal(true)}
           className="text-sm bg-blue-600 hover:bg-blue-500 text-white rounded px-4 py-1.5"
         >
-          Create token
+          {t('settings.apiTokens.createButton')}
         </button>
       </div>
 
@@ -70,7 +72,7 @@ export function ApiTokensSection() {
       )}
 
       {tokens.length === 0 && !error && (
-        <p className="text-sm text-gray-500">No API tokens yet.</p>
+        <p className="text-sm text-gray-500">{t('settings.apiTokens.empty')}</p>
       )}
 
       {tokens.length > 0 && (
@@ -78,6 +80,7 @@ export function ApiTokensSection() {
           {tokens.map((token) => {
             const status = getTokenStatus(token)
             const isInactive = status !== 'active'
+            const statusKey = status === 'active' ? 'statusActive' : status === 'expired' ? 'statusExpired' : 'statusRevoked'
             return (
               <div
                 key={token.id}
@@ -85,20 +88,20 @@ export function ApiTokensSection() {
               >
                 <div className="min-w-0 space-y-0.5">
                   <p className="font-medium text-white truncate">{token.name}</p>
-                  <p className="text-xs text-gray-400 font-mono">{token.prefix}…</p>
+                  <p className="text-xs text-gray-400 font-mono">{token.prefix}{t('settings.apiTokens.prefixSuffix')}</p>
                   <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-gray-500">
                     <span className={
                       status === 'active' ? 'text-green-400' :
                       status === 'expired' ? 'text-yellow-500' :
                       'text-red-400'
                     }>
-                      {status}
+                      {t(`settings.apiTokens.${statusKey}`)}
                     </span>
                     {token.expires_at && (
-                      <span>expires {token.expires_at}</span>
+                      <span>{t('settings.apiTokens.expiresOnTmpl', { date: token.expires_at })}</span>
                     )}
                     {token.last_used_at && (
-                      <span>last used {token.last_used_at}</span>
+                      <span>{t('settings.apiTokens.lastUsedTmpl', { date: token.last_used_at })}</span>
                     )}
                   </div>
                 </div>
@@ -109,7 +112,7 @@ export function ApiTokensSection() {
                     disabled={revoking === token.id}
                     className="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 shrink-0"
                   >
-                    {revoking === token.id ? '…' : 'Revoke'}
+                    {revoking === token.id ? t('settings.apiTokens.prefixSuffix') : t('settings.apiTokens.revoke')}
                   </button>
                 )}
               </div>

--- a/frontend/src/components/SettingsPage/ApiTokensSection.tsx
+++ b/frontend/src/components/SettingsPage/ApiTokensSection.tsx
@@ -112,7 +112,7 @@ export function ApiTokensSection() {
                     disabled={revoking === token.id}
                     className="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 shrink-0"
                   >
-                    {revoking === token.id ? t('settings.apiTokens.prefixSuffix') : t('settings.apiTokens.revoke')}
+                    {revoking === token.id ? t('settings.apiTokens.revoking') : t('settings.apiTokens.revoke')}
                   </button>
                 )}
               </div>

--- a/frontend/src/components/SettingsPage/CreateTokenModal.tsx
+++ b/frontend/src/components/SettingsPage/CreateTokenModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
 import type { ApiTokenCreated } from '../../api/types'
 
@@ -7,19 +8,20 @@ interface Props {
   onCreated: () => void
 }
 
-const EXPIRY_OPTIONS: { label: string; days: number | null }[] = [
-  { label: '30 days', days: 30 },
-  { label: '90 days', days: 90 },
-  { label: '365 days', days: 365 },
-  { label: 'Never', days: null },
-]
-
 export function CreateTokenModal({ onClose, onCreated }: Props) {
+  const { t } = useTranslation()
   const [name, setName] = useState('')
   const [expiryDays, setExpiryDays] = useState<number | null>(90)
   const [created, setCreated] = useState<ApiTokenCreated | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+
+  const expiryOptions = [
+    { label: t('settings.apiTokens.expiry30'), days: 30 },
+    { label: t('settings.apiTokens.expiry90'), days: 90 },
+    { label: t('settings.apiTokens.expiry365'), days: 365 },
+    { label: t('settings.apiTokens.expiryNever'), days: null },
+  ]
 
   async function handleCreate() {
     setError(null)
@@ -48,9 +50,9 @@ export function CreateTokenModal({ onClose, onCreated }: Props) {
       <div className="bg-gray-900 border border-gray-700 rounded-lg p-6 max-w-md w-full space-y-4 mx-4">
         {created ? (
           <>
-            <h2 className="text-lg font-semibold text-white">Token created</h2>
+            <h2 className="text-lg font-semibold text-white">{t('settings.apiTokens.createdHeader')}</h2>
             <p className="text-sm text-yellow-400">
-              Save this now — you won't see it again.
+              {t('settings.apiTokens.saveNowWarning')}
             </p>
             <div className="bg-gray-800 rounded px-3 py-2 font-mono text-sm text-green-400 break-all select-all">
               {created.token}
@@ -61,27 +63,27 @@ export function CreateTokenModal({ onClose, onCreated }: Props) {
                 onClick={handleCopy}
                 className="text-sm bg-gray-700 hover:bg-gray-600 text-white rounded px-4 py-1.5"
               >
-                Copy
+                {t('settings.apiTokens.copy')}
               </button>
               <button
                 type="button"
                 onClick={handleDone}
                 className="text-sm bg-blue-600 hover:bg-blue-500 text-white rounded px-4 py-1.5"
               >
-                Done
+                {t('settings.apiTokens.done')}
               </button>
             </div>
           </>
         ) : (
           <>
-            <h2 className="text-lg font-semibold text-white">Create API token</h2>
+            <h2 className="text-lg font-semibold text-white">{t('settings.apiTokens.createButton')}</h2>
 
             {error && (
               <p className="text-sm text-red-400">{error}</p>
             )}
 
             <div>
-              <label className="block text-xs text-gray-400 mb-1">Name</label>
+              <label className="block text-xs text-gray-400 mb-1">{t('settings.apiTokens.nameLabel')}</label>
               <input
                 type="text"
                 value={name}
@@ -93,14 +95,14 @@ export function CreateTokenModal({ onClose, onCreated }: Props) {
             </div>
 
             <div>
-              <label htmlFor="token-expiry-select" className="block text-xs text-gray-400 mb-1">Expires in</label>
+              <label htmlFor="token-expiry-select" className="block text-xs text-gray-400 mb-1">{t('settings.apiTokens.expiresLabel')}</label>
               <select
                 id="token-expiry-select"
                 value={expiryDays === null ? '' : String(expiryDays)}
                 onChange={(e) => setExpiryDays(e.target.value === '' ? null : Number(e.target.value))}
                 className="w-full bg-gray-800 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500 border border-gray-700"
               >
-                {EXPIRY_OPTIONS.map((opt) => (
+                {expiryOptions.map((opt) => (
                   <option key={opt.label} value={opt.days === null ? '' : String(opt.days)}>
                     {opt.label}
                   </option>
@@ -114,7 +116,7 @@ export function CreateTokenModal({ onClose, onCreated }: Props) {
                 onClick={onClose}
                 className="text-sm text-gray-400 hover:text-white px-3 py-1.5"
               >
-                Cancel
+                {t('settings.apiTokens.cancel')}
               </button>
               <button
                 type="button"
@@ -122,7 +124,7 @@ export function CreateTokenModal({ onClose, onCreated }: Props) {
                 disabled={submitting || !name.trim()}
                 className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
               >
-                {submitting ? '…' : 'Create'}
+                {submitting ? t('settings.apiTokens.prefixSuffix') : t('settings.apiTokens.createCta')}
               </button>
             </div>
           </>

--- a/frontend/src/components/SettingsPage/CreateTokenModal.tsx
+++ b/frontend/src/components/SettingsPage/CreateTokenModal.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react'
+import { api } from '../../api/client'
+import type { ApiTokenCreated } from '../../api/types'
+
+interface Props {
+  onClose: () => void
+  onCreated: () => void
+}
+
+const EXPIRY_OPTIONS: { label: string; days: number | null }[] = [
+  { label: '30 days', days: 30 },
+  { label: '90 days', days: 90 },
+  { label: '365 days', days: 365 },
+  { label: 'Never', days: null },
+]
+
+export function CreateTokenModal({ onClose, onCreated }: Props) {
+  const [name, setName] = useState('')
+  const [expiryDays, setExpiryDays] = useState<number | null>(90)
+  const [created, setCreated] = useState<ApiTokenCreated | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleCreate() {
+    setError(null)
+    setSubmitting(true)
+    try {
+      const result = await api.createApiToken(name.trim(), expiryDays)
+      setCreated(result)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleCopy() {
+    if (created) await navigator.clipboard.writeText(created.token)
+  }
+
+  function handleDone() {
+    setCreated(null)
+    onCreated()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg p-6 max-w-md w-full space-y-4 mx-4">
+        {created ? (
+          <>
+            <h2 className="text-lg font-semibold text-white">Token created</h2>
+            <p className="text-sm text-yellow-400">
+              Save this now — you won't see it again.
+            </p>
+            <div className="bg-gray-800 rounded px-3 py-2 font-mono text-sm text-green-400 break-all select-all">
+              {created.token}
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="text-sm bg-gray-700 hover:bg-gray-600 text-white rounded px-4 py-1.5"
+              >
+                Copy
+              </button>
+              <button
+                type="button"
+                onClick={handleDone}
+                className="text-sm bg-blue-600 hover:bg-blue-500 text-white rounded px-4 py-1.5"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-lg font-semibold text-white">Create API token</h2>
+
+            {error && (
+              <p className="text-sm text-red-400">{error}</p>
+            )}
+
+            <div>
+              <label className="block text-xs text-gray-400 mb-1">Name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                maxLength={64}
+                placeholder="e.g. my-script"
+                className="w-full bg-gray-800 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500 border border-gray-700"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="token-expiry-select" className="block text-xs text-gray-400 mb-1">Expires in</label>
+              <select
+                id="token-expiry-select"
+                value={expiryDays === null ? '' : String(expiryDays)}
+                onChange={(e) => setExpiryDays(e.target.value === '' ? null : Number(e.target.value))}
+                className="w-full bg-gray-800 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500 border border-gray-700"
+              >
+                {EXPIRY_OPTIONS.map((opt) => (
+                  <option key={opt.label} value={opt.days === null ? '' : String(opt.days)}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex gap-2 justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-sm text-gray-400 hover:text-white px-3 py-1.5"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleCreate}
+                disabled={submitting || !name.trim()}
+                className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
+              >
+                {submitting ? '…' : 'Create'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SettingsPage/CreateTokenModal.tsx
+++ b/frontend/src/components/SettingsPage/CreateTokenModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api/client'
 import type { ApiTokenCreated } from '../../api/types'
+import { useStore } from '../../store'
 
 interface Props {
   onClose: () => void
@@ -10,8 +11,9 @@ interface Props {
 
 export function CreateTokenModal({ onClose, onCreated }: Props) {
   const { t } = useTranslation()
+  const defaultDays = useStore((s) => s.config?.api_token_default_expiry_days) ?? 90
   const [name, setName] = useState('')
-  const [expiryDays, setExpiryDays] = useState<number | null>(90)
+  const [expiryDays, setExpiryDays] = useState<number | null>(defaultDays)
   const [created, setCreated] = useState<ApiTokenCreated | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
@@ -124,7 +126,7 @@ export function CreateTokenModal({ onClose, onCreated }: Props) {
                 disabled={submitting || !name.trim()}
                 className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
               >
-                {submitting ? t('settings.apiTokens.prefixSuffix') : t('settings.apiTokens.createCta')}
+                {submitting ? t('settings.apiTokens.creating') : t('settings.apiTokens.createCta')}
               </button>
             </div>
           </>

--- a/frontend/src/components/SettingsPage/index.tsx
+++ b/frontend/src/components/SettingsPage/index.tsx
@@ -1,9 +1,12 @@
+import { useTranslation } from 'react-i18next'
 import { ApiTokensSection } from './ApiTokensSection'
 
 export function SettingsPage() {
+  const { t } = useTranslation()
+
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
-      <h1 className="text-2xl font-bold text-white">Settings</h1>
+      <h1 className="text-2xl font-bold text-white">{t('settings.title')}</h1>
       <ApiTokensSection />
     </div>
   )

--- a/frontend/src/components/SettingsPage/index.tsx
+++ b/frontend/src/components/SettingsPage/index.tsx
@@ -1,0 +1,10 @@
+import { ApiTokensSection } from './ApiTokensSection'
+
+export function SettingsPage() {
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-8">
+      <h1 className="text-2xl font-bold text-white">Settings</h1>
+      <ApiTokensSection />
+    </div>
+  )
+}

--- a/frontend/src/help/de/14-api-access.md
+++ b/frontend/src/help/de/14-api-access.md
@@ -1,0 +1,43 @@
+# API-Zugriff
+
+## Worum es geht
+
+Wenn in Ihrer Installation API-Tokens aktiviert sind, können Sie einen persönlichen Bearer-Token erzeugen und damit die REST-Schnittstelle der Anwendung direkt aus Skripten, CI-Jobs oder beliebigen HTTP-Clients aufrufen. Ein Token ist an Ihr Konto gebunden — er kann Ihre eigenen Dateien, Transkriptionen und Voreinstellungen lesen und schreiben, aber niemals Daten anderer Nutzer sehen.
+
+Ist das Feature in Ihrer Installation deaktiviert, erscheint der Eintrag **Einstellungen** in der Kopfzeile nicht und der Bereich ist nicht verfügbar.
+
+## Token erstellen
+
+Öffnen Sie **Einstellungen** in der Kopfzeile und klicken Sie auf **Token erstellen**. Vergeben Sie einen kurzen Namen, der Ihnen hilft, den Verwendungszweck wiederzuerkennen (z. B. `mein-laptop` oder `ci-pipeline`), wählen Sie eine Gültigkeit (30, 90, 365 Tage oder Nie) und bestätigen Sie mit **Erstellen**.
+
+Der Token wird **einmalig** als `tw_…`-Zeichenkette angezeigt. Kopieren Sie ihn sofort — sobald Sie den Dialog schließen, ist der vollständige Wert nicht mehr abrufbar. In der Liste ist nur das kurze Präfix zur Wiedererkennung sichtbar.
+
+## Token verwenden
+
+Senden Sie den Token als HTTP-Bearer-Header:
+
+```
+Authorization: Bearer tw_...
+```
+
+Beispiel mit curl:
+
+```
+curl -H "Authorization: Bearer tw_abc..." https://ihr-host/api/tokens
+```
+
+Für den Status-WebSocket der Transkription übergeben Sie den Token als Query-Parameter (Browser erlauben keine eigenen Header auf WebSocket-Verbindungen):
+
+```
+wss://ihr-host/api/ws/status/{transcription_id}?token=tw_abc...
+```
+
+## Token widerrufen
+
+Klicken Sie neben einem aktiven Token auf **Widerrufen**. Der Token wird sofort ungültig. Widerrufene Tokens bleiben (abgeblendet) in der Liste, damit Sie nachvollziehen können, welche Sie bereits rotiert haben.
+
+## Hinweise
+
+- **Token rotieren, wenn sich Geräte ändern.** Geht ein Laptop verloren oder wird ein CI-Secret erneuert, widerrufen Sie den passenden Token und erstellen einen neuen.
+- **Ein Token pro Einsatzzweck.** Teilen Sie einen Token möglichst nicht zwischen mehreren Werkzeugen oder Geräten — Namen pro Einsatzort erleichtern den gezielten Widerruf.
+- **Gleiche Rechte wie in der Oberfläche.** Ein Token erbt Ihre Berechtigungen: Ist in der Installation kein LLM konfiguriert, liefern Analyse, Übersetzung und Überarbeitung auch für Token-Anfragen den Status 503.

--- a/frontend/src/help/en/14-api-access.md
+++ b/frontend/src/help/en/14-api-access.md
@@ -1,0 +1,43 @@
+# API Access
+
+## What this is
+
+When your deployment has API tokens enabled, you can generate a personal bearer token and use it to call the app's REST API directly from scripts, CI jobs, or any HTTP client. A token is scoped to your account — it can read and write your own files, transcriptions, and presets, but never anyone else's.
+
+If your deployment has tokens disabled, the **Settings** link in the header won't appear and this feature isn't available.
+
+## Creating a token
+
+Open **Settings** from the header, then click **Create token**. Give the token a short name that helps you remember where you'll use it (for example, `my-laptop` or `ci-pipeline`), choose how long it should stay valid (30, 90, 365 days, or Never), and click **Create**.
+
+The raw token appears **once** as a `tw_…` string. Copy it immediately — when you close the dialog, the full token is gone and cannot be retrieved. Only the short prefix stays visible in the list for identification.
+
+## Using a token
+
+Pass the token as a standard HTTP bearer header:
+
+```
+Authorization: Bearer tw_...
+```
+
+Example with curl:
+
+```
+curl -H "Authorization: Bearer tw_abc..." https://your-host/api/tokens
+```
+
+For the transcription-status WebSocket, pass the token as a query parameter (browsers don't allow custom headers on WebSocket requests):
+
+```
+wss://your-host/api/ws/status/{transcription_id}?token=tw_abc...
+```
+
+## Revoking a token
+
+Click **Revoke** next to any active token. The token stops working immediately. Revoked tokens stay in the list (faded) so you can audit which ones you've rotated.
+
+## Tips
+
+- **Rotate tokens when machines change.** If a laptop is lost or a CI secret is rotated, revoke the matching token and create a new one.
+- **One token per context.** Avoid sharing a single token across multiple tools or machines — naming them per usage makes revocation safer.
+- **Capabilities match the UI.** A token inherits your access: if your deployment has no LLM configured, token-authenticated requests also can't run analysis, translation, or refinement (those endpoints return 503 regardless of how you authenticated).

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -398,6 +398,33 @@
     "settings": "Einstellungen",
     "menu": "Menü"
   },
+  "settings": {
+    "title": "Einstellungen",
+    "apiTokens": {
+      "title": "API-Tokens",
+      "createButton": "Token erstellen",
+      "nameLabel": "Name",
+      "expiresLabel": "Läuft ab",
+      "expiry30": "30 Tage",
+      "expiry90": "90 Tage",
+      "expiry365": "365 Tage",
+      "expiryNever": "Nie",
+      "createCta": "Erstellen",
+      "cancel": "Abbrechen",
+      "revoke": "Widerrufen",
+      "statusActive": "Aktiv",
+      "statusExpired": "Abgelaufen",
+      "statusRevoked": "Widerrufen",
+      "createdHeader": "Token erstellt",
+      "saveNowWarning": "Jetzt speichern — Sie sehen ihn nicht erneut.",
+      "copy": "Kopieren",
+      "done": "Fertig",
+      "prefixSuffix": "…",
+      "expiresOnTmpl": "läuft ab am {{date}}",
+      "lastUsedTmpl": "zuletzt verwendet {{date}}",
+      "empty": "Noch keine API-Tokens. Erstellen Sie einen, um zu beginnen."
+    }
+  },
   "common": {
     "loading": "Laden...",
     "error": "Fehler",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -420,6 +420,8 @@
       "copy": "Kopieren",
       "done": "Fertig",
       "prefixSuffix": "…",
+      "revoking": "Wird widerrufen…",
+      "creating": "Wird erstellt…",
       "expiresOnTmpl": "läuft ab am {{date}}",
       "lastUsedTmpl": "zuletzt verwendet {{date}}",
       "empty": "Noch keine API-Tokens. Erstellen Sie einen, um zu beginnen."

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -457,7 +457,8 @@
       "refinement": "Verfeinerung",
       "format-viewer": "Formatansicht",
       "presets": "Voreinstellungen",
-      "bundles": "Bundles"
+      "bundles": "Bundles",
+      "api-access": "API-Zugriff"
     }
   }
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -395,6 +395,7 @@
     "newUpload": "Hochladen",
     "newRecording": "Aufnehmen",
     "presets": "Voreinstellungen",
+    "settings": "Einstellungen",
     "menu": "Menü"
   },
   "common": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -420,6 +420,8 @@
       "copy": "Copy",
       "done": "Done",
       "prefixSuffix": "…",
+      "revoking": "Revoking…",
+      "creating": "Creating…",
       "expiresOnTmpl": "expires {{date}}",
       "lastUsedTmpl": "last used {{date}}",
       "empty": "No API tokens yet. Create one to get started."

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -457,7 +457,8 @@
       "refinement": "Refinement",
       "format-viewer": "Format Viewer",
       "presets": "Presets",
-      "bundles": "Bundles"
+      "bundles": "Bundles",
+      "api-access": "API Access"
     }
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -398,6 +398,33 @@
     "settings": "Settings",
     "menu": "Menu"
   },
+  "settings": {
+    "title": "Settings",
+    "apiTokens": {
+      "title": "API tokens",
+      "createButton": "Create token",
+      "nameLabel": "Name",
+      "expiresLabel": "Expires in",
+      "expiry30": "30 days",
+      "expiry90": "90 days",
+      "expiry365": "365 days",
+      "expiryNever": "Never",
+      "createCta": "Create",
+      "cancel": "Cancel",
+      "revoke": "Revoke",
+      "statusActive": "Active",
+      "statusExpired": "Expired",
+      "statusRevoked": "Revoked",
+      "createdHeader": "Token created",
+      "saveNowWarning": "Save this now — you won't see it again.",
+      "copy": "Copy",
+      "done": "Done",
+      "prefixSuffix": "…",
+      "expiresOnTmpl": "expires {{date}}",
+      "lastUsedTmpl": "last used {{date}}",
+      "empty": "No API tokens yet. Create one to get started."
+    }
+  },
   "common": {
     "loading": "Loading...",
     "error": "Error",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -395,6 +395,7 @@
     "newUpload": "Upload",
     "newRecording": "Record",
     "presets": "Presets",
+    "settings": "Settings",
     "menu": "Menu"
   },
   "common": {

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import type { FileInfo, TranscriptionResult, TranscriptionListItem, ConfigResponse, Utterance, RefinementMetadata, AnalysisListItem, TranscriptionPreset, AnalysisPreset, RefinementPreset, PresetBundle } from '../api/types'
 
-type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets'
+type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets' | 'settings'
 
 interface AppState {
   currentView: AppView


### PR DESCRIPTION
## Summary

Adds a personal API token system so users can call `/api/*` from scripts, CI, or a future MCP server without disturbing the existing reverse-proxy header auth.

- New `ENABLE_API_TOKENS` flag (default off). Router is mounted and Settings UI appears only when on.
- `Authorization: Bearer tw_…` accepted on HTTP routes; `?token=tw_…` on `/api/ws/status/{id}`. Token wins over `X-Auth-Request-*` headers when both are present; invalid tokens return 401 with `WWW-Authenticate` and no header fallback.
- Tokens stored sha256-hashed in a new `api_tokens` table; raw value shown once at creation.
- `POST/GET/DELETE /api/tokens` + new Settings view (Header link + list + create modal).
- Scope matches UI permissions — no LLM configured → analysis/translation/refinement still 503 regardless of auth method.
- Metrics: `api_tokens_created_total`, `api_tokens_revoked_total`, `api_token_auth_total{result}`, `api_tokens_active`; extended `auth_failures_total{reason}` with `invalid_token`. Stale-token cleanup piggybacks on `cleanup_old_files`.
- Help drawer: new **API Access** section (en + de).

## Configuration

```
ENABLE_API_TOKENS=true
API_TOKEN_MAX_PER_USER=10        # optional, default 10
API_TOKEN_DEFAULT_EXPIRY_DAYS=90 # optional, default 90
```

## Out of scope

MCP server implementation (sketched in the spec only), per-token scopes, admin-issued service-account tokens, rate limiting. README and help drawer document the feature.