### PR TITLE
fix(metrics): expose real app version via APP_VERSION build arg

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -36,5 +36,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend/ ./
 COPY --from=frontend-build /app/frontend/dist ./static
 RUN mkdir -p /app/tmp/transcription-files && chown -R nobody:nogroup /app/tmp
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
 USER nobody
 EXPOSE 8000
 HEALTHCHECK CMD curl --fail http://localhost:8000/api/health || exit 1

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,3 +1,4 @@
+import os
 import time
 from contextlib import asynccontextmanager
 
@@ -36,7 +37,7 @@ def _gauge(name, desc):
 # --- App info ---
 if _enabled:
     app_info = Info("transcription_app_info", "Application info")
-    app_info.info({"version": "1.0.0", "name": "transcription-whisper"})
+    app_info.info({"version": os.getenv("APP_VERSION", "dev"), "name": "transcription-whisper"})
 
 # --- Uploads ---
 file_uploads_total = _counter("transcription_file_uploads_total", "Total file uploads", ["file_type", "status"])


### PR DESCRIPTION
## Summary

`transcription_app_info_info{version="1.0.0"}` was hardcoded in [`backend/app/metrics.py`](backend/app/metrics.py), so the metric reported `1.0.0` regardless of which image tag was actually running. This made it impossible to verify in Grafana / Prometheus which release was deployed.

## Changes

- **Dockerfile**: declare `ARG APP_VERSION=dev` and persist it as `ENV APP_VERSION` in the runtime stage.
- **publish-docker-image.yaml**: pass `APP_VERSION=${{ steps.meta.outputs.version }}` from `docker/metadata-action` (git tag for tagged builds, branch / short SHA otherwise) as a build-arg.
- **backend/app/metrics.py**: read `os.getenv("APP_VERSION", "dev")` instead of the hardcoded `"1.0.0"`. Local `docker build` without `--build-arg` still works and reports `dev`.

After this is merged and a tagged image is published, `transcription_app_info_info` will reflect the actual release tag (e.g. `v1.9.2`).