### PR TITLE
chore: fix lint errors across backend and frontend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,12 @@
 import asyncio
 import os
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from app.config import settings
 from app.database import init_db, get_db
 from app.routers import config_router, upload, transcription, refinement, analysis, translation, presets, tokens, invitations as invitations_router
@@ -164,9 +166,6 @@ if settings.ENABLE_API_TOKENS:
 app.include_router(invitations_router.router)
 
 # Serve frontend static files (only when built files exist, i.e., in Docker)
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
-
 static_dir = os.path.join(os.path.dirname(__file__), "..", "static")
 if os.path.isdir(static_dir):
     app.mount("/assets", StaticFiles(directory=os.path.join(static_dir, "assets")), name="assets")

--- a/backend/app/routers/analysis.py
+++ b/backend/app/routers/analysis.py
@@ -13,7 +13,6 @@ from app.services.llm.prompt import (
     build_analysis_system_prompt,
     list_analysis_templates,
     chunk_transcript,
-    build_consolidation_prompt,
 )
 from app.metrics import inc, observe, track_llm_tokens, llm_requests_total, llm_duration_seconds, llm_errors_total, deletions_total, errors_total
 

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -19,7 +19,9 @@ from app.models import (
 )
 from app.services.email import send_invitation_email, EmailConfigError
 from app.services.idp_admin import (
-    KeycloakAdminClient, KeycloakAdminError, build_default_client,
+    KeycloakAdminClient,  # noqa: F401  re-exported for test monkeypatching
+    KeycloakAdminError,
+    build_default_client,
 )
 from app.services.invitations import (
     create_invitation, list_invitations, revoke_invitation,

--- a/backend/app/routers/translation.py
+++ b/backend/app/routers/translation.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from app.config import settings
 from app.dependencies import get_current_user
 from app.router_helpers import ensure_transcription_owned, reset_translation_state
-from app.models import UserInfo, TranslationRequest, Utterance
+from app.models import UserInfo, TranslationRequest
 from app.database import get_db
 from app.services.llm import get_llm_provider
 from app.services.llm.prompt import (

--- a/backend/app/services/asr/whisperx.py
+++ b/backend/app/services/asr/whisperx.py
@@ -28,7 +28,7 @@ class WhisperXBackend(ASRBackend):
                 result = await self._call_whisperx(file_path, ts)
                 _results[job_id] = result
                 _statuses[job_id] = "completed"
-            except Exception as e:
+            except Exception:
                 _statuses[job_id] = "failed"
                 _results[job_id] = TranscriptionResult(
                     id=job_id, status="failed", text="", utterances=[], language=None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,7 +6,7 @@ import asyncio
 import tempfile
 import pytest
 import pytest_asyncio
-from app.database import init_db, get_db
+from app.database import init_db
 
 
 @pytest.fixture

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -11,7 +11,6 @@ from app.services.api_tokens import (
     resolve_token,
     touch_last_used,
     cleanup_stale_tokens,
-    count_active_tokens,
     TokenLimitError,
     DuplicateTokenNameError,
 )

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -3,6 +3,7 @@ from httpx import AsyncClient, ASGITransport
 from fastapi import FastAPI, Depends
 
 from app.dependencies import get_current_user
+from app.main import app
 from app.models import UserInfo
 from app.database import get_db
 from app.services.api_tokens import create_token
@@ -92,9 +93,6 @@ async def test_non_tw_bearer_falls_through(monkeypatch):
         )
     assert r.status_code == 200
     assert r.json()["id"] == "u1"
-
-
-from app.main import app
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pytest
 from httpx import AsyncClient, ASGITransport
 from app.main import app
@@ -21,10 +23,6 @@ async def test_metrics_endpoint():
         response = await client.get("/metrics")
     assert response.status_code == 200
     assert "transcription_app_info" in response.text
-
-
-import importlib
-import os
 
 
 def test_api_token_settings_defaults(monkeypatch):

--- a/backend/tests/test_invitations_service.py
+++ b/backend/tests/test_invitations_service.py
@@ -55,9 +55,9 @@ async def test_create_invitation_rejects_duplicate_pending():
 @pytest.mark.asyncio
 async def test_list_returns_newest_first():
     async with get_db() as db:
-        a = await create_invitation(db, email="a@example.com", created_by="admin@example.com")
+        await create_invitation(db, email="a@example.com", created_by="admin@example.com")
         await asyncio.sleep(1.1)  # Ensure different timestamps (rounded to seconds)
-        b = await create_invitation(db, email="b@example.com", created_by="admin@example.com")
+        await create_invitation(db, email="b@example.com", created_by="admin@example.com")
         items = await list_invitations(db)
     assert [i["email"] for i in items][0:2] == ["b@example.com", "a@example.com"]
 

--- a/backend/tests/test_presets.py
+++ b/backend/tests/test_presets.py
@@ -121,8 +121,7 @@ async def test_delete_preset_nullifies_bundle_reference(client):
     # Create preset and bundle referencing it
     resp = await client.post("/api/presets/transcription", json={"name": "T1"}, headers=DEV_HEADERS)
     t_id = resp.json()["id"]
-    resp = await client.post("/api/presets/bundles", json={"name": "Bundle", "transcription_preset_id": t_id}, headers=DEV_HEADERS)
-    bundle_id = resp.json()["id"]
+    await client.post("/api/presets/bundles", json={"name": "Bundle", "transcription_preset_id": t_id}, headers=DEV_HEADERS)
 
     # Delete the preset
     await client.delete(f"/api/presets/transcription/{t_id}", headers=DEV_HEADERS)

--- a/backend/tests/test_refinement_prompt.py
+++ b/backend/tests/test_refinement_prompt.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 from app.services.llm.prompt import (
     REFINEMENT_SCHEMA,
     build_refinement_system_prompt,

--- a/backend/tests/test_token_e2e.py
+++ b/backend/tests/test_token_e2e.py
@@ -12,7 +12,6 @@ async def test_upload_works_with_bearer_token(monkeypatch):
     # captured reference, to survive importlib.reload side-effects from other
     # tests.
     from app import dependencies as dep
-    from app.routers import upload as upload_router
     monkeypatch.setattr(config_module.settings, "ENABLE_API_TOKENS", True)
     monkeypatch.setattr(dep.settings, "ENABLE_API_TOKENS", True)
     monkeypatch.setattr(config_module.settings, "DEV_MODE", False)  # force token path

--- a/backend/tests/test_transcription_api.py
+++ b/backend/tests/test_transcription_api.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 from unittest.mock import patch, AsyncMock
 from httpx import AsyncClient, ASGITransport

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -152,7 +152,10 @@ function App() {
   if (pathMatch) {
     return <InviteLanding token={pathMatch[1]} />
   }
+  return <MainApp />
+}
 
+function MainApp() {
   const { t } = useTranslation()
   const config = useStore((s) => s.config)
   const setConfig = useStore((s) => s.setConfig)

--- a/frontend/src/components/SpeakerMapping/SpeakerMapping.tsx
+++ b/frontend/src/components/SpeakerMapping/SpeakerMapping.tsx
@@ -51,9 +51,12 @@ export function SpeakerMapping({ isOpen, onClose, focusSpeaker }: Props) {
   // renaming "Lars" to "Lars".
   const [edits, setEdits] = useState<Record<string, string>>({})
 
-  const prevIsOpenRef = useRef(isOpen)
-  if (isOpen !== prevIsOpenRef.current) {
-    prevIsOpenRef.current = isOpen
+  // Reset draft edits whenever the dialog (re-)opens. Tracking the previous
+  // value as state and adjusting during render is the React-recommended way
+  // to derive state from a prop change without a redundant effect.
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen)
+  if (isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen)
     if (isOpen) setEdits({})
   }
 


### PR DESCRIPTION
## Summary

Cleared all `ruff` errors (19 → 0) on the backend and all `eslint` errors (57 → 0) on the frontend. No CI lint job is wired up yet, so these had accumulated silently. Backend test suite still green (185 passed).

## Backend (ruff, 19 → 0)

- Removed unused imports (`F401`) in `app/main.py`, `app/routers/{analysis,translation}.py`, `app/services/asr/whisperx.py`, and several test files.
- Removed unused local variables (`F841`) in `tests/test_invitations_service.py` and `tests/test_presets.py`.
- Hoisted mid-module imports (`E402`) to the top of file in `app/main.py` (`StaticFiles`, `FileResponse`) and in `tests/test_auth_dependency.py` / `tests/test_config.py`.
- `app/routers/invitations.py`: kept `KeycloakAdminClient` as a re-import marked `# noqa: F401` — `tests/test_invitations_router.py` monkeypatches `app.routers.invitations.KeycloakAdminClient.*` and would otherwise break.

## Frontend (eslint, 57 → 0)

- **`App.tsx`** — 55 `react-hooks/rules-of-hooks` errors. The component had an early `return <InviteLanding/>` for `/invite/*` URLs *before* any hooks ran, so all subsequent hook calls were "conditional" by React's rules. Split into a thin `App` wrapper that does the route check and a `MainApp` that holds the (now unconditional) hooks.
- **`SpeakerMapping.tsx`** — 2 `react-hooks/refs` errors (and one secondary `react-hooks/set-state-in-effect` after a first attempt). The original code used a `useRef`+inline-mutation pattern to reset draft edits when the dialog opened, which is disallowed by both rules. Switched to the React-recommended *"adjust state during render"* pattern with a `prevIsOpen` state value. Behaviour is unchanged.

## Verification

- `cd backend && ruff check` → `All checks passed!`
- `cd frontend && npm run lint` → clean
- `cd frontend && npx tsc -b` → clean
- `pytest backend/tests/` → 185 passed