### PR TITLE
refactor(backend): extract router helpers and remove dead code

### DIFF
--- a/backend/app/router_helpers.py
+++ b/backend/app/router_helpers.py
@@ -1,0 +1,50 @@
+from fastapi import HTTPException
+
+from app.database import get_db
+
+
+async def ensure_transcription_owned(db, transcription_id: str, user_id: str) -> None:
+    cursor = await db.execute(
+        "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
+        (transcription_id, user_id),
+    )
+    if not await cursor.fetchone():
+        raise HTTPException(status_code=404, detail="Transcription not found")
+
+
+async def load_speaker_mappings(db, transcription_id: str) -> dict[str, str]:
+    cursor = await db.execute(
+        "SELECT original_label, custom_name FROM speaker_mappings WHERE transcription_id = ?",
+        (transcription_id,),
+    )
+    rows = await cursor.fetchall()
+    return {r["original_label"]: r["custom_name"] for r in rows} if rows else {}
+
+
+async def reset_translation_state(transcription_id: str, user_id: str) -> None:
+    async with get_db() as db:
+        await db.execute(
+            "UPDATE transcriptions SET translated_utterances_json = NULL, translation_language = NULL WHERE id = ? AND user_id = ?",
+            (transcription_id, user_id),
+        )
+        await db.commit()
+
+
+async def reset_refinement_state(transcription_id: str, user_id: str) -> None:
+    async with get_db() as db:
+        await db.execute(
+            "UPDATE transcriptions SET refined_utterances_json = NULL WHERE id = ? AND user_id = ?",
+            (transcription_id, user_id),
+        )
+        await db.commit()
+
+
+async def fetch_file_owned_or_404(db, file_id: str, user_id: str, *, detail: str = "File not found"):
+    cursor = await db.execute(
+        "SELECT * FROM files WHERE id = ? AND user_id = ?",
+        (file_id, user_id),
+    )
+    row = await cursor.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail=detail)
+    return row

--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -4,6 +4,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException
 from app.config import settings
 from app.dependencies import get_current_user
+from app.router_helpers import ensure_transcription_owned, load_speaker_mappings
 from app.models import UserInfo, AnalysisRequest, AnalysisListItem
 from app.database import get_db
 from app.services.llm import get_llm_provider
