### PR TITLE
fix(settings): show the model name instead of a quality tier when only one model is configured

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -188,11 +188,13 @@ function MainApp() {
 
   const configModelApplied = useRef(false)
   useEffect(() => {
-    if (config?.default_model && !configModelApplied.current) {
-      configModelApplied.current = true
-      setSettings((s) => ({ ...s, model: config.default_model }))
-    }
-  }, [config?.default_model])
+    if (!config || configModelApplied.current) return
+    const models = config.whisper_models ?? []
+    const model = models.length === 1 ? models[0] : config.default_model
+    if (!model) return
+    configModelApplied.current = true
+    setSettings((s) => ({ ...s, model }))
+  }, [config])
 
   const updateSettings = useCallback((patch: Partial<SettingsPanelValues>) => {
     setSettings((s) => ({ ...s, ...patch }))
@@ -396,13 +398,15 @@ function MainApp() {
     const bundleId = state.activeBundleId
     const bundleList = state.bundles
     const bundleName = bundleId ? bundleList.find((b) => b.id === bundleId)?.name : undefined
+    const configuredModels = state.config?.whisper_models ?? []
+    const model = configuredModels.length === 1 ? configuredModels[0] : settings.model
 
     if (!f && !isUploading) return
 
     const summary: SubmittedSummary = {
       filename: f?.original_filename || t('transcription.statusUploading'),
       fileSize: f?.file_size || 0,
-      model: settings.model,
+      model,
       language: settings.language === 'auto' ? null : settings.language,
       detectSpeakers: settings.detectSpeakers,
       minSpeakers: settings.minSpeakers,
@@ -423,7 +427,7 @@ function MainApp() {
       const result = await api.startTranscription({
         file_id: f.id,
         language: settings.language === 'auto' ? null : settings.language,
-        model: settings.model,
+        model,
         min_speakers: settings.detectSpeakers ? settings.minSpeakers : 0,
         max_speakers: settings.detectSpeakers ? settings.maxSpeakers : 0,
         initial_prompt: settings.initialPrompt || null,

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -25,6 +25,8 @@ interface SettingsPanelProps {
 export function SettingsPanel({ values, onChange, saveError = null }: SettingsPanelProps) {
   const { t } = useTranslation()
   const config = useStore((s) => s.config)
+  const models = config?.whisper_models || []
+  const singleModel = models.length === 1 ? models[0] : null
   const transcriptionPresets = useStore((s) => s.transcriptionPresets)
   const setTranscriptionPresets = useStore((s) => s.setTranscriptionPresets)
   const bundles = useStore((s) => s.bundles)
@@ -138,32 +140,26 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
             />
           </div>
           <div className="min-w-0">
-            <label htmlFor="upload-model-field" className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
-            {(() => {
-              const models = config?.whisper_models || []
-              if (models.length === 1) {
-                const m = models[0]
-                const label = t(`settings.modelLabels.${m}`, '')
-                return (
-                  <output id="upload-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
-                    {label ? `${label} (${m})` : m}
-                  </output>
-                )
-              }
-              return (
-                <select
-                  id="upload-model-field"
-                  value={values.model}
-                  onChange={(e) => onChange({ model: e.target.value })}
-                  className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
-                >
-                  {models.map((m) => {
-                    const label = t(`settings.modelLabels.${m}`, '')
-                    return <option key={m} value={m}>{label ? `${label} (${m})` : m}</option>
-                  })}
-                </select>
-              )
-            })()}
+            <label htmlFor="upload-model-field" className="block text-xs text-gray-400 mb-1">
+              {singleModel ? t('settings.modelName') : t('settings.model')}
+            </label>
+            {singleModel ? (
+              <output id="upload-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
+                {singleModel}
+              </output>
+            ) : (
+              <select
+                id="upload-model-field"
+                value={values.model}
+                onChange={(e) => onChange({ model: e.target.value })}
+                className="w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5"
+              >
+                {models.map((m) => {
+                  const label = t(`settings.modelLabels.${m}`, '')
+                  return <option key={m} value={m}>{label ? `${label} (${m})` : m}</option>
+                })}
+              </select>
+            )}
           </div>
         </fieldset>
 

--- a/frontend/src/components/FileUpload/SettingsPanel.tsx
+++ b/frontend/src/components/FileUpload/SettingsPanel.tsx
@@ -53,7 +53,7 @@ export function SettingsPanel({ values, onChange, saveError = null }: SettingsPa
     const preset = await api.createTranscriptionPreset({
       name,
       language: values.language === 'auto' ? null : values.language,
-      model: values.model,
+      model: singleModel ?? values.model,
       min_speakers: values.detectSpeakers ? values.minSpeakers : 0,
       max_speakers: values.detectSpeakers ? values.maxSpeakers : 0,
       initial_prompt: values.initialPrompt || null,

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -39,7 +39,7 @@ function TranscriptionPresetsList() {
 
   const openNew = () => {
     setEditingId(null)
-    setForm({ ...emptyForm, model: defaultModel })
+    setForm({ ...emptyForm, model: singleModel ?? defaultModel })
     setShowForm(true)
   }
 

--- a/frontend/src/components/PresetsPage/PresetsPage.tsx
+++ b/frontend/src/components/PresetsPage/PresetsPage.tsx
@@ -32,6 +32,7 @@ function TranscriptionPresetsList() {
   const [saving, setSaving] = useState(false)
 
   const models = config?.whisper_models ?? []
+  const singleModel = models.length === 1 ? models[0] : null
   const defaultModel = config?.default_model ?? ''
   const enabledLanguages = config?.enabled_languages ?? []
   const popularLanguages = config?.popular_languages ?? []
@@ -135,16 +136,14 @@ function TranscriptionPresetsList() {
             </select>
           </div>
           <div>
-            <label htmlFor="transcription-preset-model-field" className="block text-xs text-gray-400 mb-1">{t('settings.model')}</label>
-            {models.length === 1 ? (() => {
-              const m = models[0]
-              const label = t(`settings.modelLabels.${m}`, '')
-              return (
-                <output id="transcription-preset-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
-                  {label ? `${label} (${m})` : m}
-                </output>
-              )
-            })() : (
+            <label htmlFor="transcription-preset-model-field" className="block text-xs text-gray-400 mb-1">
+              {singleModel ? t('settings.modelName') : t('settings.model')}
+            </label>
+            {singleModel ? (
+              <output id="transcription-preset-model-field" className="block w-full bg-gray-700 text-white text-sm rounded px-3 py-1.5">
+                {singleModel}
+              </output>
+            ) : (
               <select
                 id="transcription-preset-model-field"
                 value={form.model ?? defaultModel}

--- a/frontend/src/help/de/05-transcription-settings.md
+++ b/frontend/src/help/de/05-transcription-settings.md
@@ -4,18 +4,24 @@
 
 Die Sprechererkennung (Diarization) erkennt, wer wann gesprochen hat, und versieht jede Äußerung mit einer Bezeichnung wie SPEAKER_00, SPEAKER_01 usw. Schalte sie für Aufnahmen mit mehreren Sprechern ein und für Einzelsprecher-Inhalte aus, um Verarbeitungszeit zu sparen. Optional kannst du eine minimale und maximale Sprecheranzahl angeben, um die Erkennung zu steuern. Die Sprechererkennung erhöht die Verarbeitungszeit spürbar. Nach der Transkription kannst du Sprecher über das **Speaker Mapping** umbenennen.
 
-## Qualität
+## Modell und Qualität
+
+Welche Whisper-Modelle zur Verfügung stehen, hängt von der Konfiguration deiner Installation ab.
+
+**Ist nur ein Modell konfiguriert**, zeigt der Einstellungsbereich ein schreibgeschütztes Feld **Modell** mit dessen Namen an (zum Beispiel `large-v3-turbo`). Es gibt nichts auszuwählen — jede Transkription verwendet dieses Modell.
+
+**Sind mehrere konfiguriert**, wird daraus ein Auswahlfeld **Qualität**. Jeder Eintrag nennt eine Stufe und das dahinterliegende Modell:
 
 | Stufe | Geschwindigkeit | Hinweis |
 |---|---|---|
-| Entwurf | Schnellste | Gut für schnelle Vorschauen langer Dateien |
-| Standard | Schnell | — |
-| Gut | Mittel | — |
-| Besser | Langsam | — |
-| Ausgewogen | Schnell/genau | Empfohlene Standardwahl |
-| Beste Qualität | Langsamste | Maximale Genauigkeit |
+| Entwurf (tiny) | Schnellste | Gut für schnelle Vorschauen langer Dateien |
+| Standard (base) | Schnell | — |
+| Gut (small) | Mittel | — |
+| Besser (medium) | Langsam | — |
+| Ausgewogen (large-v3-turbo) | Schnell/genau | Empfohlene Standardwahl |
+| Beste Qualität (large-v3) | Langsamste | Maximale Genauigkeit |
 
-**Ausgewogen** ist für die meisten Anwendungsfälle die richtige Wahl.
+Es erscheinen nur die Stufen, die deine Installation anbietet. Die Abstände sind nicht gleichmäßig — der Sprung hinauf zu `large-v3-turbo` ist groß, während der Unterschied zwischen `large-v3-turbo` und `large-v3` klein ist.
 
 ## Erweiterte Optionen
 

--- a/frontend/src/help/de/12-presets.md
+++ b/frontend/src/help/de/12-presets.md
@@ -2,7 +2,7 @@
 
 ## Transkriptions-Voreinstellungen
 
-Eine Transkriptions-Voreinstellung speichert deine bevorzugte Kombination aus Sprache, Modell (Qualitätsstufe), Sprechererkennungs-Einstellungen, initialem Prompt und Hotwords. Wähle eine gespeicherte Voreinstellung in der Upload- oder Aufnahme-Ansicht aus, anstatt jede Option jedes Mal manuell einzustellen. Voreinstellungen erstellst und verwaltest du auf der **Voreinstellungen**-Seite, die du über die Kopfzeile erreichst.
+Eine Transkriptions-Voreinstellung speichert deine bevorzugte Kombination aus Sprache, Modell, Sprechererkennungs-Einstellungen, initialem Prompt und Hotwords. Wähle eine gespeicherte Voreinstellung in der Upload- oder Aufnahme-Ansicht aus, anstatt jede Option jedes Mal manuell einzustellen. Voreinstellungen erstellst und verwaltest du auf der **Voreinstellungen**-Seite, die du über die Kopfzeile erreichst.
 
 ## Analyse-Voreinstellungen
 

--- a/frontend/src/help/en/05-transcription-settings.md
+++ b/frontend/src/help/en/05-transcription-settings.md
@@ -4,18 +4,24 @@
 
 Diarization detects who spoke when and tags each utterance with a label like SPEAKER_00, SPEAKER_01, and so on. Turn it on for multi-speaker recordings and off for single-speaker content to save processing time. You can optionally set minimum and maximum speaker counts to guide detection. Diarization adds noticeable processing time. Once the transcription is ready, rename speakers to real names via the **Speaker Mapping** feature.
 
-## Quality selection
+## Model and quality
+
+Which Whisper models are available depends on how your deployment is configured.
+
+**If only one model is configured**, the settings panel shows a read-only **Model** field naming it (for example `large-v3-turbo`). There is nothing to choose — every transcription uses that model.
+
+**If several are configured**, the field is a **Quality** dropdown. Each entry shows a tier name and the model behind it:
 
 | Tier | Speed | Notes |
 |---|---|---|
-| Draft | Fastest | Good for quick previews of long files |
-| Standard | Fast | — |
-| Good | Medium | — |
-| Better | Slow | — |
-| Balanced | Fast/accurate | Recommended default |
-| Best quality | Slowest | Maximum accuracy |
+| Draft (tiny) | Fastest | Good for quick previews of long files |
+| Standard (base) | Fast | — |
+| Good (small) | Medium | — |
+| Better (medium) | Slow | — |
+| Balanced (large-v3-turbo) | Fast/accurate | Recommended default |
+| Best quality (large-v3) | Slowest | Maximum accuracy |
 
-**Balanced** is usually the right choice for most use cases.
+Only the tiers your deployment offers appear. The steps are not evenly spaced — the jump up to `large-v3-turbo` is large, while the gap between `large-v3-turbo` and `large-v3` is small.
 
 ## Advanced options
 

--- a/frontend/src/help/en/12-presets.md
+++ b/frontend/src/help/en/12-presets.md
@@ -2,7 +2,7 @@
 
 ## Transcription presets
 
-A transcription preset saves your preferred combination of language, model (quality tier), speaker detection settings, initial prompt, and hotwords. Select a saved preset from the Upload or Record view instead of configuring each option manually every time. Create and manage presets on the **Presets** page, accessible from the header.
+A transcription preset saves your preferred combination of language, model, speaker detection settings, initial prompt, and hotwords. Select a saved preset from the Upload or Record view instead of configuring each option manually every time. Create and manage presets on the **Presets** page, accessible from the header.
 
 ## Analysis presets
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -12,6 +12,7 @@
     "title": "Einstellungen",
     "language": "Sprache für die Transkription",
     "model": "Qualität",
+    "modelName": "Modell",
     "detectSpeakers": "Sprecher erkennen",
     "minSpeakers": "Minimale Sprecher",
     "maxSpeakers": "Maximale Sprecher",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -12,6 +12,7 @@
     "title": "Settings",
     "language": "Transcription language",
     "model": "Quality",
+    "modelName": "Model",
     "detectSpeakers": "Detect speakers",
     "minSpeakers": "Min speakers",
     "maxSpeakers": "Max speakers",


### PR DESCRIPTION
## Problem

The deployment runs with `WHISPER_MODELS=large-v3-turbo` — exactly one model. The settings panel still rendered a field labelled **Quality** whose only value was `Balanced (large-v3-turbo)`, in a read-only box shaped like a disabled dropdown.

Two things went wrong for users:

1. A field promising a quality *choice* offered none.
2. "Balanced" is a relative qualifier. Anyone who knew the older three-tier UI reads it as "the good option was taken away" — when in fact `large-v3-turbo` sits close to `large-v3` and far above `base`. The tiers were never equidistant, but the label implies they are.

## Change

Keep the field visible — users should be able to see which model transcribes their audio — but drop the relative qualifier when there is nothing to compare against.

| Models configured | Field label | Value |
|---|---|---|
| Exactly 1 | `Model` / `Modell` | bare model name, e.g. `large-v3-turbo`, read-only |
| 2 or more | `Quality` / `Qualität` (unchanged) | `Balanced (large-v3-turbo)` etc. in a dropdown (unchanged) |

Applied in both places that render the field: the upload/record settings panel and the Presets form.

Because the field now reads as a plain statement of fact — *this is the model your audio runs through* — the model actually submitted is clamped to the single configured model. It previously came from `DEFAULT_WHISPER_MODEL` and could be overwritten by a saved preset, so a preset created under an older configuration could name a model the deployment no longer offers. The same clamp is applied when a preset is saved, so no preset can be written naming a model that isn't available.

The help drawer section is rewritten for both shapes in EN and DE — it previously printed a six-row tier table and advised picking "Balanced", in a deployment offering one model and no choice at all.

## Alternatives considered

- **Hiding the field entirely when one model is configured.** Rejected: it removes transparency about which model ran.
- **Admin-configurable label text.** Rejected: the labels are translated per locale, so an env-based scheme either breaks German, needs a built-in label vocabulary, or needs parallel per-language env vars. The labels stay in the locale files and change by code edit.

## Verification

No frontend test runner exists in this repo (setting up Vitest is separate follow-up work), so this was verified by running the app under both configurations:

- `WHISPER_MODELS=large-v3-turbo`: upload view and Presets form both show **Model** / `large-v3-turbo` with no qualifier, **Modell** in German.
- `WHISPER_MODELS=base,large-v3,large-v3-turbo`: **Quality** dropdown unchanged; selecting `Best quality (large-v3)` submits `"model":"large-v3"` — the clamp does not pin when a real choice exists.
- With one model configured, loading a preset that names `large-v3` and submitting sends `"model":"large-v3-turbo"` while the preset's other fields still apply.

`pytest` 187 passed, `npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` succeeds.

## Known follow-ups (pre-existing, not introduced here)

- If `/api/config` fails, the field renders as an empty unlabelled picker and the `'base'` fallback is submitted; the backend does not validate `model` against `WHISPER_MODELS`.
- In multi-model deployments, a stale preset can still put a non-offered model into the `<select>`.