### PR TITLE
fix(media): play .opus recordings and stop failed sources overlaying the UI

### DIFF
--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -106,7 +106,7 @@ async def get_media(
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="File not found on disk")
 
-    media_types = {"mp3": "audio/mpeg", "wav": "audio/wav", "mp4": "video/mp4", "webm": "video/webm", "m4a": "audio/mp4", "mov": "video/quicktime", "aac": "audio/aac", "opus": "audio/opus", "ogg": "audio/ogg"}
+    media_types = {"mp3": "audio/mpeg", "wav": "audio/wav", "mp4": "video/mp4", "webm": "video/webm", "m4a": "audio/mp4", "mov": "video/quicktime", "aac": "audio/aac", "opus": "audio/ogg", "ogg": "audio/ogg"}
     return FileResponse(file_path, media_type=media_types.get(row["media_type"], "application/octet-stream"))
 
 

--- a/frontend/src/components/MediaPlayer/MediaPlayer.tsx
+++ b/frontend/src/components/MediaPlayer/MediaPlayer.tsx
@@ -15,7 +15,7 @@ const mimeTypes: Record<string, string> = {
   wav: 'audio/wav',
   m4a: 'audio/mp4',
   aac: 'audio/aac',
-  opus: 'audio/opus',
+  opus: 'audio/ogg',
   ogg: 'audio/ogg',
 }
 

--- a/frontend/src/components/MediaPlayer/MediaPlayer.tsx
+++ b/frontend/src/components/MediaPlayer/MediaPlayer.tsx
@@ -205,7 +205,7 @@ export function MediaPlayer({ fileId, mediaType, hasVideo, onCollapsedChange }: 
   }
 
   return (
-    <div className={`mx-6 my-2 ${hasVideo && !collapsed ? 'flex flex-col items-center' : hasVideo ? '' : 'max-h-16'}`}>
+    <div className={`mx-6 my-2 ${hasVideo && !collapsed ? 'flex flex-col items-center' : hasVideo ? '' : 'max-h-16 overflow-hidden'}`}>
       {playbackErrorKey && (
         <div className="p-4 bg-gray-800 rounded-lg border border-gray-700 text-center">
           <p className="text-gray-400 text-sm">{t(playbackErrorKey)}</p>


### PR DESCRIPTION
## Problem

Opening an `.opus` recording showed a giant black box overlaying the subtitle editor, the audio wouldn't play, and the console reported `VIDEOJS: ERROR (CODE:4 MEDIA_ERR_SRC_NOT_SUPPORTED) — No compatible source was found for this media`.

Root cause is two stacked bugs:

1. **Wrong MIME for opus.** Opus audio lives in an Ogg container and must be typed `audio/ogg`. It was served (backend) and passed to video.js (frontend) as `audio/opus`, which browsers don't recognise — `canPlayType` returns empty, so the source is rejected (CODE:4). This affected every `.opus` recording.

2. **Failed source overlays the page.** The player uses `fluid: true` and relies on `audioOnlyMode` to collapse to a control bar. When a source fails to load, nothing sets the player's dimensions, so `fluid` keeps the default 16:9 ratio and paints a full-width black box. The `max-h-16` audio wrapper had no overflow clipping, so the box spilled over the TabBar and SubtitleEditor — which is why the subtitle rows looked faint and half-hidden (they were behind the black box).

## Changes

- Serve and type opus as `audio/ogg` (backend `upload.py`, frontend `MediaPlayer.tsx`). This alone makes `.opus` play on the first try.
- Add `overflow-hidden` to the audio player wrapper so any future playback failure stays contained to the audio-bar height instead of overlaying the page.

## Verification

- ffprobe confirms the affected file is a single opus-in-ogg audio stream (`has_video=0`).
- Reproduced the black-box behaviour with the real video.js 8.23.7: a source that loads collapses to a thin bar; a failing source expands to a 16:9 black box that overflows an un-clipped wrapper. The `overflow-hidden` guard contains it.
- `npx tsc --noEmit` passes.