@@ -65,12 +66,7 @@ async def generate_analysis(
         analysis_language = request_language or row["language"]
 
         # Get speaker mappings
-        cursor = await db.execute(
-            "SELECT original_label, custom_name FROM speaker_mappings WHERE transcription_id = ?",
-            (transcription_id,),
-        )
-        mapping_rows = await cursor.fetchall()
-        speaker_map = {r["original_label"]: r["custom_name"] for r in mapping_rows} if mapping_rows else None
+        speaker_map = await load_speaker_mappings(db, transcription_id)
 
         # Insert placeholder row to mark generation as in-progress
         await db.execute(
@@ -212,12 +208,7 @@ async def list_analyses(
 ):
     """List all analyses for a transcription."""
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
-            (transcription_id, user.id),
-        )
-        if not await cursor.fetchone():
-            raise HTTPException(status_code=404, detail="Transcription not found")
+        await ensure_transcription_owned(db, transcription_id, user.id)
 
         cursor = await db.execute(
             "SELECT id, template, language, llm_provider, llm_model, created_at FROM analyses WHERE transcription_id = ? AND analysis_json IS NOT NULL ORDER BY created_at DESC",
@@ -246,12 +237,7 @@ async def get_analysis(
 ):
     """Get a single analysis by ID."""
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
-            (transcription_id, user.id),
-        )
-        if not await cursor.fetchone():
-            raise HTTPException(status_code=404, detail="Transcription not found")
+        await ensure_transcription_owned(db, transcription_id, user.id)
 
         cursor = await db.execute(
             "SELECT id, analysis_json, llm_provider, llm_model FROM analyses WHERE id = ? AND transcription_id = ?",
@@ -275,12 +261,7 @@ async def delete_analysis(
     user: UserInfo = Depends(get_current_user),
 ):
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
-            (transcription_id, user.id),
-        )
-        if not await cursor.fetchone():
-            raise HTTPException(status_code=404, detail="Transcription not found")
+        await ensure_transcription_owned(db, transcription_id, user.id)
 
         cursor = await db.execute(
             "DELETE FROM analyses WHERE id = ? AND transcription_id = ?",
@@ -309,12 +290,7 @@ async def delete_analysis_item(
         raise HTTPException(status_code=400, detail=f"Field must be one of: {', '.join(sorted(ALLOWED_FIELDS))}")
 
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
-            (transcription_id, user.id),
-        )
-        if not await cursor.fetchone():
-            raise HTTPException(status_code=404, detail="Transcription not found")
+        await ensure_transcription_owned(db, transcription_id, user.id)
 
         cursor = await db.execute(
             "SELECT analysis_json, llm_provider, llm_model FROM analyses WHERE id = ? AND transcription_id = ?",

--- a/backend/app/routers/refinement.py
+++ b/backend/app/routers/refinement.py
@@ -4,6 +4,11 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException
 from app.config import settings
 from app.dependencies import get_current_user
+from app.router_helpers import (
+    ensure_transcription_owned,
+    load_speaker_mappings,
+    reset_refinement_state,
+)
 from app.models import (
     UserInfo, RefineRequest, LLMRefinementResponse, RefinementMetadata, RefinementResult, Utterance,
 )
@@ -49,12 +54,7 @@ async def refine_transcription(
 
         original_utterances = json.loads(result_json or "[]")
 
-        cursor = await db.execute(
-            "SELECT original_label, custom_name FROM speaker_mappings WHERE transcription_id = ?",
-            (transcription_id,),
-        )
-        mapping_rows = await cursor.fetchall()
-        speaker_map = {r["original_label"]: r["custom_name"] for r in mapping_rows} if mapping_rows else {}
+        speaker_map = await load_speaker_mappings(db, transcription_id)
 
         await db.execute(
             "UPDATE transcriptions SET refined_utterances_json = '' WHERE id = ? AND user_id = ?",
@@ -80,12 +80,7 @@ async def refine_transcription(
     except Exception:
         inc(llm_errors_total, settings.LLM_PROVIDER, settings.LLM_MODEL, "refinement")
         inc(errors_total, "llm_failed", "refinement")
-        async with get_db() as db:
-            await db.execute(
-                "UPDATE transcriptions SET refined_utterances_json = NULL WHERE id = ? AND user_id = ?",
-                (transcription_id, user.id),
-            )
-            await db.commit()
+        await reset_refinement_state(transcription_id, user.id)
         raise HTTPException(status_code=500, detail="Refinement failed")
 
     duration = time.monotonic() - start_time
@@ -93,12 +88,7 @@ async def refine_transcription(
     observe(llm_duration_seconds, duration, settings.LLM_PROVIDER, settings.LLM_MODEL, "refinement")
 
     if len(llm_result.utterances) != len(original_utterances):
-        async with get_db() as db:
-            await db.execute(
-                "UPDATE transcriptions SET refined_utterances_json = NULL WHERE id = ? AND user_id = ?",
-                (transcription_id, user.id),
-            )
-            await db.commit()
+        await reset_refinement_state(transcription_id, user.id)
         raise HTTPException(
             status_code=500,
             detail=f"LLM returned {len(llm_result.utterances)} utterances, expected {len(original_utterances)}",
@@ -162,12 +152,7 @@ async def delete_refinement(
     user: UserInfo = Depends(get_current_user),
 ):
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
-            (transcription_id, user.id),
-        )
-        if not await cursor.fetchone():
-            raise HTTPException(status_code=404, detail="Transcription not found")
+        await ensure_transcription_owned(db, transcription_id, user.id)
 
         await db.execute(
             """UPDATE transcriptions

--- a/backend/app/routers/transcription.py
+++ b/backend/app/routers/transcription.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from app.config import settings
 from app.dependencies import get_current_user
+from app.router_helpers import ensure_transcription_owned, load_speaker_mappings
 from app.models import (
     UserInfo, TranscriptionSettings as TranscriptionSettingsModel,
     TranscriptionStatus, TranscriptionListItem, Utterance, SpeakerMappingRequest,
@@ -194,12 +195,7 @@ async def get_transcription(transcription_id: str, user: UserInfo = Depends(get_
     utterances = [Utterance(**u) for u in json.loads(row["result_json"] or "[]")]
 
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT original_label, custom_name FROM speaker_mappings WHERE transcription_id = ?",
-            (transcription_id,),
-        )
-        mapping_rows = await cursor.fetchall()
-        speaker_mappings = {r["original_label"]: r["custom_name"] for r in mapping_rows} if mapping_rows else {}
+        speaker_mappings = await load_speaker_mappings(db, transcription_id)
 
     return {
         "id": row["id"], "status": row["status"],
@@ -224,12 +220,7 @@ async def export_transcription(transcription_id: str, format_type: str, user: Us
         if not row:
             raise HTTPException(status_code=404, detail="Transcription not found")
 
-        cursor = await db.execute(
-            "SELECT original_label, custom_name FROM speaker_mappings WHERE transcription_id = ?",
-            (transcription_id,),
-        )
-        mapping_rows = await cursor.fetchall()
-        speaker_map = {r["original_label"]: r["custom_name"] for r in mapping_rows} if mapping_rows else None
+        speaker_map = await load_speaker_mappings(db, transcription_id)
 
     utterances = [Utterance(**u) for u in json.loads(row["result_json"] or "[]")]
 
@@ -277,12 +268,7 @@ async def update_transcription(transcription_id: str, utterances: list[Utterance
 async def update_speaker_mappings(transcription_id: str, request: SpeakerMappingRequest, user: UserInfo = Depends(get_current_user)):
     mappings = request.mappings
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
-            (transcription_id, user.id),
-        )
-        if not await cursor.fetchone():
-            raise HTTPException(status_code=404, detail="Transcription not found")
+        await ensure_transcription_owned(db, transcription_id, user.id)
 
         await db.execute("DELETE FROM speaker_mappings WHERE transcription_id = ?", (transcription_id,))
         for original, custom in mappings.items():

--- a/backend/app/routers/translation.py
+++ b/backend/app/routers/translation.py
@@ -3,6 +3,7 @@ import time
 from fastapi import APIRouter, Depends, HTTPException
 from app.config import settings
 from app.dependencies import get_current_user
+from app.router_helpers import ensure_transcription_owned, reset_translation_state
 from app.models import UserInfo, TranslationRequest, Utterance
 from app.database import get_db
 from app.services.llm import get_llm_provider
@@ -102,12 +103,7 @@ async def translate_transcription(
     except Exception:
         inc(llm_errors_total, settings.LLM_PROVIDER, settings.LLM_MODEL, "translation")
         inc(errors_total, "llm_failed", "translation")
-        async with get_db() as db:
-            await db.execute(
-                "UPDATE transcriptions SET translated_utterances_json = NULL, translation_language = NULL WHERE id = ? AND user_id = ?",
-                (transcription_id, user.id),
-            )
-            await db.commit()
+        await reset_translation_state(transcription_id, user.id)
         raise HTTPException(status_code=500, detail="Translation failed")
 
     duration = time.monotonic() - start_time
@@ -115,12 +111,7 @@ async def translate_transcription(
     observe(llm_duration_seconds, duration, settings.LLM_PROVIDER, settings.LLM_MODEL, "translation")
 
     if len(translated) != len(original_utterances):
-        async with get_db() as db:
-            await db.execute(
-                "UPDATE transcriptions SET translated_utterances_json = NULL, translation_language = NULL WHERE id = ? AND user_id = ?",
-                (transcription_id, user.id),
-            )
-            await db.commit()
+        await reset_translation_state(transcription_id, user.id)
         raise HTTPException(
             status_code=500,
             detail=f"LLM returned {len(translated)} utterances, expected {len(original_utterances)}",
@@ -176,12 +167,7 @@ async def delete_translation(
     user: UserInfo = Depends(get_current_user),
 ):
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT id FROM transcriptions WHERE id = ? AND user_id = ?",
-            (transcription_id, user.id),
-        )
-        if not await cursor.fetchone():
-            raise HTTPException(status_code=404, detail="Transcription not found")
+        await ensure_transcription_owned(db, transcription_id, user.id)
 
         await db.execute(
             """UPDATE transcriptions

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, UploadFile, HTTPException
 from fastapi.responses import FileResponse
 from app.config import settings
 from app.dependencies import get_current_user
+from app.router_helpers import fetch_file_owned_or_404
 from app.models import UserInfo, FileInfo, RenameRequest
 from app.database import get_db
 from app.services.audio import convert_to_mp3, has_video_stream
@@ -99,14 +100,7 @@ async def get_media(
     user: UserInfo = Depends(get_current_user),
 ):
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT file_path, media_type FROM files WHERE id = ? AND user_id = ?",
-            (file_id, user.id),
-        )
-        row = await cursor.fetchone()
-
-    if not row:
-        raise HTTPException(status_code=404, detail="File not found")
+        row = await fetch_file_owned_or_404(db, file_id, user.id)
 
     file_path = row["file_path"]
     if not os.path.exists(file_path):
@@ -122,13 +116,9 @@ async def get_media_fallback(
     user: UserInfo = Depends(get_current_user),
 ):
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT mp3_path FROM files WHERE id = ? AND user_id = ?",
-            (file_id, user.id),
-        )
-        row = await cursor.fetchone()
+        row = await fetch_file_owned_or_404(db, file_id, user.id, detail="No fallback available")
 
-    if not row or not row["mp3_path"]:
+    if not row["mp3_path"]:
         raise HTTPException(status_code=404, detail="No fallback available")
 
     mp3_path = row["mp3_path"]
@@ -149,13 +139,7 @@ async def rename_file(
         raise HTTPException(status_code=400, detail="Invalid filename")
 
     async with get_db() as db:
-        cursor = await db.execute(
-            "SELECT original_filename, media_type, file_size, has_video FROM files WHERE id = ? AND user_id = ?",
-            (file_id, user.id),
-        )
-        row = await cursor.fetchone()
-        if not row:
-            raise HTTPException(status_code=404, detail="File not found")
+        row = await fetch_file_owned_or_404(db, file_id, user.id)
 
         # Preserve original extension
         original_ext = os.path.splitext(row["original_filename"])[1]

--- a/backend/app/services/llm/prompt.py
+++ b/backend/app/services/llm/prompt.py
@@ -414,10 +414,6 @@ Do not include any text outside the JSON object.""",
 }
 
 
-def get_analysis_template(name: str) -> dict | None:
-    return ANALYSIS_TEMPLATES.get(name)
-
-
 def list_analysis_templates() -> list[dict]:
     return [
         {"id": k, "name": v["name"], "description": v["description"], "default_prompt": v["system_prompt"]}


### PR DESCRIPTION
## Summary

First of two planned backend dedup PRs. Scope: **low-risk** helper extraction and one dead-code removal. No change to public API surface, response shapes, or error detail strings.

### What changed

New module `backend/app/router_helpers.py` consolidates four repeated patterns:

| Helper | Replaces | Sites |
|---|---|---|
| `ensure_transcription_owned` | `SELECT id FROM transcriptions WHERE id=? AND user_id=?` + 404 | 7 |
| `load_speaker_mappings` | `SELECT original_label, custom_name FROM speaker_mappings ...` + dict-comprehension | 4 |
| `reset_translation_state` / `reset_refinement_state` | error-recovery `UPDATE ... = NULL` | 4 |
| `fetch_file_owned_or_404` | `SELECT ... FROM files WHERE id=? AND user_id=?` + 404 | 3 |

Removed unused function: `get_analysis_template` in `services/llm/prompt.py` (zero references in repo — `list_analysis_templates` is the used one).

### Intentionally not touched

- `update_transcription` ownership check uses `AND status='completed'` — different semantics
- `update_title` uses `detail="Not found"` instead of `"Transcription not found"` — preserved to avoid API behavior change
- `websocket_status` ownership check uses `websocket.close()` not `HTTPException` — different error path
- `C2` semantic note: two call sites previously returned `None` when no mappings existed; all call sites are downstream-guarded with falsy checks (`if mappings:` / `if speaker and speaker_mappings:`), so unifying to `{}` is behavior-identical.

### Follow-up

A second PR will land medium-risk LLM-provider consolidation (shared chunking base methods for OpenAI/Ollama providers) once this one is merged.

### Stats

- Net: −115 / +78 lines across 7 files (new helpers module: +53)
- All 106 passing tests still pass (`tests/test_config.py::test_api_token_settings_defaults` pre-existing failure unrelated — it reads local `.env`)