### PR TITLE
fix(metrics): pre-init transcription_jobs_total label series at startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import settings
 from app.database import init_db, get_db
 from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets, tokens, invitations as invitations_router
-from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes, api_tokens_active, invitations_expired_total
+from app.metrics import inc, gauge_set, cleanup_runs_total, cleanup_items_deleted_total, storage_bytes, api_tokens_active, invitations_expired_total, init_label_series
 from app.services.audio import has_video_stream
 from app.services.api_tokens import cleanup_stale_tokens, count_active_tokens
 
@@ -133,6 +133,7 @@ async def lifespan(app: FastAPI):
     _refresh_storage_gauge()
     async with get_db() as db:
         gauge_set(api_tokens_active, await count_active_tokens(db))
+    init_label_series()
     cleanup_task = asyncio.create_task(cleanup_old_files())
     yield
     cleanup_task.cancel()

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -246,3 +246,20 @@ async def measure_llm_operation(operation: str):
 
 def metrics_response() -> Response:
     return Response(content=generate_latest(), media_type=CONTENT_TYPE)
+
+
+def init_label_series() -> None:
+    """Pre-create label combinations at value 0 so `increase()` sees a 0→N
+    transition on the first job. Without this, a counter that records exactly
+    one job during a process lifetime is reported by Prometheus as a constant
+    series at 1, and `increase()` returns 0.
+    """
+    if not _enabled or transcriptions_total is None:
+        return
+    backend = settings.ASR_BACKEND
+    languages = {"auto", *settings.POPULAR_LANGUAGES, *settings.ENABLED_LANGUAGES}
+    models = {"default", *settings.WHISPER_MODELS}
+    for language in languages:
+        for model in models:
+            for status in ("completed", "failed"):
+                transcriptions_total.labels(backend, language, model, status).inc(0)


### PR DESCRIPTION
## Summary

Low-volume languages (`ja`, `es`) disappeared from the *Languages used (successful jobs, range)* Grafana panel even when the underlying job did succeed. The panel uses `increase(transcription_jobs_total[$__range])` and reported `0` for those languages.

## Root cause

`prometheus_client` only materialises a Counter's labelled child on the first `.inc()`. So when a language is used exactly once during a process lifetime, the *very first sample* Prometheus scrapes for that label series is already `1`, and every subsequent sample stays `1` until the container restarts and the series disappears. There is no internal delta — `increase()` over a window where the series is constant at `1` returns `0`, not `1`.

This was triggered in production by an unattended `dnf-automatic` Docker CE upgrade that bounced the daemon (and therefore all metric counters) at 04:03 UTC. Languages that had been incremented multiple times in the prior counter lifetime (`de`, `auto`, `en`, `tr`) still showed up; languages used once (`ja`, `es`) collapsed to `0`.

## Fix

Add `init_label_series()` to `app.metrics` and call it from the FastAPI lifespan. It pre-creates the full cross-product of `(backend, language, model, status)` at `.inc(0)` on startup, giving Prometheus a `0`-valued first sample. The first real job is then a `0→1` transition that `increase()` can see.

Cardinality: ~1 backend × ~10 languages × ~4 models × 2 statuses ≈ 80 series — comfortably within scrape limits.