### PR TITLE
refactor(llm): consolidate provider orchestration into base class

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,5 +1,8 @@
+import time
+from contextlib import asynccontextmanager
+
 from prometheus_client import Counter, Histogram, Gauge, Info, generate_latest, CONTENT_TYPE_LATEST
-from fastapi import Response
+from fastapi import HTTPException, Response
 from app.config import settings
 
 CONTENT_TYPE = CONTENT_TYPE_LATEST
@@ -211,6 +214,27 @@ def track_llm_tokens(provider: str, model: str, operation: str, usage) -> None:
         inc(llm_tokens_total, provider, model, operation, "prompt", amount=int(prompt))
     if completion:
         inc(llm_tokens_total, provider, model, operation, "completion", amount=int(completion))
+
+
+@asynccontextmanager
+async def measure_llm_operation(operation: str):
+    """Time an LLM call and emit request/duration/error metrics.
+
+    HTTPException passes through without counting as an LLM error (it signals a
+    caller-side failure like an unsupported provider, not a model failure).
+    """
+    start = time.monotonic()
+    try:
+        yield
+    except HTTPException:
+        raise
+    except Exception:
+        inc(llm_errors_total, settings.LLM_PROVIDER, settings.LLM_MODEL, operation)
+        inc(errors_total, "llm_failed", operation)
+        raise
+    duration = time.monotonic() - start
+    inc(llm_requests_total, settings.LLM_PROVIDER, settings.LLM_MODEL, operation)
+    observe(llm_duration_seconds, duration, settings.LLM_PROVIDER, settings.LLM_MODEL, operation)
 
 
 def metrics_response() -> Response:

--- a/backend/app/routers/refinement.py
+++ b/backend/app/routers/refinement.py
@@ -1,5 +1,4 @@
 import json
-import time
 from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException
 from app.config import settings
@@ -14,7 +13,7 @@ from app.models import (
 )
 from app.database import get_db
 from app.services.llm import get_llm_provider
-from app.metrics import inc, observe, llm_requests_total, llm_duration_seconds, llm_errors_total, deletions_total, errors_total
+from app.metrics import inc, measure_llm_operation, deletions_total
 
 router = APIRouter()
 
