### PR TITLE
feat: self-service registration via dedicated Keycloak (opt-in)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -52,6 +52,7 @@ class Settings:
     SMTP_USER: str = os.getenv("SMTP_USER", "")
     SMTP_PASSWORD: str = os.getenv("SMTP_PASSWORD", "")
     SMTP_FROM: str = os.getenv("SMTP_FROM", "")
+    SMTP_STARTTLS: bool = os.getenv("SMTP_STARTTLS", "true").lower() in ("true", "1", "yes")
 
     APP_PUBLIC_URL: str = os.getenv("APP_PUBLIC_URL", "")
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -35,6 +35,26 @@ class Settings:
     API_TOKEN_MAX_PER_USER: int = int(os.getenv("API_TOKEN_MAX_PER_USER", "10"))
     API_TOKEN_DEFAULT_EXPIRY_DAYS: int = int(os.getenv("API_TOKEN_DEFAULT_EXPIRY_DAYS", "90"))
 
+    INVITATION_MODE: bool = os.getenv("INVITATION_MODE", "false").lower() in ("true", "1", "yes")
+    ADMIN_EMAILS: list[str] = [
+        e.strip().lower() for e in os.getenv("ADMIN_EMAILS", "").split(",") if e.strip()
+    ]
+    INVITATION_EXPIRY_DAYS: int = int(os.getenv("INVITATION_EXPIRY_DAYS", "7"))
+
+    KEYCLOAK_ADMIN_URL: str = os.getenv("KEYCLOAK_ADMIN_URL", "")
+    KEYCLOAK_ADMIN_REALM: str = os.getenv("KEYCLOAK_ADMIN_REALM", "master")
+    KEYCLOAK_TARGET_REALM: str = os.getenv("KEYCLOAK_TARGET_REALM", "")
+    KEYCLOAK_ADMIN_CLIENT_ID: str = os.getenv("KEYCLOAK_ADMIN_CLIENT_ID", "admin-cli")
+    KEYCLOAK_ADMIN_CLIENT_SECRET: str = os.getenv("KEYCLOAK_ADMIN_CLIENT_SECRET", "")
+
+    SMTP_HOST: str = os.getenv("SMTP_HOST", "")
+    SMTP_PORT: int = int(os.getenv("SMTP_PORT", "587"))
+    SMTP_USER: str = os.getenv("SMTP_USER", "")
+    SMTP_PASSWORD: str = os.getenv("SMTP_PASSWORD", "")
+    SMTP_FROM: str = os.getenv("SMTP_FROM", "")
+
+    APP_PUBLIC_URL: str = os.getenv("APP_PUBLIC_URL", "")
+
     @property
     def db_path(self) -> str:
         if self.DATABASE_PATH:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -131,6 +131,20 @@ CREATE TABLE IF NOT EXISTS api_tokens (
 );
 CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
