### PR TITLE
docs(readme): document user metrics and fix drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,19 @@ The application includes comprehensive Prometheus metrics for monitoring usage a
   - `transcription_storage_bytes` — Disk usage of the media/DB volume, refreshed at startup and after each cleanup run (labelled by `path`)
 
 - **Auth**:
-  - `transcription_auth_failures_total` — Authentication failures by reason (`missing_headers`, `ws_missing_headers`)
+  - `transcription_auth_failures_total` — Authentication failures by reason (`missing_headers`, `ws_missing_headers`, `invalid_token`, `no_invitation`)
+
+- **API Tokens**:
+  - `transcription_api_tokens_active` — Active (non-revoked, non-expired) API tokens, refreshed at startup and after each cleanup run
+  - `transcription_api_tokens_created_total` — API tokens created
+  - `transcription_api_tokens_revoked_total` — API tokens revoked
+  - `transcription_api_token_auth_total` — API token authentication attempts by `result` (`success`/`failure`)
+
+- **Invitations**:
+  - `transcription_invitations_created_total` — Invitations created
+  - `transcription_invitations_accepted_total` — Invitations accepted on first login
+  - `transcription_invitations_expired_total` — Invitations transitioned to expired
+  - `transcription_invitations_revoked_total` — Invitations revoked by an admin
 
 - **Users**:
   - `transcription_users_total` — Total registered users

--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ The application includes comprehensive Prometheus metrics for monitoring usage a
 - **Auth**:
   - `transcription_auth_failures_total` — Authentication failures by reason (`missing_headers`, `ws_missing_headers`)
 
+- **Users**:
+  - `transcription_users_total` — Total registered users
+  - `transcription_users_with_transcriptions` — Distinct users with at least one transcription record on file
+  - `transcription_users_new` — New user registrations within a rolling window, labelled by `window` (`7d`, `30d`)
+
 - **Cleanup**:
   - `transcription_cleanup_runs_total` — Cleanup job runs by status (success/failed)
   - `transcription_cleanup_items_deleted_total` — Items deleted by resource type


### PR DESCRIPTION
## Summary

Two atomic commits:

- `66a20d5` adds a **Users** group to the Available Metrics list documenting `transcription_users_total`, `transcription_users_with_transcriptions`, and `transcription_users_new{window=…}` — the gauges introduced in #150.
- `e3f6385` backfills pre-existing drift in the same section: extends the **Auth** failure-reason list (was missing `invalid_token` and `no_invitation`), adds the **API Tokens** group (4 metrics — gauge + 3 counters), and adds the **Invitations** group (4 counters). All were live in `backend/app/metrics.py` but undocumented.

## Verification

Every entry was cross-checked against the metric declarations in `backend/app/metrics.py` and the reason-label comment at `metrics.py:146`. The API Tokens and Invitations groups intentionally do not include feature-flag qualifiers: the gauges/counters are declared unconditionally — only the routers are gated, and disabled features simply leave the counters at 0.