### PR TITLE
refactor(frontend): consolidate resultToText/Markdown into formatResult

### DIFF
--- a/frontend/src/components/AnalysisView/AnalysisView.tsx
+++ b/frontend/src/components/AnalysisView/AnalysisView.tsx
@@ -39,89 +39,66 @@ function isProtocolShape(result: unknown): result is ProtocolShape {
   return typeof r.title === 'string' && Array.isArray(r.key_points) && Array.isArray(r.decisions) && Array.isArray(r.action_items)
 }
 
-function resultToText(result: unknown, t: (key: string) => string): string {
+function formatResult(result: unknown, t: (key: string) => string, format: 'text' | 'markdown'): string {
+  const md = format === 'markdown'
+
   if (isSummaryShape(result)) {
-    let text = result.summary + '\n'
+    let out = result.summary + '\n'
     if (result.chapters.length > 0) {
-      text += '\n'
+      out += '\n'
       result.chapters.forEach((ch, i) => {
-        text += `${i + 1}. ${ch.title} [${formatTime(ch.start_time)} — ${formatTime(ch.end_time)}]\n${ch.summary}\n\n`
+        const times = `${formatTime(ch.start_time)} — ${formatTime(ch.end_time)}`
+        out += md
+          ? `### ${i + 1}. ${ch.title}\n*${times}*\n\n${ch.summary}\n\n`
+          : `${i + 1}. ${ch.title} [${times}]\n${ch.summary}\n\n`
       })
     }
-    return text.trimEnd()
+    return out.trimEnd()
   }
+
   if (isProtocolShape(result)) {
-    let text = `${t('editor.protocol')}: ${result.title}\n`
-    text += `${t('editor.participants')}: ${result.participants.join(', ')}\n`
+    let out = md
+      ? `# ${t('editor.protocol')}: ${result.title}\n\n**${t('editor.participants')}:** ${result.participants.join(', ')}\n`
+      : `${t('editor.protocol')}: ${result.title}\n${t('editor.participants')}: ${result.participants.join(', ')}\n`
+
     if (result.key_points.length > 0) {
-      text += `\n${t('editor.keyPoints').toUpperCase()}\n`
+      out += md ? `\n## ${t('editor.keyPoints')}\n\n` : `\n${t('editor.keyPoints').toUpperCase()}\n`
       result.key_points.forEach((kp, i) => {
         const ts = kp.timestamp !== null ? `[${formatTime(kp.timestamp)}] ` : ''
-        text += `${i + 1}. ${ts}${kp.speaker} — ${kp.topic}\n   ${kp.content}\n\n`
+        out += md
+          ? `${i + 1}. **${ts}${kp.speaker}** — ${kp.topic}\n   ${kp.content}\n\n`
+          : `${i + 1}. ${ts}${kp.speaker} — ${kp.topic}\n   ${kp.content}\n\n`
       })
     }
     if (result.decisions.length > 0) {
-      text += `${t('editor.decisions').toUpperCase()}\n`
+      out += md ? `## ${t('editor.decisions')}\n\n` : `${t('editor.decisions').toUpperCase()}\n`
       result.decisions.forEach((d, i) => {
-        const ts = d.timestamp !== null ? `[${formatTime(d.timestamp)}] ` : ''
-        text += `${i + 1}. ${ts}${d.decision}\n\n`
+        const ts = d.timestamp !== null
+          ? (md ? `**[${formatTime(d.timestamp)}]** ` : `[${formatTime(d.timestamp)}] `)
+          : ''
+        out += `${i + 1}. ${ts}${d.decision}\n\n`
       })
     }
     if (result.action_items.length > 0) {
-      text += `${t('editor.actionItems').toUpperCase()}\n`
+      out += md ? `## ${t('editor.actionItems')}\n\n` : `${t('editor.actionItems').toUpperCase()}\n`
       result.action_items.forEach((ai, i) => {
-        const ts = ai.timestamp !== null ? ` (${formatTime(ai.timestamp)})` : ''
-        text += `${i + 1}. ${ai.assignee} — ${ai.task}${ts}\n\n`
+        const ts = ai.timestamp !== null
+          ? (md ? ` *(${formatTime(ai.timestamp)})*` : ` (${formatTime(ai.timestamp)})`)
+          : ''
+        out += md
+          ? `- [ ] **${ai.assignee}** — ${ai.task}${ts}\n`
+          : `${i + 1}. ${ai.assignee} — ${ai.task}${ts}\n\n`
       })
     }
-    return text.trimEnd()
+    return out.trimEnd()
   }
+
   if (typeof result === 'string') return result
   return JSON.stringify(result, null, 2)
 }
 
-function resultToMarkdown(result: unknown, t: (key: string) => string): string {
-  if (isSummaryShape(result)) {
-    let md = result.summary + '\n'
-    if (result.chapters.length > 0) {
-      md += '\n'
-      result.chapters.forEach((ch, i) => {
-        md += `### ${i + 1}. ${ch.title}\n`
-        md += `*${formatTime(ch.start_time)} — ${formatTime(ch.end_time)}*\n\n`
-        md += `${ch.summary}\n\n`
-      })
-    }
-    return md.trimEnd()
-  }
-  if (isProtocolShape(result)) {
-    let md = `# ${t('editor.protocol')}: ${result.title}\n\n`
-    md += `**${t('editor.participants')}:** ${result.participants.join(', ')}\n`
-    if (result.key_points.length > 0) {
-      md += `\n## ${t('editor.keyPoints')}\n\n`
-      result.key_points.forEach((kp, i) => {
-        const ts = kp.timestamp !== null ? `[${formatTime(kp.timestamp)}] ` : ''
-        md += `${i + 1}. **${ts}${kp.speaker}** — ${kp.topic}\n   ${kp.content}\n\n`
-      })
-    }
-    if (result.decisions.length > 0) {
-      md += `## ${t('editor.decisions')}\n\n`
-      result.decisions.forEach((d, i) => {
-        const ts = d.timestamp !== null ? `**[${formatTime(d.timestamp)}]** ` : ''
-        md += `${i + 1}. ${ts}${d.decision}\n\n`
-      })
-    }
-    if (result.action_items.length > 0) {
-      md += `## ${t('editor.actionItems')}\n\n`
-      result.action_items.forEach((ai) => {
-        const ts = ai.timestamp !== null ? ` *(${formatTime(ai.timestamp)})*` : ''
-        md += `- [ ] **${ai.assignee}** — ${ai.task}${ts}\n`
-      })
-    }
-    return md.trimEnd()
-  }
-  if (typeof result === 'string') return result
-  return JSON.stringify(result, null, 2)
-}
+const resultToText = (result: unknown, t: (key: string) => string) => formatResult(result, t, 'text')
+const resultToMarkdown = (result: unknown, t: (key: string) => string) => formatResult(result, t, 'markdown')
 
 // Individual analysis card that loads its own data on expand
 function AnalysisCard({ analysisId, transcriptionId, templates, baseName, onDelete }: {


### PR DESCRIPTION
## Summary

Final item from the audit (F3). Collapses the two ~40-line formatters in AnalysisView — `resultToText` and `resultToMarkdown` — into a single `formatResult(result, t, format)` function. The two originals were ~90% parallel, differing only in string-interpolation syntax (plain text vs. markdown headings/bolds/checkboxes).

### What changed

- Single `formatResult(result, t, 'text' | 'markdown')` with per-divergence ternaries for the 8 syntactic points where the formats differ (chapter lines, section headers, list bullets, timestamp decoration, etc.)
- `resultToText` and `resultToMarkdown` kept as thin delegating wrappers so call sites (copy-to-clipboard, `.txt` download, `.md` download, fallback `<pre>` render) don't change

### Parity verification

Ran a standalone parity script comparing old vs. new implementations on 16 cases (8 inputs × 2 formats):

- Empty-chapters summary
- Summary with multiple chapters
- Multi-line summary body
- Full protocol (all 3 sections, all timestamp variants)
- Protocol with only key_points
- Protocol with all-null timestamps
- String-typed input (fallback path)
- Arbitrary-object input (JSON fallback)

**Every case produced byte-identical output** vs. the pre-refactor functions.

### Stats

- 1 file changed, −58 / +35 → **−23 net**
- `npx tsc --noEmit` clean
- `npm run build` OK (same bundle size)

### Audit complete

This closes out the full audit that started with the backend dedup in #130:
- #130: Backend low-risk dedup (−37 lines)
- #131: LLM provider consolidation (−117 lines)
- #132: Frontend dedup easy items (−37 lines)
- This PR: Frontend F3 (−23 lines)

**Total across the audit: −214 lines, 0 public-surface changes, all tests green.**