+
+CREATE TABLE IF NOT EXISTS invitations (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    created_by TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    accepted_at TIMESTAMP,
+    accepted_by_user_id TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_invitations_email ON invitations(email);
+CREATE INDEX IF NOT EXISTS idx_invitations_status ON invitations(status);
 """
 
 _db_path: str = ""

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -150,6 +150,9 @@ CREATE INDEX IF NOT EXISTS idx_invitations_status ON invitations(status);
 _db_path: str = ""
 
 
+# SCHEMA holds CREATE TABLE / CREATE INDEX statements (idempotent via
+# IF NOT EXISTS). New tables go here. MIGRATIONS is only for adding
+# *columns* to existing tables on old databases.
 MIGRATIONS = [
     # (column_name, table, column_def)
     ("refined_utterances_json", "transcriptions", "refined_utterances_json TEXT"),

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -65,6 +65,11 @@ async def _invitation_gate_allows(user_id: str, email: str | None) -> bool:
         )
         pending = await cursor.fetchone()
         if pending is not None:
+            # Race note: two concurrent first-logins for the same email can both reach
+            # here; the second UPDATE overwrites accepted_at/accepted_by_user_id. The
+            # gate still allows both users through, so the functional outcome is correct;
+            # only the audit trail reflects the later login. Acceptable given invitations
+            # are admin-issued one-per-email.
             await db.execute(
                 """
                 UPDATE invitations
@@ -124,6 +129,9 @@ async def get_current_user(request: Request) -> UserInfo:
         inc(auth_failures_total, "missing_headers")
         raise HTTPException(status_code=401, detail="Missing authentication headers")
 
+    # NOTE: when DEV_MODE and INVITATION_MODE are both true, the synthesised
+    # dev-user has no users row and no invitation, so requests will 403 unless
+    # `dev@localhost` is added to ADMIN_EMAILS. This combination is uncommon.
     if settings.INVITATION_MODE:
         allowed = await _invitation_gate_allows(resolved.id, resolved.email)
         if not allowed:

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException, Request
 
 from app.config import settings
 from app.database import get_db
-from app.metrics import inc, auth_failures_total, api_token_auth_total
+from app.metrics import inc, auth_failures_total, api_token_auth_total, invitations_accepted_total
 from app.models import UserInfo
 from app.services.api_tokens import resolve_token, touch_last_used
 
@@ -20,6 +20,71 @@ async def _touch_best_effort(token_id: str) -> None:
         logger.warning("touch_last_used failed for %s: %s", token_id, e)
 
 
+def _is_admin_email(email: str | None) -> bool:
+    if not email:
+        return False
+    return email.strip().lower() in settings.ADMIN_EMAILS
+
+
+async def _invitation_gate_allows(user_id: str, email: str | None) -> bool:
+    """Return True iff INVITATION_MODE should let this request proceed.
+
+    - Admins always allowed.
+    - Existing users (row in `users` table) always allowed.
+    - First-login users are allowed iff they have a pending-and-not-expired
+      invitation for their email. Their pending invitation is marked accepted
+      as a side effect (so subsequent logins also pass).
+    - First-login users whose email already has an accepted invitation for a
+      different sub (edge case: admin revoked + re-invited) are also allowed.
+    """
+    from app.services.invitations import (
+        email_has_accepted_invitation, _now_str,
+    )
+
+    if _is_admin_email(email):
+        return True
+
+    async with get_db() as db:
+        cursor = await db.execute("SELECT 1 FROM users WHERE id = ? LIMIT 1", (user_id,))
+        if await cursor.fetchone() is not None:
+            return True
+
+        if not email:
+            return False
+
+        em = email.strip().lower()
+
+        # Any pending, non-expired invitation → accept it on first login.
+        cursor = await db.execute(
+            """
+            SELECT id FROM invitations
+            WHERE email = ? AND status = 'pending' AND expires_at > ?
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (em, _now_str()),
+        )
+        pending = await cursor.fetchone()
+        if pending is not None:
+            await db.execute(
+                """
+                UPDATE invitations
+                SET status = 'accepted', accepted_at = ?, accepted_by_user_id = ?
+                WHERE id = ?
+                """,
+                (_now_str(), user_id, pending["id"]),
+            )
+            await db.commit()
+            inc(invitations_accepted_total)
+            return True
+
+        # Already-accepted invitation for this email (e.g. returning user
+        # whose `users` row hasn't been created yet).
+        if await email_has_accepted_invitation(db, email=em):
+            return True
+
+    return False
+
+
 async def get_current_user(request: Request) -> UserInfo:
     if settings.ENABLE_API_TOKENS:
         auth = request.headers.get("Authorization", "")
@@ -29,6 +94,7 @@ async def get_current_user(request: Request) -> UserInfo:
                 result = await resolve_token(db, raw_token=raw)
             if result is not None:
                 user, token_id = result
+                user.is_admin = _is_admin_email(user.email)
                 inc(api_token_auth_total, "success")
                 asyncio.create_task(_touch_best_effort(token_id))
                 return user
@@ -42,12 +108,29 @@ async def get_current_user(request: Request) -> UserInfo:
 
     user_id = request.headers.get("X-Auth-Request-User")
     email = request.headers.get("X-Auth-Request-Email")
-    if user_id:
-        return UserInfo(id=user_id, email=email)
-    if email:
-        return UserInfo(id=email, email=email)
-    if settings.DEV_MODE:
-        return UserInfo(id="dev-user", email="dev@localhost")
 
-    inc(auth_failures_total, "missing_headers")
-    raise HTTPException(status_code=401, detail="Missing authentication headers")
+    def _build(uid: str, em: str | None) -> UserInfo:
+        return UserInfo(id=uid, email=em, is_admin=_is_admin_email(em))
+
+    resolved: UserInfo | None = None
+    if user_id:
+        resolved = _build(user_id, email)
+    elif email:
+        resolved = _build(email, email)
+    elif settings.DEV_MODE:
+        resolved = _build("dev-user", "dev@localhost")
+
+    if resolved is None:
+        inc(auth_failures_total, "missing_headers")
+        raise HTTPException(status_code=401, detail="Missing authentication headers")
+
+    if settings.INVITATION_MODE:
+        allowed = await _invitation_gate_allows(resolved.id, resolved.email)
+        if not allowed:
+            inc(auth_failures_total, "no_invitation")
+            raise HTTPException(
+                status_code=403,
+                detail="No invitation found for this email. Ask your administrator.",
+            )
+
+    return resolved

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -159,6 +159,9 @@ app.include_router(translation.router)
 app.include_router(presets.router)
 if settings.ENABLE_API_TOKENS:
     app.include_router(tokens.router)
+# Invitations router is mounted unconditionally; its `_require_invitation_mode`
+# dependency returns 404 when INVITATION_MODE=false. This avoids coupling the
+# mount to a startup-time flag that tests reload.
 app.include_router(invitations_router.router)
 
 # Serve frontend static files (only when built files exist, i.e., in Docker)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db, get_db
-from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets, tokens
+from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets, tokens, invitations as invitations_router
 from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes, api_tokens_active
 from app.services.audio import has_video_stream
 from app.services.api_tokens import cleanup_stale_tokens, count_active_tokens
@@ -151,6 +151,7 @@ app.include_router(translation.router)
 app.include_router(presets.router)
 if settings.ENABLE_API_TOKENS:
     app.include_router(tokens.router)
+app.include_router(invitations_router.router)
 
 # Serve frontend static files (only when built files exist, i.e., in Docker)
 from fastapi.staticfiles import StaticFiles

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db, get_db
 from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets, tokens, invitations as invitations_router
-from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes, api_tokens_active
+from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes, api_tokens_active, invitations_expired_total
 from app.services.audio import has_video_stream
 from app.services.api_tokens import cleanup_stale_tokens, count_active_tokens
 
@@ -89,6 +89,11 @@ async def cleanup_old_files():
                 await db.commit()
                 tokens_deleted = await cleanup_stale_tokens(db)
                 active_tokens = await count_active_tokens(db)
+                from app.services.invitations import (
+                    expire_pending_invitations, cleanup_old_invitations,
+                )
+                invitations_expired = await expire_pending_invitations(db)
+                invitations_deleted = await cleanup_old_invitations(db)
 
             inc(cleanup_runs_total, "success")
             inc(cleanup_items_deleted_total, "file", amount=files_deleted + db_files_deleted)
@@ -96,6 +101,9 @@ async def cleanup_old_files():
             inc(cleanup_items_deleted_total, "analysis", amount=analyses_deleted)
             inc(cleanup_items_deleted_total, "speaker_mapping", amount=mappings_deleted)
             inc(cleanup_items_deleted_total, "api_token", amount=tokens_deleted)
+            inc(cleanup_items_deleted_total, "invitation", amount=invitations_deleted)
+            for _ in range(invitations_expired):
+                inc(invitations_expired_total)
             gauge_set(api_tokens_active, active_tokens)
             _refresh_storage_gauge()
         except Exception as e:

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -153,6 +153,12 @@ api_token_auth_total = _counter(
 )
 api_tokens_active = _gauge("transcription_api_tokens_active", "Active (non-revoked, non-expired) API tokens")
 
+# --- Invitations ---
+invitations_created_total = _counter("transcription_invitations_created_total", "Invitations created")
+invitations_accepted_total = _counter("transcription_invitations_accepted_total", "Invitations accepted on first login")
+invitations_expired_total = _counter("transcription_invitations_expired_total", "Invitations that transitioned to expired")
+invitations_revoked_total = _counter("transcription_invitations_revoked_total", "Invitations revoked by an admin")
+
 
 # --- Helper for safe instrumentation ---
 def inc(counter, *args, amount=1):

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -141,7 +141,7 @@ storage_bytes = (
 # --- Auth ---
 auth_failures_total = _counter(
     "transcription_auth_failures_total", "Authentication failures",
-    ["reason"],  # reason: missing_headers | ws_missing_headers | invalid_token
+    ["reason"],  # reason: missing_headers | ws_missing_headers | invalid_token | no_invitation
 )
 
 # --- API tokens ---

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -11,6 +11,7 @@ class ErrorResponse(BaseModel):
 class UserInfo(BaseModel):
     id: str
     email: str | None = None
+    is_admin: bool = False
 
 
 class FileInfo(BaseModel):
@@ -226,6 +227,36 @@ class ConfigResponse(BaseModel):
     api_tokens_enabled: bool = False
     api_token_default_expiry_days: int = 90
     contact_email: str = ""
+    is_admin: bool = False
+    invitation_mode: bool = False
+
+
+# --- Invitations ---
+
+class InvitationCreate(BaseModel):
+    email: str
+
+
+class InvitationListItem(BaseModel):
+    id: str
+    email: str
+    status: str
+    created_at: str
+    expires_at: str
+    created_by: str
+    accepted_at: str | None = None
+
+
+class InvitationCreated(InvitationListItem):
+    token: str  # raw token, returned only on creation
+
+
+class InvitationAcceptRequest(BaseModel):
+    token: str
+
+
+class InvitationAcceptResponse(BaseModel):
+    redirect_url: str  # Keycloak account-setup URL
 
 
 # --- Presets ---

--- a/backend/app/routers/config_router.py
+++ b/backend/app/routers/config_router.py
@@ -13,7 +13,7 @@ async def health():
 
 
 @router.get("/api/config", response_model=ConfigResponse)
-async def get_config(_user: UserInfo = Depends(get_current_user)):
+async def get_config(user: UserInfo = Depends(get_current_user)):
     return ConfigResponse(
         asr_backend=settings.ASR_BACKEND,
         whisper_models=settings.WHISPER_MODELS,
@@ -25,6 +25,8 @@ async def get_config(_user: UserInfo = Depends(get_current_user)):
         api_tokens_enabled=settings.ENABLE_API_TOKENS,
         api_token_default_expiry_days=settings.API_TOKEN_DEFAULT_EXPIRY_DAYS,
         contact_email=settings.CONTACT_EMAIL,
+        is_admin=user.is_admin,
+        invitation_mode=settings.INVITATION_MODE,
     )
 
 

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -1,0 +1,141 @@
+import asyncio
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+
+from app.config import settings
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.metrics import (
+    inc,
+    invitations_created_total,
+    invitations_revoked_total,
+)
+from app.models import (
+    InvitationAcceptRequest, InvitationAcceptResponse,
+    InvitationCreate, InvitationCreated, InvitationListItem,
+    UserInfo,
+)
+from app.services.email import send_invitation_email, EmailConfigError
+from app.services.idp_admin import (
+    KeycloakAdminClient, KeycloakAdminError, build_default_client,
+)
+from app.services.invitations import (
+    create_invitation, list_invitations, revoke_invitation,
+    resolve_invitation_token,
+    DuplicatePendingInvitationError,
+    InvitationNotFoundError, InvitationExpiredError,
+    InvitationRevokedError, InvitationAlreadyAcceptedError,
+)
+
+
+async def _require_invitation_mode() -> None:
+    if not settings.INVITATION_MODE:
+        raise HTTPException(status_code=404)
+
+
+async def _require_admin(user: UserInfo = Depends(get_current_user)) -> UserInfo:
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+    return user
+
+
+router = APIRouter(dependencies=[Depends(_require_invitation_mode)])
+
+
+def _invite_url(token: str) -> str:
+    base = settings.APP_PUBLIC_URL.rstrip("/")
+    return f"{base}/invite/{token}"
+
+
+@router.post("/api/invitations", response_model=InvitationCreated, status_code=201)
+async def post_invitation(
+    req: InvitationCreate,
+    admin: UserInfo = Depends(_require_admin),
+):
+    client = build_default_client()
+    if client is None:
+        raise HTTPException(status_code=503, detail="Keycloak Admin API not configured")
+
+    # Create DB row first.
+    async with get_db() as db:
+        try:
+            inv = await create_invitation(
+                db, email=req.email, created_by=admin.email or admin.id,
+            )
+        except DuplicatePendingInvitationError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+
+    # Pre-create in Keycloak and trigger its own setup-email flow.
+    try:
+        kc_uid = await client.create_user(email=req.email)
+        await client.send_setup_email(
+            user_id=kc_uid,
+            actions=["UPDATE_PASSWORD", "VERIFY_EMAIL"],
+            redirect_uri=settings.APP_PUBLIC_URL.rstrip("/") + "/",
+        )
+    except KeycloakAdminError as e:
+        # Roll back the DB row so admin can retry cleanly.
+        async with get_db() as db:
+            await db.execute("DELETE FROM invitations WHERE id = ?", (inv["id"],))
+            await db.commit()
+        raise HTTPException(status_code=503, detail=f"Keycloak error: {e}")
+
+    # Send our own invitation email with the /invite/<token> landing link.
+    # SMTP is blocking; run it off the event loop.
+    try:
+        await asyncio.to_thread(
+            send_invitation_email,
+            to_email=req.email,
+            invite_url=_invite_url(inv["token"]),
+        )
+    except EmailConfigError as e:
+        raise HTTPException(status_code=503, detail=f"SMTP not configured: {e}")
+
+    inc(invitations_created_total)
+    return InvitationCreated(**inv)
+
+
+@router.get("/api/invitations", response_model=list[InvitationListItem])
+async def get_invitations(_admin: UserInfo = Depends(_require_admin)):
+    async with get_db() as db:
+        items = await list_invitations(db)
+    return [InvitationListItem(**it) for it in items]
+
+
+@router.delete("/api/invitations/{invitation_id}", status_code=204)
+async def delete_invitation(
+    invitation_id: str,
+    _admin: UserInfo = Depends(_require_admin),
+):
+    async with get_db() as db:
+        ok = await revoke_invitation(db, invitation_id=invitation_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    inc(invitations_revoked_total)
+    return Response(status_code=204)
+
+
+@router.post("/api/invitations/accept", response_model=InvitationAcceptResponse)
+async def post_accept(req: InvitationAcceptRequest):
+    # This endpoint is public — the invitee is not yet authenticated.
+    async with get_db() as db:
+        try:
+            await resolve_invitation_token(db, raw_token=req.token)
+        except InvitationNotFoundError:
+            raise HTTPException(status_code=404, detail="Invitation not found")
+        except InvitationExpiredError:
+            raise HTTPException(status_code=410, detail="Invitation expired")
+        except InvitationRevokedError:
+            raise HTTPException(status_code=410, detail="Invitation revoked")
+        except InvitationAlreadyAcceptedError:
+            raise HTTPException(status_code=410, detail="Invitation already used")
+
+    # Acceptance proper happens on the invitee's first login via the dependency
+    # gate in dependencies.py. Here we just point them at Keycloak's account
+    # setup page; Keycloak's execute-actions-email flow completes there.
+    issuer = settings.KEYCLOAK_ADMIN_URL.rstrip("/")
+    realm = settings.KEYCLOAK_TARGET_REALM
+    return InvitationAcceptResponse(
+        redirect_url=f"{issuer}/realms/{realm}/account",
+    )

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -1,4 +1,5 @@
 import asyncio
+import smtplib
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
@@ -89,8 +90,12 @@ async def post_invitation(
             to_email=req.email,
             invite_url=_invite_url(inv["token"]),
         )
-    except EmailConfigError as e:
-        raise HTTPException(status_code=503, detail=f"SMTP not configured: {e}")
+    except (EmailConfigError, smtplib.SMTPException, OSError) as e:
+        # Roll back the invitation row so admins can retry cleanly.
+        async with get_db() as db:
+            await db.execute("DELETE FROM invitations WHERE id = ?", (inv["id"],))
+            await db.commit()
+        raise HTTPException(status_code=503, detail=f"Invitation email failed: {e}")
 
     inc(invitations_created_total)
     return InvitationCreated(**inv)

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,46 @@
+import smtplib
+from email.message import EmailMessage
+
+from app.config import settings
+
+
+class EmailConfigError(Exception):
+    """Raised when SMTP settings are missing or incomplete."""
+
+
+def _body_text(invite_url: str) -> str:
+    return (
+        "You have been invited to the Transcription service.\n\n"
+        f"Click the link below to set up your account:\n\n{invite_url}\n\n"
+        "This link expires in 7 days. If you did not expect this email, you can ignore it.\n"
+    )
+
+
+def _body_html(invite_url: str) -> str:
+    return (
+        "<p>You have been invited to the Transcription service.</p>"
+        f'<p><a href="{invite_url}">Click here to set up your account</a></p>'
+        f'<p>Or paste this link into your browser:<br><code>{invite_url}</code></p>'
+        "<p>This link expires in 7 days. If you did not expect this email, you can ignore it.</p>"
+    )
+
+
+def send_invitation_email(*, to_email: str, invite_url: str) -> None:
+    if not settings.SMTP_HOST or not settings.SMTP_FROM:
+        raise EmailConfigError(
+            "SMTP_HOST and SMTP_FROM must be set to send invitation emails"
+        )
+
+    msg = EmailMessage()
+    msg["Subject"] = "You have been invited to the Transcription service"
+    msg["From"] = settings.SMTP_FROM
+    msg["To"] = to_email
+    msg.set_content(_body_text(invite_url))
+    msg.add_alternative(_body_html(invite_url), subtype="html")
+
+    with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT, timeout=10) as s:
+        if settings.SMTP_STARTTLS:
+            s.starttls()
+        if settings.SMTP_USER:
+            s.login(settings.SMTP_USER, settings.SMTP_PASSWORD)
+        s.send_message(msg)

--- a/backend/app/services/idp_admin.py
+++ b/backend/app/services/idp_admin.py
@@ -27,64 +27,85 @@ class KeycloakAdminClient:
         if self._token and now < self._token_expires_at - 10:
             return self._token
         url = f"{self._base_url}/realms/{self._admin_realm}/protocol/openid-connect/token"
-        async with httpx.AsyncClient(timeout=10.0) as c:
-            resp = await c.post(
-                url,
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": self._client_id,
-                    "client_secret": self._client_secret,
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-        if resp.status_code != 200:
-            raise KeycloakAdminError(f"Token acquire failed: {resp.status_code} {resp.text}")
-        payload = resp.json()
-        self._token = payload["access_token"]
-        self._token_expires_at = now + float(payload.get("expires_in", 60))
-        return self._token
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as c:
+                resp = await c.post(
+                    url,
+                    data={
+                        "grant_type": "client_credentials",
+                        "client_id": self._client_id,
+                        "client_secret": self._client_secret,
+                    },
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
+            if resp.status_code != 200:
+                raise KeycloakAdminError(f"Token acquire failed: {resp.status_code} {resp.text}")
+            payload = resp.json()
+            self._token = payload["access_token"]
+            self._token_expires_at = now + float(payload.get("expires_in", 60))
+            return self._token
+        except KeycloakAdminError:
+            raise
+        except (httpx.HTTPError, ValueError, KeyError) as e:
+            raise KeycloakAdminError(
+                f"Token acquire failed: {type(e).__name__}: {e}"
+            ) from e
 
     async def create_user(self, *, email: str) -> str:
         """Create a user with emailVerified=False. Returns the Keycloak user id."""
-        token = await self._get_admin_token()
-        url = f"{self._base_url}/admin/realms/{self._target_realm}/users"
-        body: dict[str, Any] = {
-            "email": email,
-            "username": email,
-            "enabled": True,
-            "emailVerified": False,
-        }
-        async with httpx.AsyncClient(timeout=10.0) as c:
-            resp = await c.post(
-                url, json=body,
-                headers={"Authorization": f"Bearer {token}"},
-            )
-        if resp.status_code == 409:
-            raise KeycloakAdminError(f"User already exists for {email}")
-        if resp.status_code != 201:
-            raise KeycloakAdminError(f"Create user failed: {resp.status_code} {resp.text}")
-        location = resp.headers.get("Location", "")
-        user_id = location.rstrip("/").rsplit("/", 1)[-1]
-        if not user_id:
-            raise KeycloakAdminError("Create user: no Location header in response")
-        return user_id
+        try:
+            token = await self._get_admin_token()
+            url = f"{self._base_url}/admin/realms/{self._target_realm}/users"
+            body: dict[str, Any] = {
+                "email": email,
+                "username": email,
+                "enabled": True,
+                "emailVerified": False,
+            }
+            async with httpx.AsyncClient(timeout=10.0) as c:
+                resp = await c.post(
+                    url, json=body,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+            if resp.status_code == 409:
+                raise KeycloakAdminError(f"User already exists for {email}")
+            if resp.status_code != 201:
+                raise KeycloakAdminError(f"Create user failed: {resp.status_code} {resp.text}")
+            location = resp.headers.get("Location", "")
+            user_id = location.rstrip("/").rsplit("/", 1)[-1]
+            if not user_id:
+                raise KeycloakAdminError("Create user: no Location header in response")
+            return user_id
+        except KeycloakAdminError:
+            raise
+        except (httpx.HTTPError, ValueError, KeyError) as e:
+            raise KeycloakAdminError(
+                f"Create user failed: {type(e).__name__}: {e}"
+            ) from e
 
     async def send_setup_email(
         self, *, user_id: str, actions: list[str], redirect_uri: str,
     ) -> None:
-        token = await self._get_admin_token()
-        url = (
-            f"{self._base_url}/admin/realms/{self._target_realm}"
-            f"/users/{user_id}/execute-actions-email"
-        )
-        params = {"redirect_uri": redirect_uri, "client_id": "account"}
-        async with httpx.AsyncClient(timeout=10.0) as c:
-            resp = await c.put(
-                url, json=actions, params=params,
-                headers={"Authorization": f"Bearer {token}"},
+        try:
+            token = await self._get_admin_token()
+            url = (
+                f"{self._base_url}/admin/realms/{self._target_realm}"
+                f"/users/{user_id}/execute-actions-email"
             )
-        if resp.status_code not in (200, 204):
-            raise KeycloakAdminError(f"execute-actions-email failed: {resp.status_code} {resp.text}")
+            params = {"redirect_uri": redirect_uri, "client_id": "account"}
+            async with httpx.AsyncClient(timeout=10.0) as c:
+                resp = await c.put(
+                    url, json=actions, params=params,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+            if resp.status_code not in (200, 204):
+                raise KeycloakAdminError(f"execute-actions-email failed: {resp.status_code} {resp.text}")
+        except KeycloakAdminError:
+            raise
+        except (httpx.HTTPError, ValueError, KeyError) as e:
+            raise KeycloakAdminError(
+                f"execute-actions-email failed: {type(e).__name__}: {e}"
+            ) from e
 
 
 def build_default_client() -> KeycloakAdminClient | None:

--- a/backend/app/services/idp_admin.py
+++ b/backend/app/services/idp_admin.py
@@ -1,0 +1,101 @@
+import time
+from typing import Any
+
+import httpx
+
+
+class KeycloakAdminError(Exception):
+    """Raised for any non-success response from Keycloak Admin API."""
+
+
+class KeycloakAdminClient:
+    def __init__(
+        self, *,
+        base_url: str, admin_realm: str, target_realm: str,
+        client_id: str, client_secret: str,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._admin_realm = admin_realm
+        self._target_realm = target_realm
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._token: str | None = None
+        self._token_expires_at: float = 0.0
+
+    async def _get_admin_token(self) -> str:
+        now = time.time()
+        if self._token and now < self._token_expires_at - 10:
+            return self._token
+        url = f"{self._base_url}/realms/{self._admin_realm}/protocol/openid-connect/token"
+        async with httpx.AsyncClient(timeout=10.0) as c:
+            resp = await c.post(
+                url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        if resp.status_code != 200:
+            raise KeycloakAdminError(f"Token acquire failed: {resp.status_code} {resp.text}")
+        payload = resp.json()
+        self._token = payload["access_token"]
+        self._token_expires_at = now + float(payload.get("expires_in", 60))
+        return self._token
+
+    async def create_user(self, *, email: str) -> str:
+        """Create a user with emailVerified=False. Returns the Keycloak user id."""
+        token = await self._get_admin_token()
+        url = f"{self._base_url}/admin/realms/{self._target_realm}/users"
+        body: dict[str, Any] = {
+            "email": email,
+            "username": email,
+            "enabled": True,
+            "emailVerified": False,
+        }
+        async with httpx.AsyncClient(timeout=10.0) as c:
+            resp = await c.post(
+                url, json=body,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        if resp.status_code == 409:
+            raise KeycloakAdminError(f"User already exists for {email}")
+        if resp.status_code != 201:
+            raise KeycloakAdminError(f"Create user failed: {resp.status_code} {resp.text}")
+        location = resp.headers.get("Location", "")
+        user_id = location.rstrip("/").rsplit("/", 1)[-1]
+        if not user_id:
+            raise KeycloakAdminError("Create user: no Location header in response")
+        return user_id
+
+    async def send_setup_email(
+        self, *, user_id: str, actions: list[str], redirect_uri: str,
+    ) -> None:
+        token = await self._get_admin_token()
+        url = (
+            f"{self._base_url}/admin/realms/{self._target_realm}"
+            f"/users/{user_id}/execute-actions-email"
+        )
+        params = {"redirect_uri": redirect_uri, "client_id": "account"}
+        async with httpx.AsyncClient(timeout=10.0) as c:
+            resp = await c.put(
+                url, json=actions, params=params,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        if resp.status_code not in (200, 204):
+            raise KeycloakAdminError(f"execute-actions-email failed: {resp.status_code} {resp.text}")
+
+
+def build_default_client() -> KeycloakAdminClient | None:
+    """Build a client from settings. Returns None if KEYCLOAK_ADMIN_URL is unset."""
+    from app.config import settings
+    if not settings.KEYCLOAK_ADMIN_URL:
+        return None
+    return KeycloakAdminClient(
+        base_url=settings.KEYCLOAK_ADMIN_URL,
+        admin_realm=settings.KEYCLOAK_ADMIN_REALM,
+        target_realm=settings.KEYCLOAK_TARGET_REALM,
+        client_id=settings.KEYCLOAK_ADMIN_CLIENT_ID,
+        client_secret=settings.KEYCLOAK_ADMIN_CLIENT_SECRET,
+    )

--- a/backend/app/services/invitations.py
+++ b/backend/app/services/invitations.py
@@ -1,0 +1,92 @@
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from aiosqlite import Connection
+
+from app.config import settings
+
+
+class DuplicatePendingInvitationError(Exception):
+    """Raised when a pending invitation already exists for this email."""
+
+
+class InvitationNotFoundError(Exception):
+    """Raised when no invitation matches the given token or id."""
+
+
+class InvitationExpiredError(Exception):
+    """Raised when the invitation has passed its expires_at."""
+
+
+class InvitationRevokedError(Exception):
+    """Raised when the invitation was revoked."""
+
+
+class InvitationAlreadyAcceptedError(Exception):
+    """Raised when the invitation has already been accepted."""
+
+
+def _now_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+async def create_invitation(
+    db: Connection, *, email: str, created_by: str,
+) -> dict:
+    """Create a new invitation.
+
+    Raises DuplicatePendingInvitationError if a pending, non-expired invitation
+    for this email already exists.
+    Returns dict with: id, email, token (raw), status, created_at, expires_at,
+    created_by, accepted_at (None).
+    """
+    email_norm = _normalize_email(email)
+    now_dt = datetime.now(timezone.utc)
+    now = now_dt.strftime("%Y-%m-%d %H:%M:%S")
+    expires_at = (now_dt + timedelta(days=settings.INVITATION_EXPIRY_DAYS)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+
+    cursor = await db.execute(
+        "SELECT id FROM invitations WHERE email = ? AND status = 'pending' AND expires_at > ?",
+        (email_norm, now),
+    )
+    if await cursor.fetchone() is not None:
+        raise DuplicatePendingInvitationError(
+            f"A pending invitation already exists for {email_norm}"
+        )
+
+    raw_token = "tw_inv_" + secrets.token_urlsafe(32)
+    token_hash = _hash_token(raw_token)
+    inv_id = str(uuid.uuid4())
+
+    await db.execute(
+        """
+        INSERT INTO invitations
+            (id, email, token_hash, created_by, created_at, expires_at, status)
+        VALUES (?, ?, ?, ?, ?, ?, 'pending')
+        """,
+        (inv_id, email_norm, token_hash, created_by, now, expires_at),
+    )
+    await db.commit()
+
+    return {
+        "id": inv_id,
+        "email": email_norm,
+        "token": raw_token,
+        "status": "pending",
+        "created_at": now,
+        "expires_at": expires_at,
+        "created_by": created_by,
+        "accepted_at": None,
+    }

--- a/backend/app/services/invitations.py
+++ b/backend/app/services/invitations.py
@@ -93,6 +93,7 @@ async def create_invitation(
 
 
 async def list_invitations(db: Connection) -> list[dict]:
+    """Return all invitations newest-first as plain dicts."""
     cursor = await db.execute(
         """
         SELECT id, email, status, created_at, expires_at, created_by, accepted_at
@@ -116,6 +117,7 @@ async def list_invitations(db: Connection) -> list[dict]:
 
 
 async def revoke_invitation(db: Connection, *, invitation_id: str) -> bool:
+    """Revoke a pending invitation. Returns True if a row was transitioned."""
     cursor = await db.execute(
         "UPDATE invitations SET status = 'revoked' WHERE id = ? AND status = 'pending'",
         (invitation_id,),
@@ -125,6 +127,7 @@ async def revoke_invitation(db: Connection, *, invitation_id: str) -> bool:
 
 
 async def resolve_invitation_token(db: Connection, *, raw_token: str) -> dict:
+    """Resolve a raw token, raising the specific error for revoked/accepted/expired rows (in that precedence) before the token's expiry check."""
     token_hash = _hash_token(raw_token)
     cursor = await db.execute(
         "SELECT id, email, status, expires_at FROM invitations WHERE token_hash = ?",
@@ -151,22 +154,33 @@ async def resolve_invitation_token(db: Connection, *, raw_token: str) -> dict:
 async def accept_invitation(
     db: Connection, *, raw_token: str, user_id: str,
 ) -> dict:
-    """Mark the invitation accepted. Returns the invitation row."""
+    """Mark a pending invitation as accepted.
+
+    Race-safe: the UPDATE clauses on ``status = 'pending'``, so if the row was
+    revoked, expired, or accepted between the initial resolve call and this
+    UPDATE, the UPDATE affects 0 rows and we re-resolve to raise the specific
+    error that now applies.
+    """
     inv = await resolve_invitation_token(db, raw_token=raw_token)
     now = _now_str()
-    await db.execute(
+    cursor = await db.execute(
         """
         UPDATE invitations
         SET status = 'accepted', accepted_at = ?, accepted_by_user_id = ?
-        WHERE id = ?
+        WHERE id = ? AND status = 'pending'
         """,
         (now, user_id, inv["id"]),
     )
     await db.commit()
+    if cursor.rowcount == 0:
+        # State changed under us (revoked / expired / accepted). Re-resolve to
+        # surface the specific error.
+        await resolve_invitation_token(db, raw_token=raw_token)
     return inv
 
 
 async def expire_pending_invitations(db: Connection) -> int:
+    """Transition pending rows past their expires_at to status='expired'. Returns the rowcount."""
     now = _now_str()
     cursor = await db.execute(
         "UPDATE invitations SET status = 'expired' WHERE status = 'pending' AND expires_at <= ?",
@@ -194,6 +208,7 @@ async def cleanup_old_invitations(db: Connection) -> int:
 
 
 async def email_has_accepted_invitation(db: Connection, *, email: str) -> bool:
+    """Return True iff there is at least one accepted invitation for this (normalised) email."""
     email_norm = _normalize_email(email)
     cursor = await db.execute(
         "SELECT 1 FROM invitations WHERE email = ? AND status = 'accepted' LIMIT 1",

--- a/backend/app/services/invitations.py
+++ b/backend/app/services/invitations.py
@@ -97,7 +97,7 @@ async def list_invitations(db: Connection) -> list[dict]:
         """
         SELECT id, email, status, created_at, expires_at, created_by, accepted_at
         FROM invitations
-        ORDER BY created_at DESC, rowid DESC
+        ORDER BY created_at DESC
         """
     )
     rows = await cursor.fetchall()

--- a/backend/app/services/invitations.py
+++ b/backend/app/services/invitations.py
@@ -90,3 +90,113 @@ async def create_invitation(
         "created_by": created_by,
         "accepted_at": None,
     }
+
+
+async def list_invitations(db: Connection) -> list[dict]:
+    cursor = await db.execute(
+        """
+        SELECT id, email, status, created_at, expires_at, created_by, accepted_at
+        FROM invitations
+        ORDER BY created_at DESC, rowid DESC
+        """
+    )
+    rows = await cursor.fetchall()
+    return [
+        {
+            "id": row["id"],
+            "email": row["email"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "expires_at": row["expires_at"],
+            "created_by": row["created_by"],
+            "accepted_at": row["accepted_at"],
+        }
+        for row in rows
+    ]
+
+
+async def revoke_invitation(db: Connection, *, invitation_id: str) -> bool:
+    cursor = await db.execute(
+        "UPDATE invitations SET status = 'revoked' WHERE id = ? AND status = 'pending'",
+        (invitation_id,),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def resolve_invitation_token(db: Connection, *, raw_token: str) -> dict:
+    token_hash = _hash_token(raw_token)
+    cursor = await db.execute(
+        "SELECT id, email, status, expires_at FROM invitations WHERE token_hash = ?",
+        (token_hash,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        raise InvitationNotFoundError("No invitation for this token")
+    if row["status"] == "revoked":
+        raise InvitationRevokedError("Invitation has been revoked")
+    if row["status"] == "accepted":
+        raise InvitationAlreadyAcceptedError("Invitation already used")
+    now = _now_str()
+    if row["expires_at"] <= now:
+        raise InvitationExpiredError("Invitation has expired")
+    return {
+        "id": row["id"],
+        "email": row["email"],
+        "status": row["status"],
+        "expires_at": row["expires_at"],
+    }
+
+
+async def accept_invitation(
+    db: Connection, *, raw_token: str, user_id: str,
+) -> dict:
+    """Mark the invitation accepted. Returns the invitation row."""
+    inv = await resolve_invitation_token(db, raw_token=raw_token)
+    now = _now_str()
+    await db.execute(
+        """
+        UPDATE invitations
+        SET status = 'accepted', accepted_at = ?, accepted_by_user_id = ?
+        WHERE id = ?
+        """,
+        (now, user_id, inv["id"]),
+    )
+    await db.commit()
+    return inv
+
+
+async def expire_pending_invitations(db: Connection) -> int:
+    now = _now_str()
+    cursor = await db.execute(
+        "UPDATE invitations SET status = 'expired' WHERE status = 'pending' AND expires_at <= ?",
+        (now,),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def cleanup_old_invitations(db: Connection) -> int:
+    """Hard-delete terminal rows (expired|revoked|accepted) older than 30 days."""
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=30)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    cursor = await db.execute(
+        """
+        DELETE FROM invitations
+        WHERE status IN ('expired', 'revoked', 'accepted')
+          AND created_at < ?
+        """,
+        (cutoff,),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def email_has_accepted_invitation(db: Connection, *, email: str) -> bool:
+    email_norm = _normalize_email(email)
+    cursor = await db.execute(
+        "SELECT 1 FROM invitations WHERE email = ? AND status = 'accepted' LIMIT 1",
+        (email_norm,),
+    )
+    return await cursor.fetchone() is not None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ prometheus_client>=0.21.0
 openai>=1.50.0
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
+respx>=0.22.0

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -92,3 +92,141 @@ async def test_non_tw_bearer_falls_through(monkeypatch):
         )
     assert r.status_code == 200
     assert r.json()["id"] == "u1"
+
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_is_admin_true_when_email_in_admin_list(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", ["admin@example.com"])
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "admin-id",
+                "X-Auth-Request-Email": "Admin@Example.com",
+            },
+        )
+    assert resp.status_code == 200
+    # ConfigResponse.is_admin is exposed by Task 10; at Task 9 stage we
+    # only confirm the request succeeded. The second (Task 10) test checks
+    # the body.
+
+
+@pytest.mark.asyncio
+async def test_is_admin_false_when_email_missing(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", ["admin@example.com"])
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "other-id",
+                "X-Auth-Request-Email": "other@example.com",
+            },
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_invitation_mode_blocks_first_login_without_invitation(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", True)
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", [])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "sub-new",
+                "X-Auth-Request-Email": "unknown@example.com",
+            },
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invitation_mode_allows_admin_without_invitation(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", True)
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", ["admin@example.com"])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "sub-admin",
+                "X-Auth-Request-Email": "admin@example.com",
+            },
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_invitation_mode_allows_returning_user(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", True)
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", [])
+    async with get_db() as db:
+        await db.execute(
+            "INSERT INTO users (id, email) VALUES (?, ?)",
+            ("sub-existing", "existing@example.com"),
+        )
+        await db.commit()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "sub-existing",
+                "X-Auth-Request-Email": "existing@example.com",
+            },
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_invitation_mode_accepts_pending_invitation_on_first_login(monkeypatch):
+    from app.services.invitations import create_invitation
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", True)
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", [])
+    async with get_db() as db:
+        await create_invitation(
+            db, email="invited@example.com", created_by="admin@example.com",
+        )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "sub-invited",
+                "X-Auth-Request-Email": "invited@example.com",
+            },
+        )
+    assert resp.status_code == 200
+    # Confirm the pending invitation was marked accepted.
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT status, accepted_by_user_id FROM invitations WHERE email = ?",
+            ("invited@example.com",),
+        )
+        row = await cursor.fetchone()
+    assert row["status"] == "accepted"
+    assert row["accepted_by_user_id"] == "sub-invited"
+
+
+@pytest.mark.asyncio
+async def test_invitation_mode_allows_second_login_after_acceptance(monkeypatch):
+    from app.services.invitations import create_invitation, accept_invitation
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", True)
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", [])
+    async with get_db() as db:
+        inv = await create_invitation(
+            db, email="repeat@example.com", created_by="admin@example.com",
+        )
+        await accept_invitation(db, raw_token=inv["token"], user_id="sub-repeat")
+    # No users row yet — accept_invitation only updates invitations.
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "sub-repeat",
+                "X-Auth-Request-Email": "repeat@example.com",
+            },
+        )
+    assert resp.status_code == 200

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -230,3 +230,39 @@ async def test_invitation_mode_allows_second_login_after_acceptance(monkeypatch)
             },
         )
     assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_config_response_includes_invitation_mode_and_is_admin(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", True)
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", ["a@example.com"])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "sub-a",
+                "X-Auth-Request-Email": "a@example.com",
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["invitation_mode"] is True
+    assert body["is_admin"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_response_is_admin_false_by_default(monkeypatch):
+    monkeypatch.setattr(config_module.settings, "INVITATION_MODE", False)
+    monkeypatch.setattr(config_module.settings, "ADMIN_EMAILS", [])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/config",
+            headers={
+                "X-Auth-Request-User": "sub-x",
+                "X-Auth-Request-Email": "x@example.com",
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["is_admin"] is False
+    assert body["invitation_mode"] is False

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -78,6 +78,8 @@ def test_invitation_config_defaults(monkeypatch):
     assert s.KEYCLOAK_ADMIN_CLIENT_ID == "admin-cli"
     assert s.KEYCLOAK_ADMIN_CLIENT_SECRET == ""
     assert s.SMTP_HOST == ""
+    assert s.SMTP_USER == ""
+    assert s.SMTP_PASSWORD == ""
     assert s.SMTP_PORT == 587
     assert s.SMTP_FROM == ""
     assert s.APP_PUBLIC_URL == ""

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -64,7 +64,7 @@ def test_invitation_config_defaults(monkeypatch):
         "KEYCLOAK_ADMIN_URL", "KEYCLOAK_ADMIN_REALM",
         "KEYCLOAK_TARGET_REALM", "KEYCLOAK_ADMIN_CLIENT_ID",
         "KEYCLOAK_ADMIN_CLIENT_SECRET",
-        "SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASSWORD", "SMTP_FROM",
+        "SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASSWORD", "SMTP_FROM", "SMTP_STARTTLS",
         "APP_PUBLIC_URL", "INVITATION_EXPIRY_DAYS",
     ]:
         monkeypatch.delenv(key, raising=False)
@@ -82,6 +82,7 @@ def test_invitation_config_defaults(monkeypatch):
     assert s.SMTP_PASSWORD == ""
     assert s.SMTP_PORT == 587
     assert s.SMTP_FROM == ""
+    assert s.SMTP_STARTTLS is True
     assert s.APP_PUBLIC_URL == ""
     assert s.INVITATION_EXPIRY_DAYS == 7
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -52,3 +52,44 @@ def test_api_token_settings_from_env(monkeypatch):
     assert config_module.settings.ENABLE_API_TOKENS is True
     assert config_module.settings.API_TOKEN_MAX_PER_USER == 5
     assert config_module.settings.API_TOKEN_DEFAULT_EXPIRY_DAYS == 30
+
+
+def test_invitation_config_defaults(monkeypatch):
+    import dotenv
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **kw: None)
+    from app import config as config_module
+    # Ensure env is clean, then reload settings
+    for key in [
+        "INVITATION_MODE", "ADMIN_EMAILS",
+        "KEYCLOAK_ADMIN_URL", "KEYCLOAK_ADMIN_REALM",
+        "KEYCLOAK_TARGET_REALM", "KEYCLOAK_ADMIN_CLIENT_ID",
+        "KEYCLOAK_ADMIN_CLIENT_SECRET",
+        "SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASSWORD", "SMTP_FROM",
+        "APP_PUBLIC_URL", "INVITATION_EXPIRY_DAYS",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    importlib.reload(config_module)
+    s = config_module.settings
+    assert s.INVITATION_MODE is False
+    assert s.ADMIN_EMAILS == []
+    assert s.KEYCLOAK_ADMIN_URL == ""
+    assert s.KEYCLOAK_ADMIN_REALM == "master"
+    assert s.KEYCLOAK_TARGET_REALM == ""
+    assert s.KEYCLOAK_ADMIN_CLIENT_ID == "admin-cli"
+    assert s.KEYCLOAK_ADMIN_CLIENT_SECRET == ""
+    assert s.SMTP_HOST == ""
+    assert s.SMTP_PORT == 587
+    assert s.SMTP_FROM == ""
+    assert s.APP_PUBLIC_URL == ""
+    assert s.INVITATION_EXPIRY_DAYS == 7
+
+
+def test_admin_emails_lowercased_and_trimmed(monkeypatch):
+    import dotenv
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **kw: None)
+    from app import config as config_module
+    monkeypatch.delenv("ADMIN_EMAILS", raising=False)
+    monkeypatch.setenv("ADMIN_EMAILS", "Alice@Example.com, bob@example.com ")
+    importlib.reload(config_module)
+    s = config_module.settings
+    assert s.ADMIN_EMAILS == ["alice@example.com", "bob@example.com"]

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.services.email import send_invitation_email, EmailConfigError
+
+
+def test_send_invitation_email_uses_settings(monkeypatch):
+    mock_settings = MagicMock()
+    mock_settings.SMTP_HOST = "smtp.example.com"
+    mock_settings.SMTP_PORT = 587
+    mock_settings.SMTP_STARTTLS = True
+    mock_settings.SMTP_USER = "u"
+    mock_settings.SMTP_PASSWORD = "p"
+    mock_settings.SMTP_FROM = "noreply@example.com"
+
+    fake_smtp = MagicMock()
+    fake_smtp.__enter__.return_value = fake_smtp
+
+    with patch("app.services.email.settings", mock_settings):
+        with patch("app.services.email.smtplib.SMTP", return_value=fake_smtp):
+            send_invitation_email(
+                to_email="new@example.com",
+                invite_url="https://app.example.com/invite/tw_inv_xyz",
+            )
+
+    fake_smtp.starttls.assert_called_once()
+    fake_smtp.login.assert_called_once_with("u", "p")
+    fake_smtp.send_message.assert_called_once()
+    msg = fake_smtp.send_message.call_args[0][0]
+    assert msg["To"] == "new@example.com"
+    assert msg["From"] == "noreply@example.com"
+    assert "https://app.example.com/invite/tw_inv_xyz" in str(msg)
+
+
+def test_send_invitation_email_skips_starttls_when_disabled(monkeypatch):
+    mock_settings = MagicMock()
+    mock_settings.SMTP_HOST = "relay.internal"
+    mock_settings.SMTP_PORT = 25
+    mock_settings.SMTP_STARTTLS = False
+    mock_settings.SMTP_USER = ""
+    mock_settings.SMTP_PASSWORD = ""
+    mock_settings.SMTP_FROM = "noreply@internal"
+
+    fake_smtp = MagicMock()
+    fake_smtp.__enter__.return_value = fake_smtp
+
+    with patch("app.services.email.settings", mock_settings):
+        with patch("app.services.email.smtplib.SMTP", return_value=fake_smtp):
+            send_invitation_email(
+                to_email="x@internal",
+                invite_url="https://app.internal/invite/tw_inv_a",
+            )
+
+    fake_smtp.starttls.assert_not_called()
+    fake_smtp.login.assert_not_called()
+    fake_smtp.send_message.assert_called_once()
+
+
+def test_send_invitation_email_raises_when_smtp_unset(monkeypatch):
+    mock_settings = MagicMock()
+    mock_settings.SMTP_HOST = ""
+    mock_settings.SMTP_FROM = ""
+
+    with patch("app.services.email.settings", mock_settings):
+        with pytest.raises(EmailConfigError):
+            send_invitation_email(
+                to_email="x@example.com",
+                invite_url="https://app.example.com/invite/tw_inv_y",
+            )

--- a/backend/tests/test_idp_admin.py
+++ b/backend/tests/test_idp_admin.py
@@ -1,0 +1,94 @@
+import pytest
+import respx
+from httpx import Response
+
+from app.services.idp_admin import KeycloakAdminClient, KeycloakAdminError
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_acquire_admin_token():
+    respx.post("https://kc.example.com/realms/master/protocol/openid-connect/token").mock(
+        return_value=Response(200, json={"access_token": "tok-123", "expires_in": 60})
+    )
+    client = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        admin_realm="master",
+        target_realm="app",
+        client_id="admin-cli",
+        client_secret="s3cret",
+    )
+    token = await client._get_admin_token()
+    assert token == "tok-123"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_user_returns_user_id_from_location_header():
+    respx.post("https://kc.example.com/realms/master/protocol/openid-connect/token").mock(
+        return_value=Response(200, json={"access_token": "tok-123", "expires_in": 60})
+    )
+    respx.post("https://kc.example.com/admin/realms/app/users").mock(
+        return_value=Response(
+            201,
+            headers={"Location": "https://kc.example.com/admin/realms/app/users/abc-uuid"},
+        )
+    )
+    client = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        admin_realm="master",
+        target_realm="app",
+        client_id="admin-cli",
+        client_secret="s3cret",
+    )
+    uid = await client.create_user(email="x@example.com")
+    assert uid == "abc-uuid"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_create_user_raises_on_409_conflict():
+    respx.post("https://kc.example.com/realms/master/protocol/openid-connect/token").mock(
+        return_value=Response(200, json={"access_token": "tok-123", "expires_in": 60})
+    )
+    respx.post("https://kc.example.com/admin/realms/app/users").mock(
+        return_value=Response(409, json={"errorMessage": "User exists"})
+    )
+    client = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        admin_realm="master",
+        target_realm="app",
+        client_id="admin-cli",
+        client_secret="s3cret",
+    )
+    with pytest.raises(KeycloakAdminError) as exc:
+        await client.create_user(email="x@example.com")
+    assert "exists" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_execute_actions_email_posts_required_actions():
+    respx.post("https://kc.example.com/realms/master/protocol/openid-connect/token").mock(
+        return_value=Response(200, json={"access_token": "tok-123", "expires_in": 60})
+    )
+    route = respx.put(
+        "https://kc.example.com/admin/realms/app/users/abc-uuid/execute-actions-email"
+    ).mock(return_value=Response(204))
+    client = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        admin_realm="master",
+        target_realm="app",
+        client_id="admin-cli",
+        client_secret="s3cret",
+    )
+    await client.send_setup_email(
+        user_id="abc-uuid",
+        actions=["UPDATE_PASSWORD", "VERIFY_EMAIL"],
+        redirect_uri="https://app.example.com/",
+    )
+    assert route.called
+    req = route.calls.last.request
+    import json as _json
+    body = _json.loads(req.content)
+    assert body == ["UPDATE_PASSWORD", "VERIFY_EMAIL"]

