### PR TITLE
refactor(frontend): dedupe time/download helpers and fix AppView type

### DIFF
--- a/frontend/src/components/AnalysisView/AnalysisView.tsx
+++ b/frontend/src/components/AnalysisView/AnalysisView.tsx
@@ -233,10 +233,9 @@ function AnalysisCard({ analysisId, transcriptionId, templates, baseName, onDele
             </div>
           )}
           {error && <p className="text-red-400 text-sm">{error}</p>}
-          {!!result && (
-            <>
-              {/* Download buttons at top */}
-              <div className="flex justify-end gap-2">
+          {!!result && (() => {
+            const copyDownloadButtons = (extraClassName = '') => (
+              <div className={`flex justify-end gap-2 ${extraClassName}`.trim()}>
                 <button onClick={() => handleCopy(resultToText(result, t), 'all')} className={btnCopy}>
                   {copied === 'all' ? checkIcon : copyIcon}
                   {copied === 'all' ? t('editor.copied') : t('analysis.copyResult')}
@@ -250,6 +249,10 @@ function AnalysisCard({ analysisId, transcriptionId, templates, baseName, onDele
                   Markdown
                 </button>
               </div>
+            )
+            return (
+            <>
+              {copyDownloadButtons()}
 
               {isSummaryShape(result) && (
                 <>
@@ -316,21 +319,7 @@ function AnalysisCard({ analysisId, transcriptionId, templates, baseName, onDele
                 </div>
               )}
 
-              {/* Copy / Download */}
-              <div className="flex justify-end gap-2 pt-3 border-t border-gray-700">
-                <button onClick={() => handleCopy(resultToText(result, t), 'all')} className={btnCopy}>
-                  {copied === 'all' ? checkIcon : copyIcon}
-                  {copied === 'all' ? t('editor.copied') : t('analysis.copyResult')}
-                </button>
-                <button onClick={() => downloadText(resultToText(result, t), `${baseName}_analysis.txt`)} className={btnDownload}>
-                  {downloadIcon}
-                  TXT
-                </button>
-                <button onClick={() => downloadMarkdown(resultToMarkdown(result, t), `${baseName}_analysis.md`)} className={btnDownload}>
-                  {downloadIcon}
-                  Markdown
-                </button>
-              </div>
+              {copyDownloadButtons('pt-3 border-t border-gray-700')}
 
               {/* Model info */}
               {(() => {
@@ -345,7 +334,8 @@ function AnalysisCard({ analysisId, transcriptionId, templates, baseName, onDele
                 return null
               })()}
             </>
-          )}
+            )
+          })()}
         </div>
       )}
     </div>

--- a/frontend/src/components/FormatViewer/FormatViewer.tsx
+++ b/frontend/src/components/FormatViewer/FormatViewer.tsx
@@ -1,27 +1,11 @@
 import { useMemo } from 'react'
 import { useStore } from '../../store'
 import { useTranslation } from 'react-i18next'
+import { downloadText, formatSrtTime, formatVttTime } from '../../utils/format'
 import type { Utterance } from '../../api/types'
 
 interface Props {
   format: string
-}
-
-function pad(n: number, digits = 2) {
-  return n.toString().padStart(digits, '0')
-}
-
-function formatSrtTime(ms: number): string {
-  const totalSec = Math.floor(ms / 1000)
-  const h = Math.floor(totalSec / 3600)
-  const m = Math.floor((totalSec % 3600) / 60)
-  const s = totalSec % 60
-  const millis = ms % 1000
-  return `${pad(h)}:${pad(m)}:${pad(s)},${pad(millis, 3)}`
-}
-
-function formatVttTime(ms: number): string {
-  return formatSrtTime(ms).replace(',', '.')
 }
 
 function getSpeakerLabel(utt: Utterance, mappings: Record<string, string>): string {
@@ -98,14 +82,8 @@ export function FormatViewer({ format }: Props) {
   }, [result, refinedUtterances, translatedUtterances, activeView, speakerMappings, format])
 
   const handleDownload = () => {
-    const blob = new Blob([content], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
     const baseName = file?.original_filename?.replace(/\.[^.]+$/, '') || 'transcription'
-    a.download = `${baseName}.${format}`
-    a.click()
-    URL.revokeObjectURL(url)
+    downloadText(content, `${baseName}.${format}`)
   }
 
   const downloadBtn = (

--- a/frontend/src/components/HelpDrawer/HelpDrawer.tsx
+++ b/frontend/src/components/HelpDrawer/HelpDrawer.tsx
@@ -6,14 +6,12 @@ import { HelpContent } from './HelpContent'
 import { sections, viewToSection } from './helpSections'
 import type { HelpSectionId } from './helpSections'
 
-type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets'
-
 export function HelpDrawer() {
   const { t } = useTranslation()
   const open = useStore((s) => s.helpOpen)
   const initialSection = useStore((s) => s.helpInitialSection)
   const closeHelp = useStore((s) => s.closeHelp)
-  const currentView = useStore((s) => s.currentView) as AppView
+  const currentView = useStore((s) => s.currentView)
 
   // Compute the section to land on when opening.
   // Because the component unmounts when !open, useState(derivedSection) will

--- a/frontend/src/components/HelpDrawer/helpSections.ts
+++ b/frontend/src/components/HelpDrawer/helpSections.ts
@@ -45,7 +45,7 @@ export const sections: readonly HelpSection[] = [
   { id: 'api-access', filename: '14-api-access.md' },
 ] as const
 
-type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets' | 'settings'
+import type { AppView } from '../../store'
 
 export const viewToSection: Record<AppView, HelpSectionId> = {
   archive: 'getting-started',

--- a/frontend/src/components/MediaPlayer/MediaPlayer.tsx
+++ b/frontend/src/components/MediaPlayer/MediaPlayer.tsx
@@ -4,6 +4,7 @@ import videojs from 'video.js'
 import 'video.js/dist/video-js.css'
 import { useStore } from '../../store'
 import { api } from '../../api/client'
+import { formatVttTime } from '../../utils/format'
 import type { Utterance } from '../../api/types'
 
 const mimeTypes: Record<string, string> = {
@@ -16,15 +17,6 @@ const mimeTypes: Record<string, string> = {
   aac: 'audio/aac',
   opus: 'audio/opus',
   ogg: 'audio/ogg',
-}
-
-function formatVttTime(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000)
-  const h = Math.floor(totalSeconds / 3600)
-  const m = Math.floor((totalSeconds % 3600) / 60)
-  const s = totalSeconds % 60
-  const millis = ms % 1000
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}.${String(millis).padStart(3, '0')}`
 }
 
 function generateVtt(utterances: Utterance[], speakerMappings: Record<string, string>): string {

--- a/frontend/src/components/SubtitleEditor/SubtitleRow.tsx
+++ b/frontend/src/components/SubtitleEditor/SubtitleRow.tsx
@@ -2,15 +2,8 @@ import { useState, useRef, useEffect, forwardRef } from 'react'
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useStore } from '../../store'
+import { formatTime } from '../../utils/format'
 import type { Utterance } from '../../api/types'
-
-function formatTimestamp(ms: number): string {
-  const s = Math.floor(ms / 1000)
-  const m = Math.floor(s / 60)
-  const h = Math.floor(m / 60)
-  const pad = (n: number) => n.toString().padStart(2, '0')
-  return `${pad(h)}:${pad(m % 60)}:${pad(s % 60)}`
-}
 
 function highlightText(text: string, query: string): ReactNode {
   if (!query) return text
@@ -109,8 +102,8 @@ export const SubtitleRow = forwardRef<HTMLTableRowElement, Props>(function Subti
   if (editingField !== prevEditingField) {
     setPrevEditingField(editingField)
     if (editingField && editingField !== 'text') {
-      if (editingField === 'start') setEditValue(formatTimestamp(utterance.start))
-      else if (editingField === 'end') setEditValue(formatTimestamp(utterance.end))
+      if (editingField === 'start') setEditValue(formatTime(utterance.start))
+      else if (editingField === 'end') setEditValue(formatTime(utterance.end))
       else if (editingField === 'speaker') setEditValue(speakerDisplay)
     }
   }
@@ -216,10 +209,10 @@ export const SubtitleRow = forwardRef<HTMLTableRowElement, Props>(function Subti
         </td>
         <td className="inline-block sm:table-cell px-2 py-2 sm:py-2 pt-2 pb-0 text-blue-400 cursor-pointer group" onClick={(e) => { e.stopPropagation(); delayedSeek(utterance.start) }}>
           <span className="inline-flex items-center gap-1">
-            {renderCell('start', formatTimestamp(utterance.start))}
+            {renderCell('start', formatTime(utterance.start))}
             {!readOnly && editingField !== 'start' && (
               <button
-                onClick={(e) => { e.stopPropagation(); cancelSeek(); startEdit('start', formatTimestamp(utterance.start)) }}
+                onClick={(e) => { e.stopPropagation(); cancelSeek(); startEdit('start', formatTime(utterance.start)) }}
                 className="opacity-60 hover:opacity-100 transition-opacity text-gray-500 hover:text-blue-400 shrink-0"
                 title={t('editor.editTimestamp')}
               >
@@ -232,10 +225,10 @@ export const SubtitleRow = forwardRef<HTMLTableRowElement, Props>(function Subti
         </td>
         <td className="inline-block sm:table-cell px-2 py-2 sm:py-2 pt-2 pb-0 text-blue-400 cursor-pointer group" onClick={(e) => { e.stopPropagation(); delayedSeek(utterance.end) }}>
           <span className="inline-flex items-center gap-1">
-            {renderCell('end', formatTimestamp(utterance.end))}
+            {renderCell('end', formatTime(utterance.end))}
             {!readOnly && editingField !== 'end' && (
               <button
-                onClick={(e) => { e.stopPropagation(); cancelSeek(); startEdit('end', formatTimestamp(utterance.end)) }}
+                onClick={(e) => { e.stopPropagation(); cancelSeek(); startEdit('end', formatTime(utterance.end)) }}
                 className="opacity-60 hover:opacity-100 transition-opacity text-gray-500 hover:text-blue-400 shrink-0"
                 title={t('editor.editTimestamp')}
               >

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import type { FileInfo, TranscriptionResult, TranscriptionListItem, ConfigResponse, Utterance, RefinementMetadata, AnalysisListItem, TranscriptionPreset, AnalysisPreset, RefinementPreset, PresetBundle } from '../api/types'
 
-type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets' | 'settings'
+export type AppView = 'archive' | 'upload' | 'record' | 'detail' | 'presets' | 'settings'
 
 interface AppState {
   currentView: AppView

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -6,14 +6,28 @@ export function formatTime(ms: number): string {
   return `${pad(h)}:${pad(m % 60)}:${pad(s % 60)}`
 }
 
+export function formatSrtTime(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  const millis = ms % 1000
+  const pad = (n: number, digits = 2) => n.toString().padStart(digits, '0')
+  return `${pad(h)}:${pad(m)}:${pad(s)},${pad(millis, 3)}`
+}
+
+export function formatVttTime(ms: number): string {
+  return formatSrtTime(ms).replace(',', '.')
+}
+
 export function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-export function downloadText(content: string, filename: string) {
-  const blob = new Blob([content], { type: 'text/plain' })
+export function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
@@ -22,12 +36,10 @@ export function downloadText(content: string, filename: string) {
   URL.revokeObjectURL(url)
 }
 
+export function downloadText(content: string, filename: string) {
+  downloadFile(content, filename, 'text/plain')
+}
+
 export function downloadMarkdown(content: string, filename: string) {
-  const blob = new Blob([content], { type: 'text/markdown' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
+  downloadFile(content, filename, 'text/markdown')
 }


### PR DESCRIPTION
## Summary

Frontend audit follow-up to #130 and #131. Covers B1, F1, F2, F4 from the audit. F3 (the `resultToText` / `resultToMarkdown` parallel pair in AnalysisView) is deferred to its own PR because collapsing them safely needs a careful output-parity check.

### What changed

**B1 — AppView type duplication + latent bug:**
`store/index.ts` declared `type AppView` but didn't export it. HelpDrawer had a **stale local copy missing `'settings'`**, and the `currentView as AppView` cast silently narrowed the 'settings' case away. helpSections.ts had a third (correct) copy. Exported once from the store, imported in the two consumers.

**F1 — Download helpers:**
New `downloadFile(content, filename, mimeType)` in `utils/format.ts`. `downloadText` / `downloadMarkdown` now delegate to it. FormatViewer's inline Blob+URL+click+revoke replaced with a `downloadText` call.

**F2 — Time formatters consolidated:**
`formatSrtTime` and `formatVttTime` moved into `utils/format.ts` alongside existing `formatTime`. Removed local copies from FormatViewer, MediaPlayer, and SubtitleRow (whose `formatTimestamp` was identical to `formatTime`).

**F4 — Copy/download buttons extracted:**
AnalysisView rendered the same three-button block twice (top and bottom of the expanded card). Extracted into a local render function that takes an optional wrapper className for the bottom block's border-top styling.

### Verification

- `npx tsc --noEmit` — clean
- `npm run build` — OK (429 modules, same bundle size as before)
- No API or component prop signature changes

### Stats

- 8 files changed, −81 / +44 → **−37 net**

### Follow-up

A separate PR will handle F3 — collapsing `resultToText` and `resultToMarkdown` in AnalysisView. Those two ~40-line functions are ~90% parallel but diverge in string-interpolation syntax; worth a focused diff check before merging.