### PR TITLE
docs(readme): document the frontend build, lint, and test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,11 @@ Install Node.js dependencies and start the Vite dev server:
 cd frontend
 npm install
 npm run dev           # start the dev server
+npm run build         # production build (type-checks first)
 npm test              # run the test suite once
 npm run test:watch    # run tests in watch mode
-npm run typecheck     # type-check without emitting
+npm run typecheck     # type-check the project references
+npm run lint          # eslint
 ```
 
 The Vite dev server runs on `http://localhost:5173` and proxies API requests to the backend at `http://localhost:8000`.


### PR DESCRIPTION
The frontend section listed only `npm install`, `npm run dev`, and the three commands added with the test runner. `npm run build` and `npm run lint` were never documented, and `typecheck` was described as "type-check without emitting" — the phrasing carried over from `npx tsc --noEmit`, which checks nothing in this repo because the root `tsconfig.json` is solution-style.

Now every script in `frontend/package.json` except `preview` is documented, and `typecheck` is described by what it actually does.