--- a/backend/tests/test_idp_admin.py
+++ b/backend/tests/test_idp_admin.py
@@ -92,3 +92,39 @@ async def test_execute_actions_email_posts_required_actions():
     import json as _json
     body = _json.loads(req.content)
     assert body == ["UPDATE_PASSWORD", "VERIFY_EMAIL"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_acquire_admin_token_wraps_connect_error():
+    import httpx
+    respx.post(
+        "https://kc.example.com/realms/master/protocol/openid-connect/token"
+    ).mock(side_effect=httpx.ConnectError("boom"))
+    client = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        admin_realm="master",
+        target_realm="app",
+        client_id="admin-cli",
+        client_secret="s3cret",
+    )
+    with pytest.raises(KeycloakAdminError) as exc:
+        await client._get_admin_token()
+    assert "ConnectError" in str(exc.value) or "boom" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_acquire_admin_token_wraps_malformed_json():
+    respx.post(
+        "https://kc.example.com/realms/master/protocol/openid-connect/token"
+    ).mock(return_value=Response(200, text="not json"))
+    client = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        admin_realm="master",
+        target_realm="app",
+        client_id="admin-cli",
+        client_secret="s3cret",
+    )
+    with pytest.raises(KeycloakAdminError):
+        await client._get_admin_token()