@@ -72,20 +71,16 @@ async def refine_transcription(
     context = body.context if body else None
     transcript_json = json.dumps(mapped_utterances, ensure_ascii=False)
 
-    start_time = time.monotonic()
     try:
-        llm_result: LLMRefinementResponse = await provider.generate_refinement(
-            transcript_json, context=context,
-        )
+        async with measure_llm_operation("refinement"):
+            llm_result: LLMRefinementResponse = await provider.generate_refinement(
+                transcript_json, context=context,
+            )
+    except HTTPException:
+        raise
     except Exception:
-        inc(llm_errors_total, settings.LLM_PROVIDER, settings.LLM_MODEL, "refinement")
-        inc(errors_total, "llm_failed", "refinement")
         await reset_refinement_state(transcription_id, user.id)
         raise HTTPException(status_code=500, detail="Refinement failed")
-
-    duration = time.monotonic() - start_time
-    inc(llm_requests_total, settings.LLM_PROVIDER, settings.LLM_MODEL, "refinement")
-    observe(llm_duration_seconds, duration, settings.LLM_PROVIDER, settings.LLM_MODEL, "refinement")
 
     if len(llm_result.utterances) != len(original_utterances):
         await reset_refinement_state(transcription_id, user.id)

--- a/backend/app/routers/translation.py
+++ b/backend/app/routers/translation.py
@@ -1,5 +1,4 @@
 import json
-import time
 from fastapi import APIRouter, Depends, HTTPException
 from app.config import settings
 from app.dependencies import get_current_user
@@ -12,7 +11,7 @@ from app.services.llm.prompt import (
     build_translation_user_prompt,
     chunk_utterances_for_refinement,
 )
-from app.metrics import inc, observe, track_llm_tokens, llm_requests_total, llm_duration_seconds, llm_errors_total, deletions_total, errors_total
+from app.metrics import inc, measure_llm_operation, track_llm_tokens, deletions_total
 
 router = APIRouter()
 
@@ -95,20 +94,14 @@ async def translate_transcription(
         )
         await db.commit()
 
-    start_time = time.monotonic()
     try:
-        translated = await _call_llm_translation(provider, original_utterances, body.target_language)
+        async with measure_llm_operation("translation"):
+            translated = await _call_llm_translation(provider, original_utterances, body.target_language)
     except HTTPException:
         raise
     except Exception:
-        inc(llm_errors_total, settings.LLM_PROVIDER, settings.LLM_MODEL, "translation")
-        inc(errors_total, "llm_failed", "translation")
         await reset_translation_state(transcription_id, user.id)
         raise HTTPException(status_code=500, detail="Translation failed")
-
-    duration = time.monotonic() - start_time
-    inc(llm_requests_total, settings.LLM_PROVIDER, settings.LLM_MODEL, "translation")
-    observe(llm_duration_seconds, duration, settings.LLM_PROVIDER, settings.LLM_MODEL, "translation")
 
     if len(translated) != len(original_utterances):
         await reset_translation_state(transcription_id, user.id)

--- a/backend/app/services/llm/base.py
+++ b/backend/app/services/llm/base.py
@@ -1,20 +1,127 @@
+import json
 from abc import ABC, abstractmethod
-from app.models import SummaryResult, ProtocolResult, LLMRefinementResponse
+
+from app.models import (
+    SummaryResult, SummaryChapter,
+    ProtocolResult, ProtocolKeyPoint, ProtocolDecision, ProtocolActionItem,
+    LLMRefinementResponse, Utterance,
+)
+from app.services.llm.prompt import (
+    build_system_prompt, build_user_prompt, chunk_transcript, build_consolidation_prompt,
+    build_protocol_system_prompt, build_protocol_user_prompt,
+    PROTOCOL_CONSOLIDATION_PROMPT, PROTOCOL_SCHEMA,
+    build_refinement_system_prompt, build_refinement_user_prompt,
+    chunk_utterances_for_refinement,
+    _language_name,
+)
 
 
 class LLMProvider(ABC):
     @abstractmethod
-    async def generate_summary(self, transcript: str, chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        """Generate a summary with chapters from timestamped transcript text."""
+    async def _json_chat(self, system: str, user: str, operation: str) -> dict:
+        """Run a JSON-returning chat completion and return the parsed object."""
 
     @abstractmethod
-    async def generate_protocol(self, transcript: str, summary_context: str | None = None, language: str | None = None) -> ProtocolResult:
-        """Generate a meeting protocol from timestamped transcript text."""
-
-    @abstractmethod
-    async def generate_refinement(self, transcript: str, context: str | None = None) -> LLMRefinementResponse:
-        ...
+    async def _consolidate_refinement_summaries(self, summaries: list[str]) -> str:
+        """Collapse per-chunk refinement change-summaries into one plain-text string."""
 
     @abstractmethod
     async def generate_title(self, transcript: str) -> str:
         """Generate a short title from transcript text."""
+
+    async def generate_summary(
+        self, transcript: str, chapter_hints: list | None = None, language: str | None = None
+    ) -> SummaryResult:
+        chunks = chunk_transcript(transcript)
+        system = build_system_prompt(chapter_hints, language)
+
+        if len(chunks) == 1:
+            data = await self._json_chat(system, build_user_prompt(chunks[0]), "analysis")
+            return _parse_summary(data)
+
+        chunk_summaries: list[str] = []
+        for chunk in chunks:
+            data = await self._json_chat(system, build_user_prompt(chunk), "analysis")
+            chunk_summaries.append(json.dumps(data))
+
+        prompt = build_consolidation_prompt(
+            "\n\n---\n\n".join(chunk_summaries), chapter_hints, language,
+        )
+        data = await self._json_chat(system, prompt, "analysis")
+        return _parse_summary(data)
+
+    async def generate_protocol(
+        self, transcript: str, summary_context: str | None = None, language: str | None = None
+    ) -> ProtocolResult:
+        chunks = chunk_transcript(transcript)
+        system = build_protocol_system_prompt(language)
+
+        if len(chunks) == 1:
+            data = await self._json_chat(
+                system, build_protocol_user_prompt(chunks[0], summary_context), "analysis",
+            )
+            return _parse_protocol(data)
+
+        chunk_protocols: list[str] = []
+        for chunk in chunks:
+            data = await self._json_chat(
+                system, build_protocol_user_prompt(chunk, summary_context), "analysis",
+            )
+            chunk_protocols.append(json.dumps(data))
+
+        language_instruction = (
+            f"Respond in {_language_name(language)}." if language
+            else "Respond in the same language as the content above."
+        )
+        prompt = PROTOCOL_CONSOLIDATION_PROMPT.format(
+            chunk_protocols="\n\n---\n\n".join(chunk_protocols),
+            schema=json.dumps(PROTOCOL_SCHEMA, indent=2),
+            language_instruction=language_instruction,
+        )
+        data = await self._json_chat(system, prompt, "analysis")
+        return _parse_protocol(data)
+
+    async def generate_refinement(
+        self, transcript: str, context: str | None = None
+    ) -> LLMRefinementResponse:
+        utterances = json.loads(transcript)
+        chunks = chunk_utterances_for_refinement(utterances)
+
+        all_refined: list[dict] = []
+        summaries: list[str] = []
+
+        for chunk in chunks:
+            data = await self._json_chat(
+                build_refinement_system_prompt(context),
+                build_refinement_user_prompt(chunk),
+                "refinement",
+            )
+            all_refined.extend(data.get("utterances", []))
+            summaries.append(data.get("changes_summary", ""))
+
+        if len(summaries) > 1:
+            combined_summary = await self._consolidate_refinement_summaries(summaries)
+        else:
+            combined_summary = summaries[0] if summaries else "No changes needed"
+
+        return LLMRefinementResponse(
+            utterances=[Utterance(**u) for u in all_refined],
+            changes_summary=combined_summary,
+        )
+
+
+def _parse_summary(data: dict) -> SummaryResult:
+    return SummaryResult(
+        summary=data.get("summary", ""),
+        chapters=[SummaryChapter(**ch) for ch in data.get("chapters", [])],
+    )
+
+
+def _parse_protocol(data: dict) -> ProtocolResult:
+    return ProtocolResult(
+        title=data.get("title", ""),
+        participants=data.get("participants", []),
+        key_points=[ProtocolKeyPoint(**kp) for kp in data.get("key_points", [])],
+        decisions=[ProtocolDecision(**d) for d in data.get("decisions", [])],
+        action_items=[ProtocolActionItem(**ai) for ai in data.get("action_items", [])],
+    )

--- a/backend/app/services/llm/ollama.py
+++ b/backend/app/services/llm/ollama.py
@@ -1,53 +1,17 @@
 import json
+
 import httpx
+
 from app.config import settings
 from app.metrics import track_llm_tokens
 from app.services.llm.base import LLMProvider
-from app.services.llm.prompt import (
-    build_system_prompt, build_user_prompt, chunk_transcript, build_consolidation_prompt,
-    build_protocol_system_prompt, build_protocol_user_prompt, PROTOCOL_CONSOLIDATION_PROMPT, PROTOCOL_SCHEMA,
-    build_refinement_system_prompt, build_refinement_user_prompt, chunk_utterances_for_refinement,
-    REFINEMENT_CONSOLIDATION_PROMPT,
-)
-from app.models import SummaryResult, SummaryChapter, ProtocolResult, ProtocolKeyPoint, ProtocolDecision, ProtocolActionItem, LLMRefinementResponse, Utterance
+from app.services.llm.prompt import REFINEMENT_CONSOLIDATION_PROMPT
 
 
 class OllamaProvider(LLMProvider):
     def __init__(self):
         self._base_url = settings.LLM_BASE_URL or "http://localhost:11434"
         self._model = settings.LLM_MODEL or "llama3"
-
-    async def generate_summary(self, transcript: str, chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        chunks = chunk_transcript(transcript)
-
-        if len(chunks) == 1:
-            return await self._summarize_single(chunks[0], chapter_hints, language)
-
-        chunk_summaries = []
-        for chunk in chunks:
-            result = await self._summarize_single(chunk, chapter_hints, language)
-            chunk_summaries.append(json.dumps(result.model_dump()))
-
-        return await self._consolidate(chunk_summaries, chapter_hints, language)
-
-    async def _summarize_single(self, transcript: str, chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        content = await self._chat(build_system_prompt(chapter_hints, language), build_user_prompt(transcript))
-        data = json.loads(content)
-        return SummaryResult(
-            summary=data.get("summary", ""),
-            chapters=[SummaryChapter(**ch) for ch in data.get("chapters", [])],
-        )
-
-    async def _consolidate(self, chunk_summaries: list[str], chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        prompt = build_consolidation_prompt(
-            "\n\n---\n\n".join(chunk_summaries), chapter_hints, language
-        )
-        content = await self._chat(build_system_prompt(chapter_hints, language), prompt)
-        data = json.loads(content)
-        return SummaryResult(
-            summary=data.get("summary", ""),
-            chapters=[SummaryChapter(**ch) for ch in data.get("chapters", [])],
-        )
 
     async def _chat(self, system: str, user: str, operation: str = "analysis") -> str:
         async with httpx.AsyncClient(timeout=300) as client:
@@ -68,77 +32,16 @@ class OllamaProvider(LLMProvider):
             track_llm_tokens("ollama", self._model, operation, payload)
             return payload["message"]["content"]
 
-    async def generate_protocol(self, transcript: str, summary_context: str | None = None, language: str | None = None) -> ProtocolResult:
-        chunks = chunk_transcript(transcript)
+    async def _json_chat(self, system: str, user: str, operation: str) -> dict:
+        return json.loads(await self._chat(system, user, operation))
 
-        if len(chunks) == 1:
-            return await self._protocol_single(chunks[0], summary_context, language)
-
-        chunk_protocols = []
-        for chunk in chunks:
-            result = await self._protocol_single(chunk, summary_context, language)
-            chunk_protocols.append(json.dumps(result.model_dump()))
-
-        return await self._consolidate_protocol(chunk_protocols, language)
-
-    async def _protocol_single(self, transcript: str, summary_context: str | None = None, language: str | None = None) -> ProtocolResult:
-        content = await self._chat(build_protocol_system_prompt(language), build_protocol_user_prompt(transcript, summary_context))
-        data = json.loads(content)
-        return ProtocolResult(
-            title=data.get("title", ""),
-            participants=data.get("participants", []),
-            key_points=[ProtocolKeyPoint(**kp) for kp in data.get("key_points", [])],
-            decisions=[ProtocolDecision(**d) for d in data.get("decisions", [])],
-            action_items=[ProtocolActionItem(**ai) for ai in data.get("action_items", [])],
-        )
-
-    async def _consolidate_protocol(self, chunk_protocols: list[str], language: str | None = None) -> ProtocolResult:
-        from app.services.llm.prompt import _language_name
-        language_instruction = f"Respond in {_language_name(language)}." if language else "Respond in the same language as the content above."
-        prompt = PROTOCOL_CONSOLIDATION_PROMPT.format(
-            chunk_protocols="\n\n---\n\n".join(chunk_protocols),
-            schema=json.dumps(PROTOCOL_SCHEMA, indent=2),
-            language_instruction=language_instruction,
-        )
-        content = await self._chat(build_protocol_system_prompt(language), prompt)
-        data = json.loads(content)
-        return ProtocolResult(
-            title=data.get("title", ""),
-            participants=data.get("participants", []),
-            key_points=[ProtocolKeyPoint(**kp) for kp in data.get("key_points", [])],
-            decisions=[ProtocolDecision(**d) for d in data.get("decisions", [])],
-            action_items=[ProtocolActionItem(**ai) for ai in data.get("action_items", [])],
-        )
-
-    async def generate_refinement(self, transcript: str, context: str | None = None) -> LLMRefinementResponse:
-        utterances = json.loads(transcript)
-        chunks = chunk_utterances_for_refinement(utterances)
-
-        all_refined: list[dict] = []
-        summaries: list[str] = []
-
-        for chunk in chunks:
-            system = build_refinement_system_prompt(context)
-            user = build_refinement_user_prompt(chunk)
-            content = await self._chat(system, user, operation="refinement")
-            data = json.loads(content)
-            all_refined.extend(data.get("utterances", []))
-            summaries.append(data.get("changes_summary", ""))
-
-        if len(summaries) > 1:
-            combined_summary = await self._chat(
-                "You are a helpful assistant. Return only plain text, not JSON.",
-                REFINEMENT_CONSOLIDATION_PROMPT.format(
-                    summaries="\n".join(f"- {s}" for s in summaries)
-                ),
-                operation="refinement",
-            )
-        else:
-            combined_summary = summaries[0] if summaries else "No changes needed"
-
-        return LLMRefinementResponse(
-            utterances=[Utterance(**u) for u in all_refined],
-            changes_summary=combined_summary,
+    async def _consolidate_refinement_summaries(self, summaries: list[str]) -> str:
+        return await self._chat(
+            "You are a helpful assistant. Return only plain text, not JSON.",
+            REFINEMENT_CONSOLIDATION_PROMPT.format(
+                summaries="\n".join(f"- {s}" for s in summaries),
+            ),
+            operation="refinement",
         )
 
     async def generate_title(self, transcript: str) -> str:
@@ -152,4 +55,3 @@ class OllamaProvider(LLMProvider):
             return str(data.get("title", data.get("text", result))).strip().strip('"\'')
         except (json.JSONDecodeError, AttributeError):
             return result.strip().strip('"\'')
-

--- a/backend/app/services/llm/openai.py
+++ b/backend/app/services/llm/openai.py
@@ -1,15 +1,11 @@
 import json
+
 from openai import AsyncOpenAI
+
 from app.config import settings
 from app.metrics import track_llm_tokens
 from app.services.llm.base import LLMProvider
-from app.services.llm.prompt import (
-    build_system_prompt, build_user_prompt, chunk_transcript, build_consolidation_prompt,
-    build_protocol_system_prompt, build_protocol_user_prompt, PROTOCOL_CONSOLIDATION_PROMPT, PROTOCOL_SCHEMA,
-    build_refinement_system_prompt, build_refinement_user_prompt, chunk_utterances_for_refinement,
-    REFINEMENT_CONSOLIDATION_PROMPT,
-)
-from app.models import SummaryResult, SummaryChapter, ProtocolResult, ProtocolKeyPoint, ProtocolDecision, ProtocolActionItem, LLMRefinementResponse, Utterance
+from app.services.llm.prompt import REFINEMENT_CONSOLIDATION_PROMPT
 
 
 class OpenAIProvider(LLMProvider):
@@ -20,175 +16,41 @@ class OpenAIProvider(LLMProvider):
         )
         self._model = settings.LLM_MODEL or "gpt-4o"
 
-    async def _chat_complete(self, operation: str, **kwargs):
-        response = await self._client.chat.completions.create(model=self._model, **kwargs)
+    async def _json_chat(self, system: str, user: str, operation: str) -> dict:
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            temperature=0.3,
+            response_format={"type": "json_object"},
+        )
         track_llm_tokens("openai", self._model, operation, getattr(response, "usage", None))
-        return response
+        return json.loads(response.choices[0].message.content or "{}")
 
-    async def generate_summary(self, transcript: str, chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        chunks = chunk_transcript(transcript)
-
-        if len(chunks) == 1:
-            return await self._summarize_single(chunks[0], chapter_hints, language)
-
-        # Multi-chunk: summarize each, then consolidate
-        chunk_summaries = []
-        for chunk in chunks:
-            result = await self._summarize_single(chunk, chapter_hints, language)
-            chunk_summaries.append(json.dumps(result.model_dump()))
-
-        return await self._consolidate(chunk_summaries, chapter_hints, language)
-
-    async def _summarize_single(self, transcript: str, chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        response = await self._chat_complete(
-            "analysis",
-            messages=[
-                {"role": "system", "content": build_system_prompt(chapter_hints, language)},
-                {"role": "user", "content": build_user_prompt(transcript)},
-            ],
+    async def _consolidate_refinement_summaries(self, summaries: list[str]) -> str:
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            messages=[{
+                "role": "user",
+                "content": REFINEMENT_CONSOLIDATION_PROMPT.format(
+                    summaries="\n".join(f"- {s}" for s in summaries),
+                ),
+            }],
             temperature=0.3,
-            response_format={"type": "json_object"},
         )
-
-        content = response.choices[0].message.content or "{}"
-        data = json.loads(content)
-
-        return SummaryResult(
-            summary=data.get("summary", ""),
-            chapters=[SummaryChapter(**ch) for ch in data.get("chapters", [])],
-        )
-
-    async def _consolidate(self, chunk_summaries: list[str], chapter_hints: list | None = None, language: str | None = None) -> SummaryResult:
-        prompt = build_consolidation_prompt(
-            "\n\n---\n\n".join(chunk_summaries), chapter_hints, language
-        )
-        response = await self._chat_complete(
-            "analysis",
-            messages=[
-                {"role": "system", "content": build_system_prompt(chapter_hints, language)},
-                {"role": "user", "content": prompt},
-            ],
-            temperature=0.3,
-            response_format={"type": "json_object"},
-        )
-
-        content = response.choices[0].message.content or "{}"
-        data = json.loads(content)
-
-        return SummaryResult(
-            summary=data.get("summary", ""),
-            chapters=[SummaryChapter(**ch) for ch in data.get("chapters", [])],
-        )
-
-    async def generate_protocol(self, transcript: str, summary_context: str | None = None, language: str | None = None) -> ProtocolResult:
-        chunks = chunk_transcript(transcript)
-
-        if len(chunks) == 1:
-            return await self._protocol_single(chunks[0], summary_context, language)
-
-        chunk_protocols = []
-        for chunk in chunks:
-            result = await self._protocol_single(chunk, summary_context, language)
-            chunk_protocols.append(json.dumps(result.model_dump()))
-
-        return await self._consolidate_protocol(chunk_protocols, language)
-
-    async def _protocol_single(self, transcript: str, summary_context: str | None = None, language: str | None = None) -> ProtocolResult:
-        response = await self._chat_complete(
-            "analysis",
-            messages=[
-                {"role": "system", "content": build_protocol_system_prompt(language)},
-                {"role": "user", "content": build_protocol_user_prompt(transcript, summary_context)},
-            ],
-            temperature=0.3,
-            response_format={"type": "json_object"},
-        )
-
-        content = response.choices[0].message.content or "{}"
-        data = json.loads(content)
-
-        return ProtocolResult(
-            title=data.get("title", ""),
-            participants=data.get("participants", []),
-            key_points=[ProtocolKeyPoint(**kp) for kp in data.get("key_points", [])],
-            decisions=[ProtocolDecision(**d) for d in data.get("decisions", [])],
-            action_items=[ProtocolActionItem(**ai) for ai in data.get("action_items", [])],
-        )
-
-    async def _consolidate_protocol(self, chunk_protocols: list[str], language: str | None = None) -> ProtocolResult:
-        from app.services.llm.prompt import _language_name
-        language_instruction = f"Respond in {_language_name(language)}." if language else "Respond in the same language as the content above."
-        prompt = PROTOCOL_CONSOLIDATION_PROMPT.format(
-            chunk_protocols="\n\n---\n\n".join(chunk_protocols),
-            schema=json.dumps(PROTOCOL_SCHEMA, indent=2),
-            language_instruction=language_instruction,
-        )
-        response = await self._chat_complete(
-            "analysis",
-            messages=[
-                {"role": "system", "content": build_protocol_system_prompt(language)},
-                {"role": "user", "content": prompt},
-            ],
-            temperature=0.3,
-            response_format={"type": "json_object"},
-        )
-
-        content = response.choices[0].message.content or "{}"
-        data = json.loads(content)
-
-        return ProtocolResult(
-            title=data.get("title", ""),
-            participants=data.get("participants", []),
-            key_points=[ProtocolKeyPoint(**kp) for kp in data.get("key_points", [])],
-            decisions=[ProtocolDecision(**d) for d in data.get("decisions", [])],
-            action_items=[ProtocolActionItem(**ai) for ai in data.get("action_items", [])],
-        )
-
-    async def generate_refinement(self, transcript: str, context: str | None = None) -> LLMRefinementResponse:
-        utterances = json.loads(transcript)
-        chunks = chunk_utterances_for_refinement(utterances)
-
-        all_refined: list[dict] = []
-        summaries: list[str] = []
-
-        for chunk in chunks:
-            system = build_refinement_system_prompt(context)
-            user = build_refinement_user_prompt(chunk)
-            resp = await self._chat_complete(
-                "refinement",
-                messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
-                temperature=0.3,
-                response_format={"type": "json_object"},
-            )
-            data = json.loads(resp.choices[0].message.content or "{}")
-            all_refined.extend(data.get("utterances", []))
-            summaries.append(data.get("changes_summary", ""))
-
-        if len(summaries) > 1:
-            consolidation_resp = await self._chat_complete(
-                "refinement",
-                messages=[{"role": "user", "content": REFINEMENT_CONSOLIDATION_PROMPT.format(
-                    summaries="\n".join(f"- {s}" for s in summaries)
-                )}],
-                temperature=0.3,
-            )
-            combined_summary = (consolidation_resp.choices[0].message.content or "").strip()
-        else:
-            combined_summary = summaries[0] if summaries else "No changes needed"
-
-        return LLMRefinementResponse(
-            utterances=[Utterance(**u) for u in all_refined],
-            changes_summary=combined_summary,
-        )
+        track_llm_tokens("openai", self._model, "refinement", getattr(response, "usage", None))
+        return (response.choices[0].message.content or "").strip()
 
     async def generate_title(self, transcript: str) -> str:
-        response = await self._chat_complete(
-            "title",
+        response = await self._client.chat.completions.create(
+            model=self._model,
             messages=[
                 {"role": "system", "content": "Generate a short descriptive title (max 8 words) for the following transcript. Return ONLY the title text, nothing else. No quotes, no punctuation at the end."},
                 {"role": "user", "content": transcript[:2000]},
             ],
             temperature=0.3,
         )
+        track_llm_tokens("openai", self._model, "title", getattr(response, "usage", None))
         return (response.choices[0].message.content or "").strip().strip('"\'')
-


### PR DESCRIPTION
## Summary

Second of two backend dedup PRs (follow-up to #130). Covers C3, C4, C5, and C6 from the audit — the medium-risk items that touch the pluggable LLM provider boundary.

### What changed

**C4 / C5 / C6 — LLM provider consolidation:**

The chunking-and-consolidation orchestration was copy-pasted across OpenAI and Ollama for summary, protocol, and refinement. Now it lives once, in `LLMProvider`, and providers implement only primitives.

Base class now owns:
- `generate_summary` — chunk → `_json_chat` per chunk → consolidate
- `generate_protocol` — same shape with protocol prompts + schema
- `generate_refinement` — chunk utterances → `_json_chat` per chunk → consolidate summaries via provider-specific method

Providers now implement:
- `_json_chat(system, user, operation) -> dict`
- `_consolidate_refinement_summaries(summaries) -> str`
- `generate_title(transcript)` — kept per-provider because Ollama has an intentional JSON-fallback the OpenAI path doesn't need

**C3 — LLM operation metrics helper:**

New `measure_llm_operation` async context manager in `metrics.py` that records `llm_requests_total` / `llm_duration_seconds` on success and `llm_errors_total` / `errors_total` on failure. `HTTPException` passes through without being counted as an LLM error, matching translation.py's prior behavior.

Applied in `translation.py` and `refinement.py`.

### Intentional scope limits

- **`analysis.py` not converted to `measure_llm_operation`.** Its current `except Exception:` (no HTTPException passthrough) has slightly different metric semantics than the other two routers — it increments `llm_errors_total` even for HTTPException. Converting would change that. Left untouched to honor the "no functionality change" constraint.
- **`OllamaProvider._chat` kept public.** Still used by `translation.py:_call_llm_translation` as a raw JSON-chat primitive.
- **`OpenAIProvider._client` kept public.** Still used by `translation.py` and `analysis.py:_call_llm` for custom-prompt analysis flows.

### Stats

- 6 files changed, 188 insertions, 305 deletions → **−117 net**
- openai.py: 194 → 56 lines
- ollama.py: 155 → 59 lines
- All 106 tests pass (`tests/test_config.py::test_api_token_settings_defaults` pre-existing failure is unrelated — it reads local `.env`)