--- a/backend/tests/test_invitations_cleanup_integration.py
+++ b/backend/tests/test_invitations_cleanup_integration.py
@@ -1,0 +1,35 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+
+from app.database import get_db
+from app.services.invitations import (
+    create_invitation, expire_pending_invitations, cleanup_old_invitations,
+)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_functions_are_idempotent_and_return_counts():
+    # First call: nothing to do
+    async with get_db() as db:
+        assert await expire_pending_invitations(db) == 0
+        assert await cleanup_old_invitations(db) == 0
+
+    # Create a pending invitation, artificially age it past expiry
+    async with get_db() as db:
+        inv = await create_invitation(
+            db, email="aged@example.com", created_by="admin@example.com",
+        )
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+        await db.execute(
+            "UPDATE invitations SET expires_at = ? WHERE id = ?",
+            (past, inv["id"]),
+        )
+        await db.commit()
+
+    # expire transitions pending→expired
+    async with get_db() as db:
+        assert await expire_pending_invitations(db) == 1
+
+    # Second call: nothing left to expire
+    async with get_db() as db:
+        assert await expire_pending_invitations(db) == 0

--- a/backend/tests/test_invitations_router.py
+++ b/backend/tests/test_invitations_router.py
@@ -1,0 +1,221 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from httpx import AsyncClient, ASGITransport
+
+import app.config as config_module
+from app.main import app
+from app.database import get_db
+
+
+@pytest.fixture(autouse=True)
+def _enable_invitation_mode(monkeypatch):
+    # Other tests call importlib.reload(config_module), which swaps
+    # config_module.settings with a fresh object. Modules that did
+    # `from app.config import settings` at import time still hold the old
+    # reference, so patch every captured copy that this flow touches.
+    from app import dependencies as dep
+    from app.routers import invitations as inv_router
+    from app.services import invitations as inv_service
+    from app.services import email as email_service
+    targets = [
+        config_module.settings,
+        dep.settings,
+        inv_router.settings,
+        inv_service.settings,
+        email_service.settings,
+    ]
+    overrides = {
+        "INVITATION_MODE": True,
+        "ADMIN_EMAILS": ["admin@example.com"],
+        "KEYCLOAK_ADMIN_URL": "https://kc.example",
+        "KEYCLOAK_ADMIN_REALM": "master",
+        "KEYCLOAK_TARGET_REALM": "app",
+        "KEYCLOAK_ADMIN_CLIENT_ID": "admin-cli",
+        "KEYCLOAK_ADMIN_CLIENT_SECRET": "s",
+        "SMTP_HOST": "smtp.example.com",
+        "SMTP_FROM": "noreply@example.com",
+        "APP_PUBLIC_URL": "https://app.example.com",
+    }
+    seen: set[int] = set()
+    for tgt in targets:
+        if id(tgt) in seen:
+            continue
+        seen.add(id(tgt))
+        for k, v in overrides.items():
+            monkeypatch.setattr(tgt, k, v)
+
+
+def _admin_headers():
+    return {
+        "X-Auth-Request-User": "sub-admin",
+        "X-Auth-Request-Email": "admin@example.com",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_requires_admin():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/invitations",
+            json={"email": "new@example.com"},
+            headers={
+                "X-Auth-Request-User": "sub-notadmin",
+                "X-Auth-Request-Email": "notadmin@example.com",
+            },
+        )
+    # Non-admin in invitation mode with no accepted invite → 403 from the gate
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_happy_path():
+    with patch(
+        "app.routers.invitations.KeycloakAdminClient.create_user",
+        new=AsyncMock(return_value="kc-uuid-1"),
+    ), patch(
+        "app.routers.invitations.KeycloakAdminClient.send_setup_email",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.routers.invitations.send_invitation_email",
+        return_value=None,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                "/api/invitations",
+                json={"email": "new@example.com"},
+                headers=_admin_headers(),
+            )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["email"] == "new@example.com"
+    assert body["status"] == "pending"
+    assert body["token"].startswith("tw_inv_")
+
+
+@pytest.mark.asyncio
+async def test_list_invitations_requires_admin():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get(
+            "/api/invitations",
+            headers={
+                "X-Auth-Request-User": "sub-notadmin",
+                "X-Auth-Request-Email": "notadmin@example.com",
+            },
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_invitations_returns_list_for_admin():
+    from app.services.invitations import create_invitation
+    async with get_db() as db:
+        await create_invitation(db, email="one@example.com", created_by="admin@example.com")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/invitations", headers=_admin_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert any(item["email"] == "one@example.com" for item in body)
+
+
+@pytest.mark.asyncio
+async def test_revoke_invitation_marks_revoked():
+    from app.services.invitations import create_invitation
+    async with get_db() as db:
+        inv = await create_invitation(
+            db, email="victim@example.com", created_by="admin@example.com",
+        )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.delete(
+            f"/api/invitations/{inv['id']}",
+            headers=_admin_headers(),
+        )
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_revoke_invitation_unknown_returns_404():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.delete(
+            "/api/invitations/nonexistent",
+            headers=_admin_headers(),
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_unknown_token_returns_404():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/invitations/accept",
+            json={"token": "tw_inv_nothing"},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_expired_returns_410():
+    from datetime import datetime, timezone, timedelta
+    from app.services.invitations import create_invitation
+    async with get_db() as db:
+        inv = await create_invitation(
+            db, email="e@example.com", created_by="admin@example.com",
+        )
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+        await db.execute("UPDATE invitations SET expires_at = ? WHERE id = ?", (past, inv["id"]))
+        await db.commit()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/invitations/accept", json={"token": inv["token"]})
+    assert resp.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_revoked_returns_410():
+    from app.services.invitations import create_invitation, revoke_invitation
+    async with get_db() as db:
+        inv = await create_invitation(
+            db, email="rv@example.com", created_by="admin@example.com",
+        )
+        await revoke_invitation(db, invitation_id=inv["id"])
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/invitations/accept", json={"token": inv["token"]})
+    assert resp.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_valid_returns_redirect_url():
+    from app.services.invitations import create_invitation
+    async with get_db() as db:
+        inv = await create_invitation(
+            db, email="valid@example.com", created_by="admin@example.com",
+        )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/invitations/accept", json={"token": inv["token"]})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "redirect_url" in body
+    assert body["redirect_url"].startswith("https://kc.example")
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_duplicate_returns_409():
+    from app.services.invitations import create_invitation
+    async with get_db() as db:
+        await create_invitation(db, email="dup@example.com", created_by="admin@example.com")
+    with patch(
+        "app.routers.invitations.KeycloakAdminClient.create_user",
+        new=AsyncMock(return_value="kc-uuid-dup"),
+    ), patch(
+        "app.routers.invitations.KeycloakAdminClient.send_setup_email",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.routers.invitations.send_invitation_email",
+        return_value=None,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                "/api/invitations",
+                json={"email": "dup@example.com"},
+                headers=_admin_headers(),
+            )
+    assert resp.status_code == 409

--- a/backend/tests/test_invitations_router.py
+++ b/backend/tests/test_invitations_router.py
@@ -219,3 +219,31 @@ async def test_create_invitation_duplicate_returns_409():
                 headers=_admin_headers(),
             )
     assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_smtp_failure_rolls_back_invitation():
+    import smtplib
+    with patch(
+        "app.routers.invitations.KeycloakAdminClient.create_user",
+        new=AsyncMock(return_value="kc-uuid-smtp"),
+    ), patch(
+        "app.routers.invitations.KeycloakAdminClient.send_setup_email",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.routers.invitations.send_invitation_email",
+        side_effect=smtplib.SMTPException("boom"),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post(
+                "/api/invitations",
+                json={"email": "smtpfail@example.com"},
+                headers=_admin_headers(),
+            )
+    assert resp.status_code == 503
+    # DB row must have been rolled back so a retry would not hit 409.
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT id FROM invitations WHERE email = ?", ("smtpfail@example.com",)
+        )
+        assert await cursor.fetchone() is None

--- a/backend/tests/test_invitations_schema.py
+++ b/backend/tests/test_invitations_schema.py
@@ -1,0 +1,33 @@
+import pytest
+from app.database import get_db
+
+
+@pytest.mark.asyncio
+async def test_invitations_table_exists():
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='invitations'"
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+
+
+@pytest.mark.asyncio
+async def test_invitations_table_columns():
+    async with get_db() as db:
+        cursor = await db.execute("PRAGMA table_info(invitations)")
+        cols = {row["name"] for row in await cursor.fetchall()}
+    expected = {
+        "id", "email", "token_hash", "created_by", "created_at",
+        "expires_at", "status", "accepted_at", "accepted_by_user_id",
+    }
+    assert expected.issubset(cols)
+
+
+@pytest.mark.asyncio
+async def test_invitations_email_and_status_indexes_exist():
+    async with get_db() as db:
+        cursor = await db.execute("PRAGMA index_list(invitations)")
+        idx_names = {row["name"] for row in await cursor.fetchall()}
+    assert "idx_invitations_email" in idx_names
+    assert "idx_invitations_status" in idx_names

--- a/backend/tests/test_invitations_service.py
+++ b/backend/tests/test_invitations_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from app.database import get_db
 from app.services.invitations import (
@@ -55,6 +56,7 @@ async def test_create_invitation_rejects_duplicate_pending():
 async def test_list_returns_newest_first():
     async with get_db() as db:
         a = await create_invitation(db, email="a@example.com", created_by="admin@example.com")
+        await asyncio.sleep(1.1)  # Ensure different timestamps (rounded to seconds)
         b = await create_invitation(db, email="b@example.com", created_by="admin@example.com")
         items = await list_invitations(db)
     assert [i["email"] for i in items][0:2] == ["b@example.com", "a@example.com"]

--- a/backend/tests/test_invitations_service.py
+++ b/backend/tests/test_invitations_service.py
@@ -154,3 +154,24 @@ async def test_cleanup_old_invitations_deletes_30_day_terminal_rows():
         assert deleted == 1
         cursor = await db.execute("SELECT id FROM invitations WHERE id = ?", (inv["id"],))
         assert await cursor.fetchone() is None
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_loses_race_to_revoke():
+    async with get_db() as db:
+        inv = await create_invitation(
+            db, email="race@example.com", created_by="admin@example.com",
+        )
+        # Simulate the row being revoked between resolve and update
+        await db.execute(
+            "UPDATE invitations SET status = 'revoked' WHERE id = ?", (inv["id"],)
+        )
+        await db.commit()
+        with pytest.raises(InvitationRevokedError):
+            await accept_invitation(db, raw_token=inv["token"], user_id="kc-sub-race")
+        # Confirm the status was NOT clobbered to 'accepted'
+        cursor = await db.execute(
+            "SELECT status FROM invitations WHERE id = ?", (inv["id"],)
+        )
+        row = await cursor.fetchone()
+        assert row["status"] == "revoked"

--- a/backend/tests/test_invitations_service.py
+++ b/backend/tests/test_invitations_service.py
@@ -3,6 +3,16 @@ from app.database import get_db
 from app.services.invitations import (
     create_invitation,
     DuplicatePendingInvitationError,
+    list_invitations,
+    revoke_invitation,
+    resolve_invitation_token,
+    accept_invitation,
+    expire_pending_invitations,
+    cleanup_old_invitations,
+    InvitationNotFoundError,
+    InvitationExpiredError,
+    InvitationRevokedError,
+    InvitationAlreadyAcceptedError,
 )
 
 
@@ -39,3 +49,106 @@ async def test_create_invitation_rejects_duplicate_pending():
         await create_invitation(db, email="x@example.com", created_by="admin@example.com")
         with pytest.raises(DuplicatePendingInvitationError):
             await create_invitation(db, email="x@example.com", created_by="admin@example.com")
+
+
+@pytest.mark.asyncio
+async def test_list_returns_newest_first():
+    async with get_db() as db:
+        a = await create_invitation(db, email="a@example.com", created_by="admin@example.com")
+        b = await create_invitation(db, email="b@example.com", created_by="admin@example.com")
+        items = await list_invitations(db)
+    assert [i["email"] for i in items][0:2] == ["b@example.com", "a@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_revoke_sets_status_and_returns_true():
+    async with get_db() as db:
+        inv = await create_invitation(db, email="r@example.com", created_by="admin@example.com")
+        ok = await revoke_invitation(db, invitation_id=inv["id"])
+        assert ok is True
+        cursor = await db.execute("SELECT status FROM invitations WHERE id = ?", (inv["id"],))
+        row = await cursor.fetchone()
+        assert row["status"] == "revoked"
+
+
+@pytest.mark.asyncio
+async def test_revoke_returns_false_for_unknown_id():
+    async with get_db() as db:
+        assert await revoke_invitation(db, invitation_id="does-not-exist") is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_invitation_token_returns_row_when_pending():
+    async with get_db() as db:
+        inv = await create_invitation(db, email="res@example.com", created_by="admin@example.com")
+        row = await resolve_invitation_token(db, raw_token=inv["token"])
+    assert row is not None
+    assert row["email"] == "res@example.com"
+    assert row["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_resolve_invitation_token_raises_for_expired():
+    from datetime import datetime, timezone, timedelta
+    async with get_db() as db:
+        inv = await create_invitation(db, email="e@example.com", created_by="admin@example.com")
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+        await db.execute("UPDATE invitations SET expires_at = ? WHERE id = ?", (past, inv["id"]))
+        await db.commit()
+        with pytest.raises(InvitationExpiredError):
+            await resolve_invitation_token(db, raw_token=inv["token"])
+
+
+@pytest.mark.asyncio
+async def test_resolve_invitation_token_raises_for_revoked():
+    async with get_db() as db:
+        inv = await create_invitation(db, email="rv@example.com", created_by="admin@example.com")
+        await revoke_invitation(db, invitation_id=inv["id"])
+        with pytest.raises(InvitationRevokedError):
+            await resolve_invitation_token(db, raw_token=inv["token"])
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_token_raises_not_found():
+    async with get_db() as db:
+        with pytest.raises(InvitationNotFoundError):
+            await resolve_invitation_token(db, raw_token="tw_inv_doesnotexist")
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_marks_accepted_and_blocks_reuse():
+    async with get_db() as db:
+        inv = await create_invitation(db, email="ac@example.com", created_by="admin@example.com")
+        await accept_invitation(db, raw_token=inv["token"], user_id="kc-sub-123")
+        with pytest.raises(InvitationAlreadyAcceptedError):
+            await resolve_invitation_token(db, raw_token=inv["token"])
+
+
+@pytest.mark.asyncio
+async def test_expire_pending_invitations_transitions_stale_rows():
+    from datetime import datetime, timezone, timedelta
+    async with get_db() as db:
+        inv = await create_invitation(db, email="ex@example.com", created_by="admin@example.com")
+        past = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+        await db.execute("UPDATE invitations SET expires_at = ? WHERE id = ?", (past, inv["id"]))
+        await db.commit()
+        changed = await expire_pending_invitations(db)
+        assert changed == 1
+        cursor = await db.execute("SELECT status FROM invitations WHERE id = ?", (inv["id"],))
+        row = await cursor.fetchone()
+        assert row["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_old_invitations_deletes_30_day_terminal_rows():
+    from datetime import datetime, timezone, timedelta
+    async with get_db() as db:
+        inv = await create_invitation(db, email="old@example.com", created_by="admin@example.com")
+        await revoke_invitation(db, invitation_id=inv["id"])
+        long_ago = (datetime.now(timezone.utc) - timedelta(days=45)).strftime("%Y-%m-%d %H:%M:%S")
+        await db.execute("UPDATE invitations SET created_at = ? WHERE id = ?", (long_ago, inv["id"]))
+        await db.commit()
+        deleted = await cleanup_old_invitations(db)
+        assert deleted == 1
+        cursor = await db.execute("SELECT id FROM invitations WHERE id = ?", (inv["id"],))
+        assert await cursor.fetchone() is None

--- a/backend/tests/test_invitations_service.py
+++ b/backend/tests/test_invitations_service.py
@@ -1,0 +1,41 @@
+import pytest
+from app.database import get_db
+from app.services.invitations import (
+    create_invitation,
+    DuplicatePendingInvitationError,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_returns_raw_token_and_hashes_it():
+    async with get_db() as db:
+        result = await create_invitation(
+            db, email="new@example.com", created_by="admin@example.com",
+        )
+    assert result["token"].startswith("tw_inv_")
+    assert result["email"] == "new@example.com"
+    assert result["status"] == "pending"
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT token_hash FROM invitations WHERE id = ?", (result["id"],)
+        )
+        row = await cursor.fetchone()
+    assert row is not None
+    assert row["token_hash"] != result["token"]
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_normalizes_email_lowercase():
+    async with get_db() as db:
+        result = await create_invitation(
+            db, email="Mixed@EXAMPLE.com", created_by="admin@example.com",
+        )
+    assert result["email"] == "mixed@example.com"
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_rejects_duplicate_pending():
+    async with get_db() as db:
+        await create_invitation(db, email="x@example.com", created_by="admin@example.com")
+        with pytest.raises(DuplicatePendingInvitationError):
+            await create_invitation(db, email="x@example.com", created_by="admin@example.com")

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,11 @@
+def test_invitation_metrics_defined():
+    from app.metrics import (
+        invitations_created_total,
+        invitations_accepted_total,
+        invitations_expired_total,
+        invitations_revoked_total,
+    )
+    # If metrics are disabled (no prometheus_client), these will be None — both states are acceptable.
+    for m in (invitations_created_total, invitations_accepted_total,
+              invitations_expired_total, invitations_revoked_total):
+        assert m is None or hasattr(m, "inc")

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,20 @@
+def test_userinfo_is_admin_default_false():
+    from app.models import UserInfo
+    u = UserInfo(id="u1", email="u1@example.com")
+    assert u.is_admin is False
+
+
+def test_invitation_create_model_accepts_email():
+    from app.models import InvitationCreate
+    m = InvitationCreate(email="x@example.com")
+    assert m.email == "x@example.com"
+
+
+def test_invitation_list_item_fields():
+    from app.models import InvitationListItem
+    m = InvitationListItem(
+        id="i1", email="x@example.com", status="pending",
+        created_at="2026-04-23 10:00:00", expires_at="2026-04-30 10:00:00",
+        created_by="admin@example.com", accepted_at=None,
+    )
+    assert m.status == "pending"

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -1,0 +1,57 @@
+# Public host (no scheme), used by Caddy for TLS
+APP_HOST=transcription.example.com
+
+# --- ASR backend (point at your own MurmurAI or WhisperX API) ---
+ASR_BACKEND=murmurai
+ASR_URL=https://whisperx.example.com
+ASR_API_KEY=
+ASR_MAX_CONCURRENT=3
+WHISPER_MODELS=base,large-v3,large-v3-turbo
+DEFAULT_WHISPER_MODEL=base
+
+# --- LLM provider (OpenAI-compatible or Ollama) ---
+LLM_PROVIDER=
+LLM_MODEL=
+LLM_API_KEY=
+LLM_BASE_URL=
+
+# --- Paths inside the container ---
+TEMP_PATH=/media
+DATABASE_PATH=/data/transcription.db
+
+CONTACT_EMAIL=admin@example.com
+
+# --- Retention (shorter recommended for open registration) ---
+DEFAULT_EXPIRY_HOURS=24
+ARCHIVE_EXPIRY_HOURS=168
+
+# --- Metrics / API tokens (both optional) ---
+ENABLE_METRICS=false
+ENABLE_API_TOKENS=false
+
+# --- Invitation mode (optional, admin-controlled signup) ---
+INVITATION_MODE=false
+ADMIN_EMAILS=
+INVITATION_EXPIRY_DAYS=7
+
+# Keycloak Admin API (required only when INVITATION_MODE=true)
+KEYCLOAK_ADMIN_URL=
+KEYCLOAK_ADMIN_REALM=master
+KEYCLOAK_TARGET_REALM=
+KEYCLOAK_ADMIN_CLIENT_ID=admin-cli
+KEYCLOAK_ADMIN_CLIENT_SECRET=
+
+# SMTP (required only when INVITATION_MODE=true). For internal relays that
+# require no auth and no TLS (e.g. relay.rz.uni-osnabrueck.de), set
+# SMTP_STARTTLS=false and leave SMTP_USER/SMTP_PASSWORD blank.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_STARTTLS=true
+SMTP_USER=
+SMTP_PASSWORD=
+SMTP_FROM=
+
+APP_PUBLIC_URL=https://transcription.example.com
+
+# Tell the frontend logout button where to go (your Keycloak realm)
+LOGOUT_URL=/oauth2/sign_out?rd=https://auth.example.com/realms/transcription/protocol/openid-connect/logout

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,0 +1,44 @@
+{$APP_HOST} {
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+    }
+
+    handle /oauth2/* {
+        reverse_proxy oauth2-proxy:80
+    }
+
+    @api_bearer {
+        path /api/*
+        header_regexp Authorization ^Bearer\s+tw_
+    }
+    handle @api_bearer {
+        request_header -X-Auth-Request-User
+        request_header -X-Auth-Request-Email
+        request_header -X-Auth-Request-Access-Token
+        reverse_proxy transcription:8000
+    }
+
+    @api_ws_token {
+        path /api/ws/*
+        expression `{query.token}.startsWith("tw_")`
+    }
+    handle @api_ws_token {
+        request_header -X-Auth-Request-User
+        request_header -X-Auth-Request-Email
+        request_header -X-Auth-Request-Access-Token
+        reverse_proxy transcription:8000
+    }
+
+    handle {
+        forward_auth oauth2-proxy:80 {
+            uri /oauth2/auth
+            @unauthorized status 401
+            handle_response @unauthorized {
+                redir * /oauth2/sign_in?rd={http.request.uri}
+            }
+            copy_headers X-Auth-Request-Preferred-Username>X-Auth-Request-User X-Auth-Request-Email X-Auth-Request-Access-Token
+        }
+        reverse_proxy transcription:8000
+    }
+}

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -1,0 +1,54 @@
+# Reference Docker Compose Deployment
+
+A minimal stack for running the Transcription app against any OIDC provider.
+
+## What this includes
+
+- `transcription` — the app (backend + pre-built frontend)
+- `oauth2-proxy` — OIDC reverse-proxy terminator
+- `caddy` — TLS termination and routing
+
+## What this does NOT include
+
+- **Keycloak.** Bring your own OIDC provider, or follow
+  [`docs/keycloak-setup.md`](../../docs/keycloak-setup.md) to stand one up.
+- Monitoring (node-exporter, Prometheus scrape config) — add your own if needed.
+- Per-VM hardening (firewall, SELinux, auto-updates) — use your preferred tool.
+
+## Quick start
+
+1. Copy `.env.example` to `.env` and fill in the values.
+2. Generate `cookie_secret` for oauth2-proxy:
+   ```bash
+   openssl rand -base64 32 | tr -d '\n' | tr -- '+/' '-_'
+   ```
+   Replace the placeholder in `oauth2-proxy.cfg`.
+3. Fill in the four OIDC placeholders in `oauth2-proxy.cfg` (`client_id`,
+   `client_secret`, `oidc_issuer_url`, `redirect_url`).
+4. Point DNS at the host and run `docker compose up -d`.
+5. Browse to `https://$APP_HOST`.
+
+## Identity header contract
+
+The app trusts two headers from oauth2-proxy:
+
+- `X-Auth-Request-User` — stable user id (set via Caddy `copy_headers` from
+  `X-Auth-Request-Preferred-Username`).
+- `X-Auth-Request-Email` — user's email.
+
+Any OIDC provider works as long as oauth2-proxy can emit these.
+
+## Invitation mode (optional)
+
+Set `INVITATION_MODE=true` in `.env` to require admin-issued invitations for
+new users. This requires:
+
+- `KEYCLOAK_ADMIN_URL` + an `admin-cli` client in Keycloak (see
+  `docs/keycloak-setup.md`)
+- A reachable SMTP server (or an internal relay — set `SMTP_STARTTLS=false`
+  and leave the user/password empty)
+- One or more `ADMIN_EMAILS` — the humans who can issue invitations from the
+  app's Settings → Invitations page
+
+Leaving `INVITATION_MODE=false` keeps the app open to anyone Keycloak lets in
+(useful when Keycloak self-registration is enabled).

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  transcription:
+    image: ghcr.io/virtuos/transcription-whisper:latest
+    container_name: transcription
+    env_file: .env
+    volumes:
+      - ./data:/data
+      - ./media:/media
+    restart: unless-stopped
+
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+    container_name: oauth2-proxy
+    command: --config /oauth2-proxy.cfg
+    volumes:
+      - ./oauth2-proxy.cfg:/oauth2-proxy.cfg:ro
+    restart: unless-stopped
+    depends_on:
+      - transcription
+
+  caddy:
+    image: caddy:2.11
+    container_name: caddy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    restart: unless-stopped
+    depends_on:
+      - oauth2-proxy
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/deploy/compose/oauth2-proxy.cfg
+++ b/deploy/compose/oauth2-proxy.cfg
@@ -1,0 +1,23 @@
+http_address="0.0.0.0:80"
+cookie_secret="REPLACE_WITH_32_BYTE_BASE64"
+email_domains="*"
+cookie_secure="true"
+upstreams="http://transcription:8000"
+
+# Replace with your own domain(s)
+cookie_domains=["example.com"]
+whitelist_domains=[".example.com"]
+
+# Point these at your OIDC provider (e.g. a Keycloak realm you operate — see docs/keycloak-setup.md)
+client_id="transcription-app"
+client_secret="REPLACE_WITH_KEYCLOAK_CLIENT_SECRET"
+oidc_issuer_url="https://auth.example.com/realms/transcription"
+redirect_url="https://transcription.example.com/oauth2/callback"
+
+provider="oidc"
+provider_display_name="Sign in"
+
+set_xauthrequest=true
+oidc_email_claim="email"
+auth_logging=false
+request_logging=false

--- a/docs/keycloak-setup.md
+++ b/docs/keycloak-setup.md
@@ -1,0 +1,140 @@
+# Keycloak Setup Guide
+
+This guide gets you from zero to a working Keycloak that can back a
+self-hosted Transcription instance, with registration, login, password
+reset, and optional social login.
+
+The Transcription app does **not** require Keycloak specifically — any OIDC
+provider that emits an email claim will work. Keycloak is documented here
+because it's open-source, widely deployed in higher education, and supports
+future federation (DFN-AAI / eduGAIN) without application changes.
+
+## 1. Run Keycloak with Postgres
+
+```bash
+# Postgres data
+docker run -d --name kc-postgres \
+  -e POSTGRES_DB=keycloak \
+  -e POSTGRES_USER=keycloak \
+  -e POSTGRES_PASSWORD=REPLACE_ME \
+  -v kc-postgres-data:/var/lib/postgresql/data \
+  postgres:16
+
+# Keycloak
+docker run -d --name keycloak \
+  --link kc-postgres:postgres \
+  -e KC_DB=postgres \
+  -e KC_DB_URL=jdbc:postgresql://postgres:5432/keycloak \
+  -e KC_DB_USERNAME=keycloak \
+  -e KC_DB_PASSWORD=REPLACE_ME \
+  -e KC_HOSTNAME=auth.example.com \
+  -e KC_PROXY=edge \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=REPLACE_ME \
+  -p 8080:8080 \
+  quay.io/keycloak/keycloak:26.0 start
+```
+
+Put a TLS-terminating reverse proxy in front (your Caddy is fine) and make
+sure `auth.example.com` resolves to the Keycloak host.
+
+## 2. Create the realm and client
+
+1. Log in to the admin console at `https://auth.example.com`.
+2. Create a realm: `transcription` (or whatever you want — set it as
+   `KEYCLOAK_TARGET_REALM` in the app's `.env`).
+3. In the realm, create an OIDC client:
+   - Client ID: `transcription-app`
+   - Client authentication: On
+   - Valid redirect URIs: `https://transcription.example.com/oauth2/callback`
+   - Save, then copy the client secret from the Credentials tab.
+   - Put these in `oauth2-proxy.cfg` as `client_id` / `client_secret`.
+
+## 3. Configure the realm
+
+**Realm settings → Login tab:**
+- User registration: **On** for open signup, or **Off** for invite-only.
+- Verify email: **On** (always — prevents spam).
+- Forgot password: **On**.
+
+**Realm settings → Email tab:** configure SMTP. Keycloak uses this for
+verification and password-reset emails. Share credentials with the app's
+SMTP settings or use a different sender.
+
+**Inside Uni Osnabrück:** use `Host=relay.rz.uni-osnabrueck.de`,
+`Port=25`, leave *Username* and *Password* blank, and disable *Enable
+StartTLS*. No RZ credentials are required for hosts inside the Uninetz.
+
+**Authentication → Required actions:** ensure `UPDATE_PASSWORD` and
+`VERIFY_EMAIL` are enabled.
+
+## 4. Admin-CLI service account (for invitation mode)
+
+If the app will run in `INVITATION_MODE=true`, it needs to call the Keycloak
+Admin API to pre-create users.
+
+1. In the `master` realm (or whichever realm owns admin access), create an
+   OIDC client:
+   - Client ID: `admin-cli`
+   - Client authentication: On
+   - Service accounts roles: On
+2. Credentials tab → copy the client secret → put into the app's
+   `KEYCLOAK_ADMIN_CLIENT_SECRET`.
+3. Service accounts roles tab → assign `manage-users` (and `view-users`)
+   of the *target* realm.
+4. Set the app's `KEYCLOAK_ADMIN_URL` to the public base URL of Keycloak
+   (e.g. `https://auth.example.com`) and `KEYCLOAK_TARGET_REALM` to the
+   realm name from Section 2.
+
+## 5. Social login (optional)
+
+**Google:**
+1. Google Cloud Console → APIs & Services → Credentials → Create OAuth
+   client ID → Web application.
+2. Add authorised redirect URI:
+   `https://auth.example.com/realms/transcription/broker/google/endpoint`
+3. Copy Client ID / Secret.
+4. In Keycloak: Identity Providers → Add → Google → paste credentials.
+5. Settings: "Trust email from provider" = On (Google verifies emails).
+
+**Microsoft / Entra ID:**
+1. Azure Portal → App registrations → New registration.
+2. Redirect URI (web):
+   `https://auth.example.com/realms/transcription/broker/microsoft/endpoint`
+3. Certificates & secrets → New client secret → copy value.
+4. In Keycloak: Identity Providers → Add → Microsoft → paste credentials.
+5. Settings: "Trust email from provider" = On.
+
+**Apple, GitHub, etc.** — same pattern. Skip Facebook/X unless you have a
+reason; their email claims are unreliable.
+
+**Account linking:** leave "First login flow" at the default
+(`first broker login`). This prompts users with an existing password
+account to confirm before linking a social login, preventing a class of
+phishing-style account takeovers.
+
+## 6. Break-glass: switch from open to invite-only
+
+If abuse appears:
+
+1. Keycloak admin UI → Realm settings → Login → User registration: **Off**
+2. App `.env` → `INVITATION_MODE=true` → restart the app container.
+
+Existing users keep their sessions. New unknown emails are rejected with
+"No invitation found for this email." Invitations issued before the flip
+stay valid.
+
+## 7. Future: federated login via eduGAIN / DFN-AAI
+
+Keycloak supports SAML identity providers. When/if you join DFN-AAI (the
+German HE federation) and eduGAIN (the international inter-federation), you
+will:
+
+1. Publish your Keycloak SP metadata.
+2. Sign the federation's onboarding agreement (legal + technical review,
+   weeks-to-months process).
+3. In Keycloak: Identity Providers → Add → SAML → import federation
+   metadata.
+
+No app-code change. Federated users appear to the app as any other
+Keycloak-authenticated user with an email and a stable `sub` claim.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { api } from './api/client'
 import { useBeforeUnloadWarning } from './hooks/useBeforeUnloadWarning'
 import { LoadingFallback } from './components/LoadingFallback'
 import { ChunkErrorBoundary } from './components/ChunkErrorBoundary'
+import { InviteLanding } from './components/InviteLanding'
 
 const RecorderPanel = lazy(() =>
   import('./components/Recorder').then((m) => ({ default: m.RecorderPanel }))
@@ -147,6 +148,11 @@ function DetailActions() {
 }
 
 function App() {
+  const pathMatch = window.location.pathname.match(/\/invite\/([^/]+)$/)
+  if (pathMatch) {
+    return <InviteLanding token={pathMatch[1]} />
+  }
+
   const { t } = useTranslation()
   const config = useStore((s) => s.config)
   const setConfig = useStore((s) => s.setConfig)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
   RefinementPreset, RefinementPresetCreate,
   PresetBundle, PresetBundleCreate, PresetBundleExpanded,
   ApiToken, ApiTokenCreated,
+  Invitation, InvitationCreated, InvitationAcceptResponse,
   TranslationResult, UtteranceSource,
 } from './types'
 
@@ -224,4 +225,27 @@ export const api = {
       throw new Error(response.statusText)
     }
   },
+
+  // --- Invitations ---
+
+  listInvitations: () => request<Invitation[]>('/api/invitations'),
+
+  createInvitation: (email: string) =>
+    request<InvitationCreated>('/api/invitations', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
+
+  revokeInvitation: async (id: string): Promise<void> => {
+    const response = await fetch(`${BASE}/api/invitations/${id}`, { method: 'DELETE' })
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+  },
+
+  acceptInvitation: (token: string) =>
+    request<InvitationAcceptResponse>('/api/invitations/accept', {
+      method: 'POST',
+      body: JSON.stringify({ token }),
+    }),
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -133,6 +133,8 @@ export interface ConfigResponse {
   api_tokens_enabled?: boolean
   api_token_default_expiry_days?: number
   contact_email?: string
+  is_admin?: boolean
+  invitation_mode?: boolean
 }
 
 export interface AnalysisTemplate {
@@ -277,4 +279,28 @@ export interface ApiTokenCreateRequest {
 
 export interface ApiTokenCreated extends ApiToken {
   token: string
+}
+
+// --- Invitations ---
+
+export interface Invitation {
+  id: string
+  email: string
+  status: 'pending' | 'accepted' | 'expired' | 'revoked'
+  created_at: string
+  expires_at: string
+  created_by: string
+  accepted_at: string | null
+}
+
+export interface InvitationCreated extends Invitation {
+  token: string
+}
+
+export interface InvitationCreateRequest {
+  email: string
+}
+
+export interface InvitationAcceptResponse {
+  redirect_url: string
 }

--- a/frontend/src/components/InvitationsSection/CreateInvitationModal.tsx
+++ b/frontend/src/components/InvitationsSection/CreateInvitationModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  onClose: () => void
+  onSubmit: (email: string) => Promise<void>
+}
+
+export function CreateInvitationModal({ onClose, onSubmit }: Props) {
+  const { t } = useTranslation()
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit() {
+    const normalised = email.trim().toLowerCase()
+    if (!normalised) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      await onSubmit(normalised)
+      onClose()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg p-6 max-w-md w-full space-y-4 mx-4">
+        <h2 className="text-lg font-semibold text-white">{t('invitations.create_title')}</h2>
+
+        {error && (
+          <p className="text-sm text-red-400">{error}</p>
+        )}
+
+        <div>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder={t('invitations.email_placeholder')}
+            className="w-full bg-gray-800 text-white text-sm rounded px-3 py-1.5 outline-none focus:ring-1 focus:ring-blue-500 border border-gray-700"
+            autoFocus
+          />
+        </div>
+
+        <div className="flex gap-2 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-gray-400 hover:text-white px-3 py-1.5"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !email.trim()}
+            className="text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded px-4 py-1.5"
+          >
+            {submitting ? t('common.submitting') : t('invitations.send')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/InvitationsSection/index.tsx
+++ b/frontend/src/components/InvitationsSection/index.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+import type { Invitation } from '../../api/types'
+import { CreateInvitationModal } from './CreateInvitationModal'
+
+export function InvitationsSection() {
+  const { t } = useTranslation()
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [revoking, setRevoking] = useState<string | null>(null)
+
+  const fetchInvitations = useCallback(async () => {
+    setError(null)
+    try {
+      const result = await api.listInvitations()
+      setInvitations(result)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchInvitations()
+  }, [fetchInvitations])
+
+  async function handleCreate(email: string) {
+    await api.createInvitation(email)
+    await fetchInvitations()
+  }
+
+  async function handleRevoke(id: string) {
+    if (!confirm(t('invitations.confirm_revoke'))) return
+    setRevoking(id)
+    setError(null)
+    try {
+      await api.revokeInvitation(id)
+      await fetchInvitations()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setRevoking(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-white">{t('invitations.title')}</h2>
+        <button
+          type="button"
+          onClick={() => setShowModal(true)}
+          className="text-sm bg-blue-600 hover:bg-blue-500 text-white rounded px-4 py-1.5"
+        >
+          {t('invitations.create_button')}
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-400">{error}</p>
+      )}
+
+      {loading && !error && (
+        <p className="text-sm text-gray-500">{t('common.loading')}</p>
+      )}
+
+      {!loading && invitations.length === 0 && !error && (
+        <p className="text-sm text-gray-500">{t('invitations.empty')}</p>
+      )}
+
+      {invitations.length > 0 && (
+        <div className="space-y-2">
+          {invitations.map((invitation) => {
+            const status = invitation.status
+            const isInactive = status !== 'pending'
+            const statusColor =
+              status === 'pending' ? 'text-green-400' :
+              status === 'accepted' ? 'text-blue-400' :
+              status === 'expired' ? 'text-yellow-500' :
+              'text-red-400'
+            return (
+              <div
+                key={invitation.id}
+                className={`bg-gray-800 border border-gray-700 rounded-lg p-4 flex items-start justify-between gap-3 ${isInactive ? 'opacity-60' : ''}`}
+              >
+                <div className="min-w-0 space-y-0.5">
+                  <p className="font-medium text-white truncate">{invitation.email}</p>
+                  <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-gray-500">
+                    <span className={statusColor}>
+                      {t(`invitations.status.${status}`)}
+                    </span>
+                    <span>{invitation.created_at}</span>
+                  </div>
+                </div>
+                {status === 'pending' && (
+                  <button
+                    type="button"
+                    onClick={() => handleRevoke(invitation.id)}
+                    disabled={revoking === invitation.id}
+                    className="text-sm text-red-400 hover:text-red-300 disabled:opacity-50 shrink-0"
+                  >
+                    {t('invitations.revoke')}
+                  </button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {showModal && (
+        <CreateInvitationModal
+          onClose={() => setShowModal(false)}
+          onSubmit={handleCreate}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/InviteLanding/index.tsx
+++ b/frontend/src/components/InviteLanding/index.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api/client'
+
+interface Props {
+  token: string
+}
+
+export function InviteLanding({ token }: Props) {
+  const { t } = useTranslation()
+  const [status, setStatus] = useState<'loading' | 'redirecting' | 'error'>('loading')
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    async function run() {
+      try {
+        const { redirect_url } = await api.acceptInvitation(token)
+        if (cancelled) return
+        setStatus('redirecting')
+        window.location.href = redirect_url
+      } catch (err) {
+        if (cancelled) return
+        setStatus('error')
+        setMessage(err instanceof Error ? err.message : 'Failed')
+      }
+    }
+    void run()
+    return () => { cancelled = true }
+  }, [token])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-neutral-950">
+      <div className="max-w-md w-full bg-neutral-900 rounded-lg p-6 text-center">
+        {status === 'loading' && <p className="text-white">{t('invite.verifying')}</p>}
+        {status === 'redirecting' && <p className="text-white">{t('invite.redirecting')}</p>}
+        {status === 'error' && (
+          <>
+            <p className="text-red-400 font-semibold mb-2">{t('invite.error_title')}</p>
+            <p className="text-neutral-300 text-sm">{message}</p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SettingsPage/index.tsx
+++ b/frontend/src/components/SettingsPage/index.tsx
@@ -1,13 +1,19 @@
 import { useTranslation } from 'react-i18next'
+import { useStore } from '../../store'
 import { ApiTokensSection } from './ApiTokensSection'
+import { InvitationsSection } from '../InvitationsSection'
 
 export function SettingsPage() {
   const { t } = useTranslation()
+  const config = useStore((s) => s.config)
+  const isAdmin = config?.is_admin ?? false
+  const invitationMode = config?.invitation_mode ?? false
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
       <h1 className="text-2xl font-bold text-white">{t('settings.title')}</h1>
       <ApiTokensSection />
+      {isAdmin && invitationMode && <InvitationsSection />}
     </div>
   )
 }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -442,7 +442,8 @@
     "close": "Schließen",
     "logout": "Abmelden",
     "loadError": "Diese Ansicht konnte nicht geladen werden. Bitte laden Sie die Seite neu.",
-    "reload": "Neu laden"
+    "reload": "Neu laden",
+    "submitting": "Wird gesendet…"
   },
   "help": {
     "open": "Hilfe öffnen",
@@ -468,5 +469,26 @@
       "bundles": "Bundles",
       "api-access": "API-Zugriff"
     }
+  },
+  "invitations": {
+    "title": "Einladungen",
+    "create_button": "Benutzer einladen",
+    "create_title": "Benutzer einladen",
+    "email_placeholder": "benutzer@example.com",
+    "send": "Einladung senden",
+    "empty": "Noch keine Einladungen.",
+    "revoke": "Zurückziehen",
+    "confirm_revoke": "Einladung zurückziehen? Der Link funktioniert dann nicht mehr.",
+    "status": {
+      "pending": "Ausstehend",
+      "accepted": "Angenommen",
+      "expired": "Abgelaufen",
+      "revoked": "Zurückgezogen"
+    }
+  },
+  "invite": {
+    "verifying": "Einladung wird geprüft…",
+    "redirecting": "Weiterleitung zur Kontoeinrichtung…",
+    "error_title": "Diese Einladung ist ungültig"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -442,7 +442,8 @@
     "close": "Close",
     "logout": "Logout",
     "loadError": "Failed to load this view. Please reload the page.",
-    "reload": "Reload"
+    "reload": "Reload",
+    "submitting": "Submitting…"
   },
   "help": {
     "open": "Open help",
@@ -468,5 +469,26 @@
       "bundles": "Bundles",
       "api-access": "API Access"
     }
+  },
+  "invitations": {
+    "title": "Invitations",
+    "create_button": "Invite user",
+    "create_title": "Invite a user",
+    "email_placeholder": "user@example.com",
+    "send": "Send invitation",
+    "empty": "No invitations yet.",
+    "revoke": "Revoke",
+    "confirm_revoke": "Revoke this invitation? The link will stop working.",
+    "status": {
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "expired": "Expired",
+      "revoked": "Revoked"
+    }
+  },
+  "invite": {
+    "verifying": "Verifying invitation…",
+    "redirecting": "Redirecting to set up your account…",
+    "error_title": "This invitation link is not valid"
   }
 }


### PR DESCRIPTION
## Summary

Adds self-service user registration support to enable a second deployment for external users, while keeping the existing production instance byte-for-byte unchanged.

- The app stays OIDC-agnostic — it continues to trust `X-Auth-Request-User` / `X-Auth-Request-Email` headers from oauth2-proxy. Registration, login, password reset, email verification, and optional social login (Google / Microsoft) are delegated to a dedicated Keycloak, which is a separate operational concern.
- Adds an opt-in `INVITATION_MODE` env var (defaults `false`) that, when on, gates first logins against an admin-managed allowlist (`ADMIN_EMAILS`). When off, every new code path is unreachable — prod is unchanged.
- New `/api/invitations*` admin router (create / list / revoke) and a public `/api/invitations/accept` endpoint. Invitations are sha256-hashed, expire after 7 days, and are cleaned up in the existing periodic loop.
- Includes a thin Keycloak Admin API client and an SMTP sender with optional STARTTLS so the Uni-Osnabrück internal relay (`relay.rz.uni-osnabrueck.de`, no auth/TLS) works out of the box.
- Frontend adds an admin-only "Invitations" section in Settings (gated on `is_admin` + `invitation_mode` from `/api/config`) and an `/invite/:token` landing page that redirects the invitee to Keycloak's account-setup flow.
- Ships a minimal `deploy/compose/` reference stack (transcription + oauth2-proxy + caddy, Keycloak not bundled) plus `docs/keycloak-setup.md` covering realm/client/social-login/SMTP setup.

## Production safety

- Every new env var defaults to the disabled value. With `INVITATION_MODE=false` and empty `ADMIN_EMAILS` / `KEYCLOAK_ADMIN_URL` / `SMTP_HOST`, `get_current_user` is behaviourally identical to today.
- Schema addition is additive (`CREATE TABLE IF NOT EXISTS invitations` via the main `SCHEMA` string). Existing tables untouched.
- Invitations router is unconditionally mounted but 404s per-request when the flag is off.
- Ansible repo untouched — the `deploy/compose/` artifacts are for third-party operators.

## Verification

- Backend: **185 tests passing** (131 baseline + 54 new), including invitation service, Keycloak client, SMTP sender, router, first-login gate, and cleanup integration.
- Frontend: `tsc --noEmit` clean.
- `docker compose config` validates for the new reference stack.

## Design docs

- Spec: `docs/superpowers/specs/2026-04-23-self-service-registration-design.md` *(gitignored locally)*
- Plan:  `docs/superpowers/plans/2026-04-23-self-service-registration.md` *(gitignored locally)*